### PR TITLE
Allow connecting to Zebrad on any hostname

### DIFF
--- a/zaino-fetch/src/jsonrpc/connector.rs
+++ b/zaino-fetch/src/jsonrpc/connector.rs
@@ -402,12 +402,14 @@ async fn test_node_connection(
 
 /// Tries to connect to zebrad/zcashd using IPv4 and IPv6 and returns the correct uri type, exits program with error message if connection cannot be established.
 pub async fn test_node_and_return_uri(
+    hostname: Option<String>,
     port: &u16,
     user: Option<String>,
     password: Option<String>,
 ) -> Result<Uri, JsonRpcConnectorError> {
-    let ipv4_uri: Url = format!("http://127.0.0.1:{}", port).parse()?;
-    let ipv6_uri: Url = format!("http://[::1]:{}", port).parse()?;
+    let hostname = hostname.unwrap_or_else(|| "localhost".to_string());
+    let ipv4_uri: Url = format!("http://{}:{}", hostname, port).parse()?;
+    let ipv6_uri: Url = format!("http://{}:{}", hostname, port).parse()?;
     let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(500));
     for _ in 0..3 {
         match test_node_connection(ipv4_uri.clone(), user.clone(), password.clone()).await {

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -17,6 +17,8 @@ pub struct TestManager {
     pub regtest_network: zingolib::config::RegtestNetwork,
     /// Zingo-Indexer gRPC listen port.
     pub indexer_port: u16,
+    /// Zebrad/Zcashd JsonRpc listen hostname.
+    pub zebrad_hostname: Option<String>,
     /// Zebrad/Zcashd JsonRpc listen port.
     pub zebrad_port: u16,
     /// Online status of Zingo-Indexer.
@@ -33,6 +35,7 @@ impl TestManager {
         tokio::task::JoinHandle<Result<(), zainodlib::error::IndexerError>>,
     ) {
         let lwd_port = portpicker::pick_unused_port().expect("No ports free");
+        let zebrad_hostname = Some("127.0.0.1".to_string());
         let zebrad_port = portpicker::pick_unused_port().expect("No ports free");
         let indexer_port = portpicker::pick_unused_port().expect("No ports free");
 
@@ -54,6 +57,7 @@ impl TestManager {
             tcp_active: true,
             listen_port: Some(indexer_port),
             lightwalletd_port: lwd_port,
+            zebrad_hostname: zebrad_hostname.clone(),
             zebrad_port,
             node_user: Some("xxxxxx".to_string()),
             node_password: Some("xxxxxx".to_string()),
@@ -73,6 +77,7 @@ impl TestManager {
                 regtest_manager,
                 regtest_network,
                 indexer_port,
+                zebrad_hostname: zebrad_hostname.clone(),
                 zebrad_port,
                 online,
             },
@@ -94,6 +99,7 @@ impl TestManager {
     /// Returns zebrad listen address.
     pub async fn test_and_return_zebrad_uri(&self) -> http::Uri {
         zaino_fetch::jsonrpc::connector::test_node_and_return_uri(
+            self.zebrad_hostname.clone(),
             &self.zebrad_port,
             Some("xxxxxx".to_string()),
             Some("xxxxxx".to_string()),

--- a/zainod/src/indexer.rs
+++ b/zainod/src/indexer.rs
@@ -120,8 +120,9 @@ impl Indexer {
             .authority(format!("localhost:{}", config.lightwalletd_port))
             .path_and_query("/")
             .build()?;
-        println!("Checking connection with node..");
+        println!("Checking connection with node {}:{}", config.zebrad_hostname.clone().unwrap(), &config.zebrad_port);
         let zebrad_uri = test_node_and_return_uri(
+            config.zebrad_hostname.clone(),
             &config.zebrad_port,
             config.node_user.clone(),
             config.node_password.clone(),

--- a/zainod/zindexer.toml
+++ b/zainod/zindexer.toml
@@ -9,6 +9,9 @@ listen_port = 8137
 # LightWalletD listen port [DEPRECATED]
 lightwalletd_port = 9067
 
+# Full node / validator listen hostname
+zebrad_hostname = "localhost"
+
 # Full node / validator listen port
 zebrad_port = 18232
 


### PR DESCRIPTION
This patch allows for Zaino to connect to a Zebrad that is not running on localhost.

This is my first-ever Rust pull request so bear with me! I am unsure how to run the tests, am happy to fix anything that broke.

Thank you for your great work on Zaino!