### PR TITLE
Fix get latest block

### DIFF
--- a/zaino-serve/src/rpc/service.rs
+++ b/zaino-serve/src/rpc/service.rs
@@ -112,7 +112,10 @@ impl CompactTxStreamer for GrpcClient {
 
             let block_id = BlockId {
                 height: blockchain_info.blocks.0 as u64,
-                hash: blockchain_info.best_block_hash.0.to_vec(),
+                hash: blockchain_info
+                    .best_block_hash
+                    .bytes_in_display_order()
+                    .to_vec(),
             };
 
             Ok(tonic::Response::new(block_id))


### PR DESCRIPTION
Fixes the response of get_latest_block. The block hash in this response should be in display order (reversed). This PR uses functionality in zebra for this.

- Fixes get_latest_block test in https://github.com/zingolabs/zcash-local-net.
- Work towards #52

- Built atop #82 as functionality exposed in that PR is used here. Merge that PR first.