### PR TITLE
Subtree roots RPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Zaino
-A(n eventual) rust implemented, nym enhanced, indexer and lightwallet service for Zcash.
+A rust implemented indexer and lightwallet service for Zcash.
 
-Zaino is intended to provide all necessary funtionality for clients, including "standalone" (formerly "light") clients/wallets and integrated (formerly "full") client/wallets to access both the finalized chain and non-finalized best chain and the mempool, held by a Zebrad full validator.
-
-*A note to developers/consumers/contributers: The end goal is not an exact one-to-one port of all existing lwd functionality. We currently plan to hold the Service and Darkside RPC implementations, along with a Nym counterpart to the service RPCs for sending and recieving currency over the Nym Mixnet.
+Zaino is intended to provide all necessary funtionality for clients, including "standalone" (formerly "light") clients/wallets, integrated (formerly "full") client/wallets and block explorers to access both the finalized chain and non-finalized best chain and mempool, held by either a Zebrad or Zcashd full validator.
 
 # Security Vulnerability Disclosure
 If you believe you have discovered a security issue, please contact us at:
@@ -11,19 +9,12 @@ If you believe you have discovered a security issue, please contact us at:
 zingodisclosure@proton.me
 
 # ZainoD
-The Zaino Indexer service.
-
-Under the "nym_poc" feature flag ZainoD can also act as a Nym powered proxy, running between zcash wallets and Zingo-IndexerD, capable of sending zcash transactions over the Nym Mixnet. 
-Note: The wallet-side nym service RPC implementations are moving to CompactTxStreamerClient for easier consumption by wallets. Functionality under the "nym_poc" feature flag will be removed once a working example has been implemented directly in zingolib.
-
-This is the POC and initial work on enabling zcash infrastructure to use the nym mixnet.
+The Zaino Indexer gRPC service.
 
 # Zaino-Serve
-Holds a gRPC server capable of servicing clients over both https and the nym mixnet.
+Holds a gRPC server capable of servicing clients over both https and the nym mixnet (currently removed due to dependecy conflicts).
 
-Also holds the rust implementations of the LightWallet Service (CompactTxStreamerServer) and (eventually) Darkside RPCs (DarksideTxStremerServer).
-
-* Currently only send_transaction and get_lightd_info are implemented over nym.
+Also holds the rust implementations of the LightWallet gRPC Service (CompactTxStreamerServer).
 
 # Zaino-Wallet [*Temporarily Removed due to Nym Dependency Conflict]
 Holds the nym-enhanced, wallet-side rust implementations of the LightWallet Service RPCs (NymTxStreamerClient).

--- a/zaino-fetch/src/jsonrpc/connector.rs
+++ b/zaino-fetch/src/jsonrpc/connector.rs
@@ -12,9 +12,9 @@ use std::sync::atomic::{AtomicI32, Ordering};
 use crate::jsonrpc::{
     error::JsonRpcConnectorError,
     response::{
-        BestBlockHashResponse, GetBalanceResponse, GetBlockResponse, GetBlockchainInfoResponse,
-        GetInfoResponse, GetSubtreesResponse, GetTransactionResponse, GetTreestateResponse,
-        GetUtxosResponse, SendTransactionResponse, TxidsResponse,
+        GetBalanceResponse, GetBlockResponse, GetBlockchainInfoResponse, GetInfoResponse,
+        GetSubtreesResponse, GetTransactionResponse, GetTreestateResponse, GetUtxosResponse,
+        SendTransactionResponse, TxidsResponse,
     },
 };
 
@@ -240,20 +240,6 @@ impl JsonRpcConnector {
         self.send_request("getblock", params).await
     }
 
-    /// Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
-    ///
-    /// zcashd reference: [`getbestblockhash`](https://zcash.github.io/rpc/getbestblockhash.html)
-    /// method: post
-    /// tags: blockchain
-    ///
-    /// WARNING: Unused by Zaino and untested!
-    pub async fn get_best_block_hash(
-        &self,
-    ) -> Result<BestBlockHashResponse, JsonRpcConnectorError> {
-        self.send_request::<(), BestBlockHashResponse>("getbestblockhash", ())
-            .await
-    }
-
     /// Returns all transaction ids in the memory pool, as a JSON array.
     ///
     /// zcashd reference: [`getrawmempool`](https://zcash.github.io/rpc/getrawmempool.html)
@@ -292,8 +278,6 @@ impl JsonRpcConnector {
     /// - `pool`: (string, required) The pool from which subtrees should be returned. Either "sapling" or "orchard".
     /// - `start_index`: (number, required) The index of the first 2^16-leaf subtree to return.
     /// - `limit`: (number, optional) The maximum number of subtree values to return.
-    ///
-    /// WARNING: Currently unused by Zingo-Indexer and untested!
     pub async fn get_subtrees_by_index(
         &self,
         pool: String,

--- a/zaino-fetch/src/jsonrpc/connector.rs
+++ b/zaino-fetch/src/jsonrpc/connector.rs
@@ -246,7 +246,7 @@ impl JsonRpcConnector {
     /// method: post
     /// tags: blockchain
     ///
-    /// NOTE: Currently unused by Zingo-Indexer and untested!
+    /// WARNING: Unused by Zaino and untested!
     pub async fn get_best_block_hash(
         &self,
     ) -> Result<BestBlockHashResponse, JsonRpcConnectorError> {
@@ -293,7 +293,7 @@ impl JsonRpcConnector {
     /// - `start_index`: (number, required) The index of the first 2^16-leaf subtree to return.
     /// - `limit`: (number, optional) The maximum number of subtree values to return.
     ///
-    /// NOTE: Currently unused by Zingo-Indexer and untested!
+    /// WARNING: Currently unused by Zingo-Indexer and untested!
     pub async fn get_subtrees_by_index(
         &self,
         pool: String,

--- a/zaino-serve/src/rpc/service.rs
+++ b/zaino-serve/src/rpc/service.rs
@@ -446,6 +446,7 @@ impl CompactTxStreamer for GrpcClient {
             let (channel_tx, channel_rx) = tokio::sync::mpsc::channel(32);
             tokio::spawn(async move {
                 // NOTE: This timeout is so slow due to the blockcache not being implemented. This should be reduced to 30s once functionality is in place.
+                // TODO: Make [rpc_timout] a configurable system variable with [default = 30s] and [mempool_rpc_timout = 4*rpc_timeout]
                 let timeout = timeout(std::time::Duration::from_secs(120), async {
                     for height in start..=end {
                         let height = if rev_order {
@@ -589,6 +590,7 @@ impl CompactTxStreamer for GrpcClient {
             let (channel_tx, channel_rx) = tokio::sync::mpsc::channel(32);
             tokio::spawn(async move {
                 // NOTE: This timeout is so slow due to the blockcache not being implemented. This should be reduced to 30s once functionality is in place.
+                // TODO: Make [rpc_timout] a configurable system variable with [default = 30s] and [mempool_rpc_timout = 4*rpc_timeout]
                 let timeout = timeout(std::time::Duration::from_secs(120), async {
                     for height in start..=end {
                         let height = if rev_order {
@@ -817,7 +819,9 @@ impl CompactTxStreamer for GrpcClient {
                 .map_err(|e| e.to_grpc_status())?;
             let (channel_tx, channel_rx) = tokio::sync::mpsc::channel(32);
             tokio::spawn(async move {
-                let timeout = timeout(std::time::Duration::from_secs(30), async {
+                // NOTE: This timeout is so slow due to the blockcache not being implemented. This should be reduced to 30s once functionality is in place.
+                // TODO: Make [rpc_timout] a configurable system variable with [default = 30s] and [mempool_rpc_timout = 4*rpc_timeout]
+                let timeout = timeout(std::time::Duration::from_secs(120), async {
                     for txid in txids.transactions {
                         let transaction = zebrad_client.get_raw_transaction(txid, Some(1)).await;
                         match transaction {
@@ -948,7 +952,9 @@ impl CompactTxStreamer for GrpcClient {
             .await?;
             let (channel_tx, mut channel_rx) = tokio::sync::mpsc::channel::<String>(32);
             let fetcher_task_handle = tokio::spawn(async move {
-                let fetcher_timeout = timeout(std::time::Duration::from_secs(30), async {
+                // NOTE: This timeout is so slow due to the blockcache not being implemented. This should be reduced to 30s once functionality is in place.
+                // TODO: Make [rpc_timout] a configurable system variable with [default = 30s] and [mempool_rpc_timout = 4*rpc_timeout]
+                let fetcher_timeout = timeout(std::time::Duration::from_secs(120), async {
                     let mut total_balance: u64 = 0;
                     loop {
                         match channel_rx.recv().await {
@@ -977,7 +983,9 @@ impl CompactTxStreamer for GrpcClient {
                     )),
                 }
             });
-            let addr_recv_timeout = timeout(std::time::Duration::from_secs(30), async {
+            // NOTE: This timeout is so slow due to the blockcache not being implemented. This should be reduced to 30s once functionality is in place.
+            // TODO: Make [rpc_timout] a configurable system variable with [default = 30s] and [mempool_rpc_timout = 4*rpc_timeout]
+            let addr_recv_timeout = timeout(std::time::Duration::from_secs(120), async {
                 let mut address_stream = request.into_inner();
                 while let Some(address_result) = address_stream.next().await {
                     // TODO: Hide server error from clients before release. Currently useful for dev purposes.
@@ -1086,8 +1094,9 @@ impl CompactTxStreamer for GrpcClient {
                 .collect();
             let (channel_tx, channel_rx) = tokio::sync::mpsc::channel(32);
             tokio::spawn(async move {
-                // TODO: Make [rpc_timout] a configurable system variable with [default = 30s] and [streaming_rpc_timout = 4*rpc_timeout]
-                let timeout = timeout(std::time::Duration::from_secs(600), async {
+                // NOTE: This timeout is so slow due to the blockcache not being implemented. This should be reduced to 30s once functionality is in place.
+                // TODO: Make [rpc_timout] a configurable system variable with [default = 30s] and [mempool_rpc_timout = 4*rpc_timeout]
+                let timeout = timeout(std::time::Duration::from_secs(480), async {
                     let mempool = Mempool::new();
                     if let Err(e) = mempool.update(&zebrad_uri).await {
                         channel_tx.send(Err(tonic::Status::unknown(e.to_string())))
@@ -1261,8 +1270,9 @@ impl CompactTxStreamer for GrpcClient {
             let mempool_height = zebrad_client.get_blockchain_info().await?.blocks.0;
             let (channel_tx, channel_rx) = tokio::sync::mpsc::channel(32);
             tokio::spawn(async move {
-                // TODO: Make [rpc_timout] a configurable system variable with [default = 30s] and [streaming_rpc_timout = 4*rpc_timeout]
-                let timeout = timeout(std::time::Duration::from_secs(600), async {
+                // NOTE: This timeout is so slow due to the blockcache not being implemented. This should be reduced to 30s once functionality is in place.
+                // TODO: Make [rpc_timout] a configurable system variable with [default = 30s] and [mempool_rpc_timout = 4*rpc_timeout]
+                let timeout = timeout(std::time::Duration::from_secs(480), async {
                     let mempool = Mempool::new();
                     if let Err(e) = mempool.update(&zebrad_uri).await {
                         // TODO: Hide server error from clients before release. Currently useful for dev purposes.
@@ -1547,8 +1557,9 @@ impl CompactTxStreamer for GrpcClient {
             let subtrees = zebrad_client.get_subtrees_by_index(pool.to_string(), start_index, limit).await?;
             let (channel_tx, channel_rx) = tokio::sync::mpsc::channel(32);
             tokio::spawn(async move {
-                // TODO: Make [rpc_timout] a configurable system variable with [default = 30s] and [streaming_rpc_timout = 4*rpc_timeout]
-                let timeout = timeout(std::time::Duration::from_secs(600), async {
+                // NOTE: This timeout is so slow due to the blockcache not being implemented. This should be reduced to 30s once functionality is in place.
+                // TODO: Make [rpc_timout] a configurable system variable with [default = 30s] and [mempool_rpc_timout = 4*rpc_timeout]
+                let timeout = timeout(std::time::Duration::from_secs(120), async {
                     for subtree in subtrees.subtrees {
                         match zebrad_client.get_block(subtree.end_height.0.to_string(), Some(1)).await {
                             Ok(GetBlockResponse::Object {
@@ -1782,46 +1793,65 @@ impl CompactTxStreamer for GrpcClient {
             let utxos = zebrad_client.get_address_utxos(addr_args.addresses).await?;
             let (channel_tx, channel_rx) = tokio::sync::mpsc::channel(32);
             tokio::spawn(async move {
-                let mut entries: u32 = 0;
-                for utxo in utxos {
-                    if (utxo.height.0 as u64) < addr_args.start_height {
-                        continue;
-                    }
-                    entries += 1;
-                    if addr_args.max_entries > 0 && entries > addr_args.max_entries {
-                        break;
-                    }
-                    let checked_index = match i32::try_from(utxo.output_index) {
-                        Ok(index) => index,
-                        Err(_) => {
-                            let _ = channel_tx
-                                .send(Err(tonic::Status::unknown(
-                                    "Error: Index out of range. Failed to convert to i32.",
-                                )))
-                                .await;
+                // NOTE: This timeout is so slow due to the blockcache not being implemented. This should be reduced to 30s once functionality is in place.
+                // TODO: Make [rpc_timout] a configurable system variable with [default = 30s] and [mempool_rpc_timout = 4*rpc_timeout]
+                let timeout = timeout(std::time::Duration::from_secs(120), async {
+                    let mut entries: u32 = 0;
+                    for utxo in utxos {
+                        if (utxo.height.0 as u64) < addr_args.start_height {
+                            continue;
+                        }
+                        entries += 1;
+                        if addr_args.max_entries > 0 && entries > addr_args.max_entries {
+                            break;
+                        }
+                        let checked_index = match i32::try_from(utxo.output_index) {
+                            Ok(index) => index,
+                            Err(_) => {
+                                let _ = channel_tx
+                                    .send(Err(tonic::Status::unknown(
+                                        "Error: Index out of range. Failed to convert to i32.",
+                                    )))
+                                    .await;
+                                return;
+                            }
+                        };
+                        let checked_satoshis = match i64::try_from(utxo.satoshis) {
+                            Ok(satoshis) => satoshis,
+                            Err(_) => {
+                                let _ = channel_tx
+                                    .send(Err(tonic::Status::unknown(
+                                        "Error: Satoshis out of range. Failed to convert to i64.",
+                                    )))
+                                    .await;
+                                return;
+                            }
+                        };
+                        let utxo_reply = GetAddressUtxosReply {
+                            address: utxo.address.to_string(),
+                            txid: utxo.txid.0.to_vec(),
+                            index: checked_index,
+                            script: utxo.script.as_ref().to_vec(),
+                            value_zat: checked_satoshis,
+                            height: utxo.height.0 as u64,
+                        };
+                        if channel_tx.send(Ok(utxo_reply)).await.is_err() {
                             return;
                         }
-                    };
-                    let checked_satoshis = match i64::try_from(utxo.satoshis) {
-                        Ok(satoshis) => satoshis,
-                        Err(_) => {
-                            let _ = channel_tx
-                                .send(Err(tonic::Status::unknown(
-                                    "Error: Satoshis out of range. Failed to convert to i64.",
-                                )))
-                                .await;
-                            return;
-                        }
-                    };
-                    let utxo_reply = GetAddressUtxosReply {
-                        address: utxo.address.to_string(),
-                        txid: utxo.txid.0.to_vec(),
-                        index: checked_index,
-                        script: utxo.script.as_ref().to_vec(),
-                        value_zat: checked_satoshis,
-                        height: utxo.height.0 as u64,
-                    };
-                    if channel_tx.send(Ok(utxo_reply)).await.is_err() {
+                    }
+                })
+                .await;
+                match timeout {
+                    Ok(_) => {
+                        return;
+                    }
+                    Err(_) => {
+                        channel_tx
+                            .send(Err(tonic::Status::deadline_exceeded(
+                                "Error: get_mempool_stream gRPC request timed out",
+                            )))
+                            .await
+                            .ok();
                         return;
                     }
                 }


### PR DESCRIPTION
Implements get_subtree_roots RPC. Also adds a timeout to the get_address_utxos RPC and unifies timeout times.

- Build atop Fix error types https://github.com/zingolabs/zaino/pull/89, https://github.com/zingolabs/zaino/pull/90, #91,  #92, #97, #98 and #99.

- Work towards 1.5 - Implement lightwalletd gRPC functionality in Rust using JSONRPC interface for backwards compatibility. https://github.com/zingolabs/zaino/issues/52

- Closes #95