### PR TITLE
Remove start mempool helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,6 +1470,7 @@ version = "0.1.0"
 dependencies = [
  "tokio",
  "zaino-testutils",
+ "zingolib",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ license = "Apache-2.0"
 
 
 [workspace.dependencies]
+# Zingolabs
+zingolib = { git = "https://github.com/zingolabs/zingolib.git", tag = "zaino_dep_002_091024_95e5b0d8f9d5ee0485c6141533da2f727aeafae2", features = ["zaino-test"] }
+
 # Temporarily removed until dependency conflic can be resolved.
 # NymSdk
 # nym-sdk = { git = "https://github.com/nymtech/nym", branch = "master" }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -14,6 +14,7 @@ nym_poc = []
 
 [dependencies]
 zaino-testutils = { path = "../zaino-testutils" }
+zingolib = { workspace = true }
 
 # Miscellaneous Workspace
 tokio = { workspace = true }

--- a/integration-tests/tests/integrations.rs
+++ b/integration-tests/tests/integrations.rs
@@ -6,11 +6,13 @@
 use std::sync::{atomic::AtomicBool, Arc};
 use zaino_testutils::{
     drop_test_manager,
-    zingo_lightclient::{get_address, quick_send, start_mempool_monitor},
+    zingo_lightclient::{get_address, start_mempool_monitor},
     TestManager,
 };
 
 mod wallet_basic {
+    use zingolib::testutils::lightclient::from_inputs;
+
     use super::*;
 
     #[tokio::test]
@@ -41,7 +43,7 @@ mod wallet_basic {
         test_manager.regtest_manager.generate_n_blocks(1).unwrap();
         zingo_client.do_sync(false).await.unwrap();
 
-        quick_send(
+        from_inputs::quick_send(
             &zingo_client,
             vec![(&get_address(&zingo_client, "unified").await, 250_000, None)],
         )
@@ -71,7 +73,7 @@ mod wallet_basic {
 
         test_manager.regtest_manager.generate_n_blocks(1).unwrap();
         zingo_client.do_sync(false).await.unwrap();
-        quick_send(
+        from_inputs::quick_send(
             &zingo_client,
             vec![(&get_address(&zingo_client, "sapling").await, 250_000, None)],
         )
@@ -101,7 +103,7 @@ mod wallet_basic {
 
         test_manager.regtest_manager.generate_n_blocks(1).unwrap();
         zingo_client.do_sync(false).await.unwrap();
-        quick_send(
+        from_inputs::quick_send(
             &zingo_client,
             vec![(
                 &get_address(&zingo_client, "transparent").await,
@@ -135,19 +137,19 @@ mod wallet_basic {
 
         test_manager.regtest_manager.generate_n_blocks(2).unwrap();
         zingo_client.do_sync(false).await.unwrap();
-        quick_send(
+        from_inputs::quick_send(
             &zingo_client,
             vec![(&get_address(&zingo_client, "unified").await, 250_000, None)],
         )
         .await
         .unwrap();
-        quick_send(
+        from_inputs::quick_send(
             &zingo_client,
             vec![(&get_address(&zingo_client, "sapling").await, 250_000, None)],
         )
         .await
         .unwrap();
-        quick_send(
+        from_inputs::quick_send(
             &zingo_client,
             vec![(
                 &get_address(&zingo_client, "transparent").await,
@@ -183,7 +185,7 @@ mod wallet_basic {
 
         test_manager.regtest_manager.generate_n_blocks(1).unwrap();
         zingo_client.do_sync(false).await.unwrap();
-        quick_send(
+        from_inputs::quick_send(
             &zingo_client,
             vec![(
                 &get_address(&zingo_client, "transparent").await,
@@ -228,14 +230,14 @@ mod wallet_basic {
         zingo_client.do_sync(false).await.unwrap();
 
         test_manager.regtest_manager.generate_n_blocks(5).unwrap();
-        quick_send(
+        from_inputs::quick_send(
             &zingo_client,
             vec![(&get_address(&zingo_client, "unified").await, 250_000, None)],
         )
         .await
         .unwrap();
         test_manager.regtest_manager.generate_n_blocks(15).unwrap();
-        quick_send(
+        from_inputs::quick_send(
             &zingo_client,
             vec![(&get_address(&zingo_client, "sapling").await, 250_000, None)],
         )
@@ -243,7 +245,7 @@ mod wallet_basic {
         .unwrap();
 
         test_manager.regtest_manager.generate_n_blocks(15).unwrap();
-        quick_send(
+        from_inputs::quick_send(
             &zingo_client,
             vec![(
                 &get_address(&zingo_client, "transparent").await,
@@ -281,13 +283,13 @@ mod wallet_basic {
 
         test_manager.regtest_manager.generate_n_blocks(1).unwrap();
         zingo_client.do_sync(false).await.unwrap();
-        quick_send(
+        from_inputs::quick_send(
             &zingo_client,
             vec![(&get_address(&zingo_client, "sapling").await, 250_000, None)],
         )
         .await
         .unwrap();
-        quick_send(
+        from_inputs::quick_send(
             &zingo_client,
             vec![(&get_address(&zingo_client, "sapling").await, 250_000, None)],
         )

--- a/zaino-testutils/Cargo.toml
+++ b/zaino-testutils/Cargo.toml
@@ -16,7 +16,7 @@ zaino-fetch = { path = "../zaino-fetch" }
 zainod = { path = "../zainod" }
 
 # ZingoLib
-zingolib = { git = "https://github.com/zingolabs/zingolib.git", tag = "zaino_dep_002_091024_95e5b0d8f9d5ee0485c6141533da2f727aeafae2", features = ["zaino-test"] }
+zingolib = { workspace = true }
 # zingolib = { git = "https://github.com/idky137/zingolib.git", branch = "zaino_temp_dep", features = ["zaino-test"] }
 # zingolib = { path = "../../zingolib/zingolib", features = ["zaino-test"] }
 

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -285,20 +285,4 @@ pub mod zingo_lightclient {
     ) -> String {
         zingolib::get_base_address_macro!(zingo_client, pool)
     }
-
-    /// Starts Zingolib::lightclients's mempool monitor.
-    pub async fn start_mempool_monitor(zingo_client: &zingolib::lightclient::LightClient) {
-        let zingo_client_saved = zingo_client.export_save_buffer_async().await.unwrap();
-        let zingo_client_loaded = std::sync::Arc::new(
-            zingolib::lightclient::LightClient::read_wallet_from_buffer_async(
-                zingo_client.config(),
-                &zingo_client_saved[..],
-            )
-            .await
-            .unwrap(),
-        );
-        zingolib::lightclient::LightClient::start_mempool_monitor(zingo_client_loaded.clone());
-        // This seems to be long enough for the mempool monitor to kick in (from zingolib).
-        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-    }
 }

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -286,18 +286,6 @@ pub mod zingo_lightclient {
         zingolib::get_base_address_macro!(zingo_client, pool)
     }
 
-    /// Sends funds to address given, handles proposals internally.
-    ///
-    /// recievers should be in the form vec![Address, Amount, Option<Memo>]
-    pub async fn quick_send(
-        zingo_client: &zingolib::lightclient::LightClient,
-        receivers: Vec<(&str, u64, Option<&str>)>,
-    ) -> Result<String, zingolib::lightclient::send::send_with_proposal::QuickSendError> {
-        zingolib::testutils::lightclient::from_inputs::quick_send(zingo_client, receivers)
-            .await
-            .map(|tx_ids| tx_ids.into_iter().next().unwrap().to_string())
-    }
-
     /// Starts Zingolib::lightclients's mempool monitor.
     pub async fn start_mempool_monitor(zingo_client: &zingolib::lightclient::LightClient) {
         let zingo_client_saved = zingo_client.export_save_buffer_async().await.unwrap();


### PR DESCRIPTION
this adds a wallet clear to correctly fail the test due to mempool monitoring being broken.
the test was passing due to the wallet scanning the sent tx's locally instead.
then this sets up mempool monitoring so the test passes, removing unnecessary helper.

on top of #78 