### PR TITLE
Replace hyper with reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,9 +266,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes 1.6.0",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -286,8 +292,8 @@ dependencies = [
  "async-trait",
  "bytes 1.6.0",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -332,6 +338,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -1990,7 +2002,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http",
+ "http 0.2.11",
  "js-sys",
  "pin-project",
  "serde",
@@ -2073,7 +2085,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes 1.6.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -2298,12 +2329,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes 1.6.0",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-api-client"
 version = "0.1.0"
 source = "git+https://github.com/nymtech/nym?branch=master#00d47958a7181d0c2ddb0ccb01340bbe216e3b5e"
 dependencies = [
  "async-trait",
- "reqwest",
+ "reqwest 0.11.24",
  "serde",
  "serde_json",
  "thiserror",
@@ -2319,7 +2361,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes 1.6.0",
- "http",
+ "http 0.2.11",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes 1.6.0",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes 1.6.0",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2386,9 +2451,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.24",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2401,13 +2466,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes 1.6.0",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "log",
  "rustls 0.20.9",
  "rustls-native-certs",
@@ -2422,8 +2507,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "rustls 0.21.10",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -2435,7 +2520,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2448,10 +2533,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes 1.6.0",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes 1.6.0",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+dependencies = [
+ "bytes 1.6.0",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3118,7 +3239,7 @@ dependencies = [
  "nym-topology",
  "nym-validator-client",
  "rand 0.7.3",
- "reqwest",
+ "reqwest 0.11.24",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -3349,7 +3470,7 @@ source = "git+https://github.com/nymtech/nym?branch=master#00d47958a7181d0c2ddb0
 dependencies = [
  "log",
  "nym-explorer-api-requests",
- "reqwest",
+ "reqwest 0.11.24",
  "serde",
  "thiserror",
  "url",
@@ -3558,7 +3679,7 @@ dependencies = [
  "bytecodec",
  "bytes 1.6.0",
  "futures",
- "http",
+ "http 0.2.11",
  "httpcodec",
  "log",
  "nym-bandwidth-controller",
@@ -3635,7 +3756,7 @@ dependencies = [
  "nym-validator-client",
  "pin-project",
  "rand 0.7.3",
- "reqwest",
+ "reqwest 0.11.24",
  "schemars",
  "serde",
  "tap",
@@ -3907,7 +4028,7 @@ dependencies = [
  "nym-vesting-contract-common",
  "openssl",
  "prost",
- "reqwest",
+ "reqwest 0.11.24",
  "serde",
  "serde_json",
  "sha2 0.9.9",
@@ -4803,12 +4924,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.24",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls 0.24.2",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -4819,7 +4940,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.21.10",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4833,7 +4954,49 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.1",
+ "bytes 1.6.0",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.2.0",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -5001,7 +5164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "schannel",
  "security-framework",
 ]
@@ -5014,6 +5177,21 @@ checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"
@@ -5610,7 +5788,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "rustls 0.20.9",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "sha2 0.10.8",
  "smallvec",
  "sqlformat 0.2.3",
@@ -5885,7 +6063,7 @@ dependencies = [
  "getrandom 0.2.12",
  "peg",
  "pin-project",
- "reqwest",
+ "reqwest 0.11.24",
  "semver 1.0.23",
  "serde",
  "serde_bytes",
@@ -6176,17 +6354,17 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes 1.6.0",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.24",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
  "prost",
  "rustls 0.21.10",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-stream",
@@ -6240,8 +6418,8 @@ dependencies = [
  "bytes 1.6.0",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "http-range-header",
  "pin-project-lite",
  "tower-layer",
@@ -6362,7 +6540,7 @@ dependencies = [
  "byteorder",
  "bytes 1.6.0",
  "data-encoding",
- "http",
+ "http 0.2.11",
  "httparse",
  "log",
  "native-tls",
@@ -6958,6 +7136,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7002,17 +7190,17 @@ dependencies = [
  "base64 0.13.1",
  "byteorder",
  "hex 0.4.3",
- "http",
- "hyper",
- "hyper-tls",
+ "http 0.2.11",
  "indexmap 2.2.6",
  "prost",
+ "reqwest 0.12.4",
  "serde",
  "serde_json",
  "sha2 0.10.8",
  "thiserror",
  "tokio",
  "tonic",
+ "url",
  "zaino-proto",
 ]
 
@@ -7045,7 +7233,7 @@ dependencies = [
  "crossbeam-channel",
  "futures",
  "hex 0.4.3",
- "http",
+ "http 0.2.11",
  "nym-sdk",
  "nym-sphinx-anonymous-replies",
  "prost",
@@ -7075,7 +7263,7 @@ name = "zaino-testutils"
 version = "0.1.0"
 dependencies = [
  "ctrlc",
- "http",
+ "http 0.2.11",
  "portpicker",
  "tempfile",
  "tokio",
@@ -7092,8 +7280,8 @@ name = "zaino-wallet"
 version = "0.1.0"
 dependencies = [
  "bytes 1.6.0",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "nym-sdk",
  "nym-sphinx-addressing",
  "nym-sphinx-anonymous-replies",
@@ -7110,7 +7298,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "ctrlc",
- "http",
+ "http 0.2.11",
  "nym-bin-common",
  "serde",
  "thiserror",
@@ -7301,12 +7489,12 @@ name = "zingo-netutils"
 version = "0.1.0"
 source = "git+https://github.com/zingolabs/zingolib.git?branch=nym_integration#f5eeb37c04d7b1b58f8c6189291ce73349cec471"
 dependencies = [
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls 0.23.2",
  "prost",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "tokio-rustls 0.23.4",
  "tonic",
  "tower",
@@ -7329,7 +7517,7 @@ version = "0.1.0"
 source = "git+https://github.com/zingolabs/zingolib.git?branch=nym_integration#f5eeb37c04d7b1b58f8c6189291ce73349cec471"
 dependencies = [
  "futures",
- "http",
+ "http 0.2.11",
  "incrementalmerkletree",
  "json",
  "log",
@@ -7365,7 +7553,7 @@ version = "0.1.0"
 source = "git+https://github.com/zingolabs/zingolib.git?branch=nym_integration#f5eeb37c04d7b1b58f8c6189291ce73349cec471"
 dependencies = [
  "dirs 3.0.2",
- "http",
+ "http 0.2.11",
  "log",
  "log4rs",
  "zcash_address",
@@ -7391,9 +7579,9 @@ dependencies = [
  "futures",
  "group 0.13.0",
  "hex 0.3.2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls 0.23.2",
  "incrementalmerkletree",
  "indoc",
@@ -7407,7 +7595,7 @@ dependencies = [
  "pairing 0.23.0",
  "prost",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.11.24",
  "ring 0.17.7",
  "ripemd160",
  "rust-embed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "master" }
 nym-sphinx-anonymous-replies = { git = "https://github.com/nymtech/nym", branch = "master" }
 
 # Miscellaneous
-tokio = { version = "=1.37.0", features = ["full"] } # { version = "1.38", features = ["full"] }
+tokio = { version = "1.37.0", features = ["full"] } # { version = "1.38", features = ["full"] }
 tonic = "0.10.2" # "0.12"
 http = "0.2.4" # "1.1"
 thiserror = "1.0.59" # "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ nym-bin-common = { git = "https://github.com/nymtech/nym", branch = "master" }
 nym-sphinx-anonymous-replies = { git = "https://github.com/nymtech/nym", branch = "master" }
 
 # Miscellaneous
-tokio = { version = "1.37.0", features = ["full"] } # { version = "1.38", features = ["full"] }
+tokio = { version = "=1.37.0", features = ["full"] } # { version = "1.38", features = ["full"] }
 tonic = "0.10.2" # "0.12"
 http = "0.2.4" # "1.1"
 thiserror = "1.0.59" # "1.0"

--- a/zaino-fetch/Cargo.toml
+++ b/zaino-fetch/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = { workspace = true }
 # Miscellaneous Crate
 prost = "0.12" # "0.13"
 hyper = { version = "0.14.28", features = ["full"] } # { version = "1.4", features = ["full"] }
+# reqwest = "0.12"
 serde_json = { version = "1.0.117", features = ["preserve_order"] } # { version = "1.0", features = ["preserve_order"] } # The preserve_order feature in serde_jsonn is a dependency of jsonrpc-core
 serde = { version = "1.0.201", features = ["derive"] } # { version = "1.0", features = ["derive"] }
 hyper-tls = "0.5" # "0.6"

--- a/zaino-fetch/Cargo.toml
+++ b/zaino-fetch/Cargo.toml
@@ -18,11 +18,10 @@ thiserror = { workspace = true }
 
 # Miscellaneous Crate
 prost = "0.12" # "0.13"
-hyper = { version = "0.14.28", features = ["full"] } # { version = "1.4", features = ["full"] }
-# reqwest = "0.12"
+reqwest = "0.12"
+url = "2.5"
 serde_json = { version = "1.0.117", features = ["preserve_order"] } # { version = "1.0", features = ["preserve_order"] } # The preserve_order feature in serde_jsonn is a dependency of jsonrpc-core
 serde = { version = "1.0.201", features = ["derive"] } # { version = "1.0", features = ["derive"] }
-hyper-tls = "0.5" # "0.6"
 hex = { version = "0.4.3", features = ["serde"] }
 indexmap = { version = "2.2.6", features = ["serde"] }
 base64 = "0.13.0" # "0.22"

--- a/zaino-fetch/src/chain/block.rs
+++ b/zaino-fetch/src/chain/block.rs
@@ -390,7 +390,7 @@ pub async fn get_block_from_node(
         Some("xxxxxx".to_string()),
         Some("xxxxxx".to_string()),
     )
-    .await;
+    .await?;
     let block_1 = zebrad_client.get_block(height.to_string(), Some(1)).await;
     match block_1 {
         Ok(GetBlockResponse::Object {

--- a/zaino-fetch/src/chain/mempool.rs
+++ b/zaino-fetch/src/chain/mempool.rs
@@ -4,8 +4,7 @@ use std::{collections::HashSet, time::SystemTime};
 use tokio::sync::{Mutex, RwLock};
 
 use crate::{
-    chain::error::MempoolError, jsonrpc::connector::JsonRpcConnector,
-    primitives::block::BlockHash,
+    chain::error::MempoolError, jsonrpc::connector::JsonRpcConnector, primitives::block::BlockHash,
 };
 
 /// Mempool state information.
@@ -58,7 +57,7 @@ impl Mempool {
             Some("xxxxxx".to_string()),
             Some("xxxxxx".to_string()),
         )
-        .await
+        .await?
         .get_raw_mempool()
         .await?
         .transactions;
@@ -90,7 +89,7 @@ impl Mempool {
             Some("xxxxxx".to_string()),
             Some("xxxxxx".to_string()),
         )
-        .await
+        .await?
         .get_blockchain_info()
         .await?
         .best_block_hash;

--- a/zaino-fetch/src/jsonrpc/connector.rs
+++ b/zaino-fetch/src/jsonrpc/connector.rs
@@ -3,9 +3,7 @@
 //! TODO: - Add option for http connector.
 
 use http::Uri;
-use hyper::{http, Body, Client, Request};
-use hyper_tls::HttpsConnector;
-// use reqwest::{Client, Url};
+use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::atomic::{AtomicI32, Ordering};
@@ -45,7 +43,7 @@ struct RpcError {
 /// JsonRPC Client config data.
 #[derive(Debug)]
 pub struct JsonRpcConnector {
-    uri: http::Uri,
+    url: Url,
     id_counter: AtomicI32,
     user: Option<String>,
     password: Option<String>,
@@ -53,25 +51,35 @@ pub struct JsonRpcConnector {
 
 impl JsonRpcConnector {
     /// Returns a new JsonRpcConnector instance, tests uri and returns error if connection is not established.
-    pub async fn new(uri: http::Uri, user: Option<String>, password: Option<String>) -> Self {
-        Self {
-            uri,
+    pub async fn new(
+        uri: Uri,
+        user: Option<String>,
+        password: Option<String>,
+    ) -> Result<Self, JsonRpcConnectorError> {
+        let url = reqwest::Url::parse(&uri.to_string())?;
+        Ok(Self {
+            url,
             id_counter: AtomicI32::new(0),
             user,
             password,
-        }
+        })
     }
 
-    /// Returns the uri the JsonRpcConnector is configured to send requests to.
-    pub fn uri(&self) -> &Uri {
-        &self.uri
+    /// Returns the http::uri the JsonRpcConnector is configured to send requests to.
+    pub fn uri(&self) -> Result<Uri, JsonRpcConnectorError> {
+        Ok(self.url.as_str().parse()?)
+    }
+
+    /// Returns the reqwest::url the JsonRpcConnector is configured to send requests to.
+    pub fn url(&self) -> Url {
+        self.url.clone()
     }
 
     /// Sends a jsonRPC request and returns the response.
     ///
     /// TODO: This function currently resends the call up to 5 times on a server response of "Work queue depth exceeded".
     /// This is because the node's queue can become overloaded and stop servicing RPCs.
-    /// This functionality is weak and should be incorporated in Zingo-Indexer's queue mechanism [WIP] that handles various errors appropriately.
+    /// This functionality is weak and should be incorporated in Zaino's queue mechanism [WIP] that handles various errors appropriately.
     async fn send_request<T: Serialize, R: for<'de> Deserialize<'de>>(
         &self,
         method: &str,
@@ -88,30 +96,33 @@ impl JsonRpcConnector {
         let mut attempts = 0;
         loop {
             attempts += 1;
-            let client = Client::builder().build(HttpsConnector::new());
-            let mut request_builder = Request::builder()
-                .method("POST")
-                .uri(self.uri.clone())
+            let client = Client::builder()
+                .connect_timeout(std::time::Duration::from_secs(2))
+                .timeout(std::time::Duration::from_secs(5))
+                .redirect(reqwest::redirect::Policy::none())
+                .build()?;
+
+            let mut request_builder = client
+                .post(self.url.clone())
                 .header("Content-Type", "application/json");
             if let (Some(user), Some(password)) = (&self.user, &self.password) {
-                let auth = base64::encode(format!("{}:{}", user, password));
-                request_builder =
-                    request_builder.header("Authorization", format!("Basic {}", auth));
+                request_builder = request_builder.basic_auth(user.clone(), Some(password.clone()));
             }
             let request_body =
                 serde_json::to_string(&req).map_err(JsonRpcConnectorError::SerdeJsonError)?;
-            let request = request_builder
-                .body(Body::from(request_body))
-                .map_err(JsonRpcConnectorError::HttpError)?;
-            let response = client
-                .request(request)
+            let response = request_builder
+                .body(request_body)
+                .send()
                 .await
-                .map_err(JsonRpcConnectorError::HyperError)?;
-            let body_bytes = hyper::body::to_bytes(response.into_body())
-                .await
-                .map_err(JsonRpcConnectorError::HyperError)?;
+                .map_err(JsonRpcConnectorError::ReqwestError)?;
 
+            let status = response.status();
+            let body_bytes = response
+                .bytes()
+                .await
+                .map_err(JsonRpcConnectorError::ReqwestError)?;
             let body_str = String::from_utf8_lossy(&body_bytes);
+
             if body_str.contains("Work queue depth exceeded") {
                 if attempts >= max_attempts {
                     return Err(JsonRpcConnectorError::new(
@@ -121,6 +132,13 @@ impl JsonRpcConnector {
                 tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                 continue;
             }
+            if !status.is_success() {
+                return Err(JsonRpcConnectorError::new(format!(
+                    "HTTP Error: {}",
+                    status
+                )));
+            }
+
             let response: RpcResponse<R> = serde_json::from_slice(&body_bytes)
                 .map_err(JsonRpcConnectorError::SerdeJsonError)?;
             return match response.error {
@@ -369,32 +387,33 @@ impl JsonRpcConnector {
 
 /// Tests connection with zebrad / zebrad.
 async fn test_node_connection(
-    uri: Uri,
+    url: Url,
     user: Option<String>,
     password: Option<String>,
 ) -> Result<(), JsonRpcConnectorError> {
-    let client = Client::builder().build::<_, Body>(HttpsConnector::new());
+    let client = Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(2))
+        .timeout(std::time::Duration::from_secs(5))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?;
 
     let user = user.unwrap_or_else(|| "xxxxxx".to_string());
     let password = password.unwrap_or_else(|| "xxxxxx".to_string());
-    let encoded_auth = base64::encode(format!("{}:{}", user, password));
-
-    let request = Request::builder()
-        .method("POST")
-        .uri(uri.clone())
+    let request_body = r#"{"jsonrpc":"2.0","method":"getinfo","params":[],"id":1}"#;
+    let mut request_builder = client
+        .post(url.clone())
         .header("Content-Type", "application/json")
-        .header("Authorization", format!("Basic {}", encoded_auth))
-        .body(Body::from(
-            r#"{"jsonrpc":"2.0","method":"getinfo","params":[],"id":1}"#,
-        ))
-        .map_err(JsonRpcConnectorError::HttpError)?;
-    let response =
-        tokio::time::timeout(tokio::time::Duration::from_secs(3), client.request(request))
-            .await
-            .map_err(JsonRpcConnectorError::TimeoutError)??;
-    let body_bytes = hyper::body::to_bytes(response.into_body())
+        .body(request_body);
+    request_builder = request_builder.basic_auth(user, Some(password)); // Used basic_auth method
+
+    let response = request_builder
+        .send()
         .await
-        .map_err(JsonRpcConnectorError::HyperError)?;
+        .map_err(JsonRpcConnectorError::ReqwestError)?;
+    let body_bytes = response
+        .bytes()
+        .await
+        .map_err(JsonRpcConnectorError::ReqwestError)?;
     let _response: RpcResponse<serde_json::Value> =
         serde_json::from_slice(&body_bytes).map_err(JsonRpcConnectorError::SerdeJsonError)?;
     Ok(())
@@ -406,24 +425,20 @@ pub async fn test_node_and_return_uri(
     user: Option<String>,
     password: Option<String>,
 ) -> Result<Uri, JsonRpcConnectorError> {
-    let ipv4_uri: Uri = format!("http://127.0.0.1:{}", port)
-        .parse()
-        .map_err(JsonRpcConnectorError::InvalidUriError)?;
-    let ipv6_uri: Uri = format!("http://[::1]:{}", port)
-        .parse()
-        .map_err(JsonRpcConnectorError::InvalidUriError)?;
+    let ipv4_uri: Url = format!("http://127.0.0.1:{}", port).parse()?;
+    let ipv6_uri: Url = format!("http://[::1]:{}", port).parse()?;
     let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(500));
     for _ in 0..3 {
         match test_node_connection(ipv4_uri.clone(), user.clone(), password.clone()).await {
             Ok(_) => {
                 println!("Connected to node using IPv4 at address {}.", ipv4_uri);
-                return Ok(ipv4_uri);
+                return Ok(ipv4_uri.as_str().parse()?);
             }
             Err(_e_ipv4) => {
                 match test_node_connection(ipv6_uri.clone(), user.clone(), password.clone()).await {
                     Ok(_) => {
                         println!("Connected to node using IPv6 at address {}.", ipv6_uri);
-                        return Ok(ipv6_uri);
+                        return Ok(ipv6_uri.as_str().parse()?);
                     }
                     Err(_e_ipv6) => {
                         tokio::time::sleep(std::time::Duration::from_secs(3)).await;

--- a/zaino-fetch/src/jsonrpc/connector.rs
+++ b/zaino-fetch/src/jsonrpc/connector.rs
@@ -5,6 +5,7 @@
 use http::Uri;
 use hyper::{http, Body, Client, Request};
 use hyper_tls::HttpsConnector;
+// use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::atomic::{AtomicI32, Ordering};

--- a/zaino-fetch/src/jsonrpc/error.rs
+++ b/zaino-fetch/src/jsonrpc/error.rs
@@ -11,9 +11,9 @@ pub enum JsonRpcConnectorError {
     #[error("Serialization/Deserialization Error: {0}")]
     SerdeJsonError(#[from] serde_json::Error),
 
-    /// HTTP Request Errors.
+    /// Reqwest Based Errors.
     #[error("HTTP Request Error: {0}")]
-    HyperError(#[from] hyper::Error),
+    ReqwestError(#[from] reqwest::Error),
 
     ///HTTP Errors.
     #[error("HTTP Error: {0}")]
@@ -22,6 +22,10 @@ pub enum JsonRpcConnectorError {
     /// Invalid URI Errors.
     #[error("Invalid URI: {0}")]
     InvalidUriError(#[from] http::uri::InvalidUri),
+
+    /// Invalid URL Errors.
+    #[error("Invalid URL: {0}")]
+    InvalidUrlError(#[from] url::ParseError),
 
     /// UTF-8 Conversion Errors.
     #[error("UTF-8 Conversion Error")]
@@ -46,7 +50,7 @@ impl JsonRpcConnectorError {
             JsonRpcConnectorError::SerdeJsonError(_) => {
                 tonic::Status::invalid_argument(self.to_string())
             }
-            JsonRpcConnectorError::HyperError(_) => tonic::Status::unavailable(self.to_string()),
+            JsonRpcConnectorError::ReqwestError(_) => tonic::Status::unavailable(self.to_string()),
             JsonRpcConnectorError::HttpError(_) => tonic::Status::internal(self.to_string()),
             _ => tonic::Status::internal(self.to_string()),
         }

--- a/zaino-fetch/src/primitives/block.rs
+++ b/zaino-fetch/src/primitives/block.rs
@@ -66,7 +66,7 @@ impl FromHex for SerializedBlock {
     type Error = hex::FromHexError;
 
     fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
-        hex::decode(hex).map(|bytes| SerializedBlock::from(bytes))
+        hex::decode(hex).map(SerializedBlock::from)
     }
 }
 

--- a/zaino-nym/src/error.rs
+++ b/zaino-nym/src/error.rs
@@ -39,10 +39,10 @@ impl From<NymError> for tonic::Status {
                 tonic::Status::internal(format!("Connection error: {}", e))
             }
             NymError::EmptyMessageError => {
-                tonic::Status::internal(format!("Empty message received from nym mixnet"))
+                tonic::Status::internal("Empty message received from nym mixnet".to_string())
             }
             NymError::EmptyRecipientTagError => {
-                tonic::Status::internal(format!("No AnonSenderTag received from nym mixnet"))
+                tonic::Status::internal("No AnonSenderTag received from nym mixnet".to_string())
             }
         }
     }

--- a/zaino-nym/src/utils.rs
+++ b/zaino-nym/src/utils.rs
@@ -20,7 +20,7 @@ fn read_nym_method(data: &[u8]) -> Result<(String, &[u8]), NymError> {
 fn check_nym_body(data: &[u8]) -> Result<&[u8], NymError> {
     let mut cursor = Cursor::new(data);
     let body_len = CompactSize::read(&mut cursor).map_err(ParseError::Io)? as usize;
-    if &body_len != &data[cursor.position() as usize..].len() {
+    if body_len != data[cursor.position() as usize..].len() {
         return Err(NymError::ParseError(ParseError::InvalidData(
             "Incorrect request body size read.".to_string(),
         )));

--- a/zaino-serve/src/rpc/service.rs
+++ b/zaino-serve/src/rpc/service.rs
@@ -109,7 +109,7 @@ impl CompactTxStreamer for GrpcClient {
                 Some("xxxxxx".to_string()),
                 Some("xxxxxx".to_string()),
             )
-            .await
+            .await?
             .get_blockchain_info()
             .await
             .map_err(|e| e.to_grpc_status())?;
@@ -320,7 +320,7 @@ impl CompactTxStreamer for GrpcClient {
                     Some("xxxxxx".to_string()),
                     Some("xxxxxx".to_string()),
                 )
-                .await
+                .await?
                 .get_raw_transaction(hash_hex, Some(1))
                 .await
                 .map_err(|e| e.to_grpc_status())?;
@@ -372,7 +372,7 @@ impl CompactTxStreamer for GrpcClient {
                 Some("xxxxxx".to_string()),
                 Some("xxxxxx".to_string()),
             )
-            .await
+            .await?
             .send_raw_transaction(hex_tx)
             .await
             .map_err(|e| e.to_grpc_status())?;
@@ -428,7 +428,7 @@ impl CompactTxStreamer for GrpcClient {
                 Some("xxxxxx".to_string()),
                 Some("xxxxxx".to_string()),
             )
-            .await;
+            .await?;
             let txids = zebrad_client
                 .get_address_txids(vec![address], start, end)
                 .await
@@ -615,7 +615,7 @@ impl CompactTxStreamer for GrpcClient {
                 Some("xxxxxx".to_string()),
                 Some("xxxxxx".to_string()),
             )
-            .await;
+            .await?;
 
             let zebrad_uri = self.zebrad_uri.clone();
             let (channel_tx, channel_rx) = tokio::sync::mpsc::channel(32);
@@ -747,7 +747,7 @@ impl CompactTxStreamer for GrpcClient {
                 Some("xxxxxx".to_string()),
                 Some("xxxxxx".to_string()),
             )
-            .await;
+            .await?;
 
             // TODO: This is slow. Chain, along with other blockchain info should be saved on startup and used here [blockcache?].
             let chain = zebrad_client
@@ -907,7 +907,7 @@ impl CompactTxStreamer for GrpcClient {
                 Some("xxxxxx".to_string()),
                 Some("xxxxxx".to_string()),
             )
-            .await;
+            .await?;
 
             let zebra_info = zebrad_client
                 .get_info()

--- a/zaino-serve/src/server/director.rs
+++ b/zaino-serve/src/server/director.rs
@@ -79,6 +79,7 @@ pub struct Server {
 
 impl Server {
     /// Spawns a new Server.
+    #[allow(clippy::too_many_arguments)]
     pub async fn spawn(
         tcp_active: bool,
         tcp_ingestor_listen_addr: Option<SocketAddr>,

--- a/zaino-serve/src/server/worker.rs
+++ b/zaino-serve/src/server/worker.rs
@@ -49,6 +49,7 @@ pub(crate) struct Worker {
 
 impl Worker {
     /// Creates a new queue worker.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn spawn(
         _worker_id: usize,
         queue: QueueReceiver<ZingoIndexerRequest>,
@@ -234,6 +235,7 @@ pub(crate) struct WorkerPool {
 
 impl WorkerPool {
     /// Creates a new worker pool containing [idle_workers] workers.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn spawn(
         max_size: u16,
         idle_size: u16,
@@ -322,14 +324,14 @@ impl WorkerPool {
                         self.status.statuses[worker_index].store(5);
                         self.workers.pop();
                         self.status.workers.fetch_sub(1, Ordering::SeqCst);
-                        return Ok(());
+                        Ok(())
                     }
                     Err(e) => {
                         self.status.statuses[worker_index].store(6);
                         eprintln!("Worker returned error on shutdown: {}", e);
                         // TODO: Handle the inner WorkerError. Return error.
                         self.status.workers.fetch_sub(1, Ordering::SeqCst);
-                        return Ok(());
+                        Ok(())
                     }
                 },
                 Err(e) => {
@@ -337,9 +339,9 @@ impl WorkerPool {
                     eprintln!("Worker returned error on shutdown: {}", e);
                     // TODO: Handle the JoinError. Return error.
                     self.status.workers.fetch_sub(1, Ordering::SeqCst);
-                    return Ok(());
+                    Ok(())
                 }
-            };
+            }
         }
     }
 
@@ -370,7 +372,7 @@ impl WorkerPool {
     /// Shuts down all the workers in the pool.
     pub(crate) async fn shutdown(
         &mut self,
-        worker_handles: &mut Vec<Option<tokio::task::JoinHandle<Result<(), WorkerError>>>>,
+        worker_handles: &mut [Option<tokio::task::JoinHandle<Result<(), WorkerError>>>],
     ) {
         for i in (0..self.workers.len()).rev() {
             self.workers[i].shutdown().await;

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -186,8 +186,11 @@ fn set_custom_drops(
                 eprintln!("Failed to delete temporary wallet directory: {:?}.", e);
             }
         }
-        // Assures tests fail on secondary thread panics.
-        assert!(false);
+        // Ensures tests fail on secondary thread panics.
+        #[allow(clippy::assertions_on_constants)]
+        {
+            assert!(false);
+        }
         std::process::exit(0);
     }));
 
@@ -208,8 +211,11 @@ fn set_custom_drops(
                     eprintln!("Failed to delete temporary wallet directory: {:?}.", e);
                 }
             }
-            // Assures tests fail on ctrlc exit.
-            assert!(false);
+            // Ensures tests fail on ctrlc exit.
+            #[allow(clippy::assertions_on_constants)]
+            {
+                assert!(false);
+            }
             std::process::exit(0);
         })
         .expect("Error setting Ctrl-C handler");

--- a/zaino-wallet/src/service.rs
+++ b/zaino-wallet/src/service.rs
@@ -252,10 +252,10 @@ where
                         Ok(tonic::Response::new(response))
                     }
                     Err(e) => {
-                        return Err(Status::invalid_argument(format!(
+                        Err(Status::invalid_argument(format!(
                             "Failed to parse nym address: {}",
                             e
-                        )));
+                        )))
                     }
                 }
             }
@@ -440,10 +440,10 @@ where
                         Ok(tonic::Response::new(response))
                     }
                     Err(e) => {
-                        return Err(Status::invalid_argument(format!(
+                        Err(Status::invalid_argument(format!(
                             "Failed to parse nym address: {}",
                             e
-                        )));
+                        )))
                     }
                 }
             }

--- a/zainod/src/config.rs
+++ b/zainod/src/config.rs
@@ -54,12 +54,10 @@ impl IndexerConfig {
                     "Invalid nym conf path syntax or non-UTF-8 characters in path.".to_string(),
                 ));
             }
-        } else {
-            if self.nym_active {
-                return Err(IndexerError::ConfigError(
-                    "NYM is active but no conf path provided.".to_string(),
-                ));
-            }
+        } else if self.nym_active {
+            return Err(IndexerError::ConfigError(
+                "NYM is active but no conf path provided.".to_string(),
+            ));
         }
         Ok(())
     }


### PR DESCRIPTION
Much of hyper's high level API was removed in 1.0 and for our current use (Zaino-Fetch::jsonrpc::connector::JsonRpcConnector) we do not require the low level functionality now offered by hyper. For this reason the use of hyper here has been replaced with reqwest.

This is the first work towards updating the zingolib and librustzcash versions used by zaino.

- This PR is the first work towards #48 

