### PR TITLE
Implement Get block nullifiers

### DIFF
--- a/zaino-serve/src/rpc/service.rs
+++ b/zaino-serve/src/rpc/service.rs
@@ -6,7 +6,10 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use crate::{rpc::GrpcClient, utils::get_build_info};
 use zaino_fetch::{
-    chain::{block::get_block_from_node, mempool::Mempool},
+    chain::{
+        block::{get_block_from_node, get_nullifiers_from_node},
+        mempool::Mempool,
+    },
     jsonrpc::{connector::JsonRpcConnector, response::GetTransactionResponse},
 };
 use zaino_proto::proto::{
@@ -153,11 +156,10 @@ impl CompactTxStreamer for GrpcClient {
 
     /// Same as GetBlock except actions contain only nullifiers.
     ///
-    /// This RPC has not been implemented as it is not currently used by zingolib.
-    /// If you require this RPC please open an issue or PR at the Zingo-Indexer github (https://github.com/zingolabs/zingo-indexer).
+    /// NOTE: This should be reimplemented with the introduction of the BlockCache.
     fn get_block_nullifiers<'life0, 'async_trait>(
         &'life0 self,
-        _request: tonic::Request<BlockId>,
+        request: tonic::Request<BlockId>,
     ) -> core::pin::Pin<
         Box<
             dyn core::future::Future<
@@ -172,7 +174,14 @@ impl CompactTxStreamer for GrpcClient {
     {
         println!("[TEST] Received call of get_block_nullifiers.");
         Box::pin(async {
-            Err(tonic::Status::unimplemented("get_block_nullifiers not yet implemented. If you require this RPC please open an issue or PR at the Zingo-Indexer github (https://github.com/zingolabs/zingo-indexer)."))
+            let zebrad_uri = self.zebrad_uri.clone();
+            let height = request.into_inner().height as u32;
+            match get_nullifiers_from_node(&zebrad_uri, &height).await {
+                Ok(block) => Ok(tonic::Response::new(block)),
+                Err(e) => {
+                    return Err(tonic::Status::internal(e.to_string()));
+                }
+            }
         })
     }
 


### PR DESCRIPTION
Implements the get_block_nullifers gRPC service.

Currently there are no tests for this in Zaino, these will be added when the last PRs for [https://github.com/zingolabs/zcash-local-net] land and we can integrate that repo into Zaino-testutils. There is a test in [https://github.com/zingolabs/zcash-local-net] that tests this function "integrations::get_block_nullifiers".

- Work towards https://github.com/zingolabs/zaino/issues/52

- Built atop https://github.com/zingolabs/zaino/pull/82 and #84