### PR TITLE
Add Fetch service to Zaino-State

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4369,7 +4369,7 @@ dependencies = [
 [[package]]
 name = "tower-batch-control"
 version = "0.2.41-beta.19"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
 dependencies = [
  "futures",
  "futures-core",
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "tower-fallback"
 version = "0.2.41-beta.19"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -5172,6 +5172,7 @@ dependencies = [
  "zcash_protocol 0.4.0",
  "zebra-chain",
  "zebra-rpc",
+ "zebra-state",
 ]
 
 [[package]]
@@ -5602,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "zebra-chain"
 version = "1.0.0-beta.43"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
 dependencies = [
  "bitflags",
  "bitflags-serde-legacy",
@@ -5658,7 +5659,7 @@ dependencies = [
 [[package]]
 name = "zebra-consensus"
 version = "1.0.0-beta.43"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5694,7 +5695,7 @@ dependencies = [
 [[package]]
 name = "zebra-network"
 version = "1.0.0-beta.43"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -5730,7 +5731,7 @@ dependencies = [
 [[package]]
 name = "zebra-node-services"
 version = "1.0.0-beta.43"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
 dependencies = [
  "color-eyre",
  "jsonrpc-core",
@@ -5744,7 +5745,7 @@ dependencies = [
 [[package]]
 name = "zebra-rpc"
 version = "1.0.0-beta.43"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5777,7 +5778,7 @@ dependencies = [
 [[package]]
 name = "zebra-script"
 version = "1.0.0-beta.43"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
 dependencies = [
  "thiserror 2.0.9",
  "zcash_script",
@@ -5787,7 +5788,7 @@ dependencies = [
 [[package]]
 name = "zebra-state"
 version = "1.0.0-beta.43"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4369,7 +4369,7 @@ dependencies = [
 [[package]]
 name = "tower-batch-control"
 version = "0.2.41-beta.19"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8e8ebe2972459a40461a718fe277b45d5d2fe7b3"
 dependencies = [
  "futures",
  "futures-core",
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "tower-fallback"
 version = "0.2.41-beta.19"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8e8ebe2972459a40461a718fe277b45d5d2fe7b3"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -5234,6 +5234,7 @@ dependencies = [
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
+ "zingolib",
 ]
 
 [[package]]
@@ -5603,7 +5604,7 @@ dependencies = [
 [[package]]
 name = "zebra-chain"
 version = "1.0.0-beta.43"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8e8ebe2972459a40461a718fe277b45d5d2fe7b3"
 dependencies = [
  "bitflags",
  "bitflags-serde-legacy",
@@ -5659,7 +5660,7 @@ dependencies = [
 [[package]]
 name = "zebra-consensus"
 version = "1.0.0-beta.43"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8e8ebe2972459a40461a718fe277b45d5d2fe7b3"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5695,7 +5696,7 @@ dependencies = [
 [[package]]
 name = "zebra-network"
 version = "1.0.0-beta.43"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8e8ebe2972459a40461a718fe277b45d5d2fe7b3"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -5731,7 +5732,7 @@ dependencies = [
 [[package]]
 name = "zebra-node-services"
 version = "1.0.0-beta.43"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8e8ebe2972459a40461a718fe277b45d5d2fe7b3"
 dependencies = [
  "color-eyre",
  "jsonrpc-core",
@@ -5745,7 +5746,7 @@ dependencies = [
 [[package]]
 name = "zebra-rpc"
 version = "1.0.0-beta.43"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8e8ebe2972459a40461a718fe277b45d5d2fe7b3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5778,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "zebra-script"
 version = "1.0.0-beta.43"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8e8ebe2972459a40461a718fe277b45d5d2fe7b3"
 dependencies = [
  "thiserror 2.0.9",
  "zcash_script",
@@ -5788,7 +5789,7 @@ dependencies = [
 [[package]]
 name = "zebra-state"
 version = "1.0.0-beta.43"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#f69f0c72631bddcece9af495d1cf543255af598b"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8e8ebe2972459a40461a718fe277b45d5d2fe7b3"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cipher",
  "cpufeatures",
 ]
@@ -44,7 +44,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -239,8 +239,8 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "itoa",
  "matchit",
@@ -265,8 +265,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -284,7 +284,7 @@ checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -302,12 +302,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -369,7 +363,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -380,7 +374,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.90",
  "which",
@@ -392,7 +386,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -401,7 +395,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.90",
 ]
@@ -453,12 +447,6 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
@@ -469,7 +457,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b64e60c28b6d25ad92e8b367801ff9aa12b41d05fc8798055d296bace4a60cc"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "serde",
 ]
 
@@ -549,16 +537,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "build_utils"
 version = "0.1.0"
 source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_004#f9f3e5f6da261ec6b7bd1282905534fdc328cb41"
@@ -629,12 +607,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -651,7 +623,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cipher",
  "cpufeatures",
 ]
@@ -671,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -901,7 +873,7 @@ version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
@@ -1092,7 +1064,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1387,7 +1359,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1398,9 +1370,11 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1428,19 +1402,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "globset"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,25 +1415,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.7.0",
- "slab",
- "tokio",
- "tokio-util 0.7.13",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
@@ -1482,11 +1424,11 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http",
  "indexmap 2.7.0",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1599,17 +1541,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
@@ -1621,23 +1552,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http",
 ]
 
 [[package]]
@@ -1648,8 +1568,8 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1689,30 +1609,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
@@ -1720,9 +1616,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1734,35 +1630,22 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.31",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http 1.2.0",
- "hyper 1.5.1",
+ "http",
+ "hyper",
  "hyper-util",
  "log",
- "rustls 0.23.19",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls",
  "tower-service",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -1771,7 +1654,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.5.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1786,7 +1669,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1803,9 +1686,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "hyper 1.5.1",
+ "http",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2057,15 +1940,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "integration-tests"
 version = "0.0.0"
 dependencies = [
@@ -2155,49 +2029,90 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-derive"
-version = "18.0.0"
+name = "jsonrpsee"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
+checksum = "c5c71d8c1a731cc4227c2f698d377e7848ca12c8a48866fc5e6951c43a4db843"
 dependencies = [
- "proc-macro-crate 0.1.5",
+ "jsonrpsee-core",
+ "jsonrpsee-server",
+ "jsonrpsee-types",
+ "tokio",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2882f6f8acb9fdaec7cefc4fd607119a9bd709831df7d7672a1d3b644628280"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "jsonrpsee-types",
+ "parking_lot",
+ "rand 0.8.5",
+ "rustc-hash 2.1.0",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06c01ae0007548e73412c08e2285ffe5d723195bf268bce67b1b77c3bb2a14d"
+dependencies = [
+ "heck",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.90",
 ]
 
 [[package]]
-name = "jsonrpc-http-server"
-version = "18.0.0"
+name = "jsonrpsee-server"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
+checksum = "82ad8ddc14be1d4290cd68046e7d1d37acd408efed6d3ca08aefcc3ad6da069c"
 dependencies = [
- "futures",
- "hyper 0.14.31",
- "jsonrpc-core",
- "jsonrpc-server-utils",
- "log",
- "net2",
- "parking_lot 0.11.2",
- "unicase",
-]
-
-[[package]]
-name = "jsonrpc-server-utils"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
-dependencies = [
- "bytes",
- "futures",
- "globset",
- "jsonrpc-core",
- "lazy_static",
- "log",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "pin-project",
+ "route-recognizer",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tokio-util 0.6.10",
- "unicase",
+ "tokio-util",
+ "tower 0.4.13",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a178c60086f24cc35bb82f57c651d0d25d99c4742b4d335de04e97fa1f08a8a1"
+dependencies = [
+ "http",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2273,7 +2188,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "windows-targets 0.52.6",
 ]
 
@@ -2289,7 +2204,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "libc",
 ]
 
@@ -2378,13 +2293,13 @@ dependencies = [
  "log",
  "log-mdc",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand 0.8.5",
  "serde",
  "serde-value",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.69",
  "thread-id",
  "typemap-ors",
  "winapi",
@@ -2412,7 +2327,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "rayon",
 ]
 
@@ -2503,24 +2418,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "net2"
-version = "0.2.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.6.0",
- "cfg-if 1.0.0",
+ "bitflags",
+ "cfg-if",
  "cfg_aliases",
  "libc",
 ]
@@ -2623,8 +2527,8 @@ version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
- "bitflags 2.6.0",
- "cfg-if 1.0.0",
+ "bitflags",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -2758,21 +2662,10 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
 ]
 
 [[package]]
@@ -2782,21 +2675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.10",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2805,9 +2684,9 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "redox_syscall 0.5.7",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -2982,15 +2861,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
@@ -3037,7 +2907,7 @@ checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.6.0",
+ "bitflags",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -3129,6 +2999,58 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.0",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.9",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+dependencies = [
+ "bytes",
+ "getrandom 0.2.15",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash 2.1.0",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.9",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3297,7 +3219,7 @@ dependencies = [
  "pasta_curves",
  "rand_core 0.6.4",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -3310,17 +3232,8 @@ dependencies = [
  "rand_core 0.6.4",
  "reddsa",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "zeroize",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3329,7 +3242,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -3340,7 +3253,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3383,47 +3296,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.31",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
@@ -3433,12 +3305,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.5.1",
- "hyper-rustls 0.27.3",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -3449,19 +3321,24 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.2.0",
+ "quinn",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.26.7",
  "windows-registry",
 ]
 
@@ -3472,7 +3349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "getrandom 0.2.15",
  "libc",
  "spin",
@@ -3507,6 +3384,12 @@ dependencies = [
  "libc",
  "librocksdb-sys",
 ]
+
+[[package]]
+name = "route-recognizer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rust-embed"
@@ -3555,6 +3438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3575,23 +3464,11 @@ version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
 ]
 
 [[package]]
@@ -3605,7 +3482,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -3624,15 +3501,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
@@ -3645,15 +3513,8 @@ name = "rustls-pki-types"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "web-time",
 ]
 
 [[package]]
@@ -3749,16 +3610,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "secp256k1"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,7 +3643,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3805,7 +3656,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -3936,12 +3787,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -3961,7 +3823,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5f2390975ebfe8838f9e861f7a588123d49a7a7a0a08568ea831d8ad53fc9b4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "either",
  "incrementalmerkletree",
  "tracing",
@@ -4014,6 +3876,22 @@ checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "soketto"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
 ]
 
 [[package]]
@@ -4106,34 +3984,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -4168,7 +4025,7 @@ version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "once_cell",
  "rustix",
@@ -4190,7 +4047,7 @@ version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -4214,7 +4071,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+dependencies = [
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -4222,6 +4088,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4244,7 +4121,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
 
@@ -4314,7 +4191,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -4346,49 +4223,25 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.19",
+ "rustls",
  "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.13",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4399,6 +4252,7 @@ checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -4441,21 +4295,21 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.7",
- "http 1.2.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
  "rustls-native-certs",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "socket2",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -4492,7 +4346,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4514,31 +4368,15 @@ dependencies = [
 
 [[package]]
 name = "tower-batch-control"
-version = "0.2.41-beta.18"
-source = "git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1#fef500a72840d4b7c89d68e14980eeda43869873"
+version = "0.2.41-beta.19"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
 dependencies = [
  "futures",
  "futures-core",
  "pin-project",
  "rayon",
  "tokio",
- "tokio-util 0.7.13",
- "tower 0.4.13",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tower-batch-control"
-version = "0.2.41-beta.18"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8f6581ef84f57969a5aff7d62b747f7b2e83fd37"
-dependencies = [
- "futures",
- "futures-core",
- "pin-project",
- "rayon",
- "tokio",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tower 0.4.13",
  "tracing",
  "tracing-futures",
@@ -4546,19 +4384,8 @@ dependencies = [
 
 [[package]]
 name = "tower-fallback"
-version = "0.2.41-beta.18"
-source = "git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1#fef500a72840d4b7c89d68e14980eeda43869873"
-dependencies = [
- "futures-core",
- "pin-project",
- "tower 0.4.13",
- "tracing",
-]
-
-[[package]]
-name = "tower-fallback"
-version = "0.2.41-beta.18"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8f6581ef84f57969a5aff7d62b747f7b2e83fd37"
+version = "0.2.41-beta.19"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -4706,12 +4533,6 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "unicase"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-ident"
@@ -4919,7 +4740,7 @@ version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
  "wasm-bindgen-macro",
 ]
@@ -4945,7 +4766,7 @@ version = "0.4.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -4992,6 +4813,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5024,7 +4855,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall 0.5.7",
+ "redox_syscall",
  "wasite",
  "web-sys",
 ]
@@ -5257,16 +5088,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if 1.0.0",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5336,21 +5157,21 @@ dependencies = [
  "base64 0.22.1",
  "byteorder",
  "hex",
- "http 1.2.0",
+ "http",
  "indexmap 2.7.0",
  "prost",
- "reqwest 0.12.9",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
  "url",
  "zaino-proto",
  "zcash_protocol 0.4.0",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
- "zebra-rpc 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
+ "zebra-chain",
+ "zebra-rpc",
 ]
 
 [[package]]
@@ -5371,19 +5192,19 @@ dependencies = [
  "crossbeam-channel",
  "futures",
  "hex",
- "http 1.2.0",
+ "http",
  "lazy-regex",
  "prost",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
  "whoami",
  "zaino-fetch",
  "zaino-proto",
  "zaino-state",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
- "zebra-rpc 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
- "zebra-state 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
+ "zebra-chain",
+ "zebra-rpc",
+ "zebra-state",
 ]
 
 [[package]]
@@ -5394,10 +5215,10 @@ dependencies = [
  "chrono",
  "futures",
  "hex",
- "http 1.2.0",
+ "http",
  "indexmap 2.7.0",
  "jsonrpc-core",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -5409,9 +5230,9 @@ dependencies = [
  "zaino-serve",
  "zaino-testutils",
  "zcash_local_net",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
- "zebra-rpc 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
- "zebra-state 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
+ "zebra-chain",
+ "zebra-rpc",
+ "zebra-state",
 ]
 
 [[package]]
@@ -5419,7 +5240,7 @@ name = "zaino-testutils"
 version = "0.0.0"
 dependencies = [
  "ctrlc",
- "http 1.2.0",
+ "http",
  "once_cell",
  "portpicker",
  "tempfile",
@@ -5430,7 +5251,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_local_net",
  "zcash_protocol 0.4.0",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
+ "zebra-chain",
  "zingolib",
 ]
 
@@ -5440,9 +5261,9 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "ctrlc",
- "http 1.2.0",
+ "http",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "toml",
  "zaino-fetch",
@@ -5581,16 +5402,16 @@ dependencies = [
 [[package]]
 name = "zcash_local_net"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zcash-local-net.git?rev=92b509aa152baf7c5b336bed9462dd751799ae76#92b509aa152baf7c5b336bed9462dd751799ae76"
+source = "git+https://github.com/idky137/zcash-local-net.git?branch=zaino_zebra_dep#fbc7871e8ef315cb2fa6e8ed0cd185dd83c5ca39"
 dependencies = [
  "getset",
  "hex",
- "http 1.2.0",
+ "http",
  "json",
  "portpicker",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -5598,9 +5419,9 @@ dependencies = [
  "zcash_client_backend",
  "zcash_primitives 0.19.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
  "zcash_protocol 0.4.0",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
- "zebra-node-services 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
- "zebra-rpc 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
+ "zebra-chain",
+ "zebra-node-services",
+ "zebra-rpc",
  "zingo-netutils",
  "zingolib",
 ]
@@ -5780,10 +5601,10 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "1.0.0-beta.42"
-source = "git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1#fef500a72840d4b7c89d68e14980eeda43869873"
+version = "1.0.0-beta.43"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "bitflags-serde-legacy",
  "bitvec",
  "blake2b_simd",
@@ -5821,63 +5642,7 @@ dependencies = [
  "sha2",
  "static_assertions",
  "tempfile",
- "thiserror",
- "tokio",
- "tracing",
- "uint 0.10.0",
- "x25519-dalek",
- "zcash_address 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_history",
- "zcash_note_encryption",
- "zcash_primitives 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.4.1",
-]
-
-[[package]]
-name = "zebra-chain"
-version = "1.0.0-beta.42"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8f6581ef84f57969a5aff7d62b747f7b2e83fd37"
-dependencies = [
- "bitflags 2.6.0",
- "bitflags-serde-legacy",
- "bitvec",
- "blake2b_simd",
- "blake2s_simd",
- "bridgetree",
- "bs58",
- "byteorder",
- "chrono",
- "dirs",
- "ed25519-zebra",
- "equihash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures",
- "group",
- "halo2_proofs",
- "hex",
- "humantime",
- "incrementalmerkletree",
- "itertools 0.13.0",
- "jubjub",
- "lazy_static",
- "num-integer",
- "orchard",
- "primitive-types",
- "rand_core 0.6.4",
- "rayon",
- "reddsa",
- "redjubjub",
- "ripemd",
- "sapling-crypto",
- "secp256k1",
- "serde",
- "serde-big-array",
- "serde_json",
- "serde_with",
- "sha2",
- "static_assertions",
- "tempfile",
- "thiserror",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "uint 0.10.0",
@@ -5892,8 +5657,8 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "1.0.0-beta.42"
-source = "git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1#fef500a72840d4b7c89d68e14980eeda43869873"
+version = "1.0.0-beta.43"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5911,63 +5676,27 @@ dependencies = [
  "rayon",
  "sapling-crypto",
  "serde",
- "thiserror",
+ "thiserror 2.0.9",
  "tokio",
  "tower 0.4.13",
- "tower-batch-control 0.2.41-beta.18 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
- "tower-fallback 0.2.41-beta.18 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
+ "tower-batch-control",
+ "tower-fallback",
  "tracing",
  "tracing-futures",
  "wagyu-zcash-parameters",
  "zcash_proofs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
- "zebra-node-services 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
- "zebra-script 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
- "zebra-state 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
-]
-
-[[package]]
-name = "zebra-consensus"
-version = "1.0.0-beta.42"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8f6581ef84f57969a5aff7d62b747f7b2e83fd37"
-dependencies = [
- "bellman",
- "blake2b_simd",
- "bls12_381",
- "chrono",
- "futures",
- "futures-util",
- "halo2_proofs",
- "jubjub",
- "lazy_static",
- "metrics",
- "once_cell",
- "orchard",
- "rand 0.8.5",
- "rayon",
- "sapling-crypto",
- "serde",
- "thiserror",
- "tokio",
- "tower 0.4.13",
- "tower-batch-control 0.2.41-beta.18 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
- "tower-fallback 0.2.41-beta.18 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
- "tracing",
- "tracing-futures",
- "wagyu-zcash-parameters",
- "zcash_proofs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
- "zebra-node-services 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
- "zebra-script 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
- "zebra-state 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
+ "zebra-chain",
+ "zebra-node-services",
+ "zebra-script",
+ "zebra-state",
 ]
 
 [[package]]
 name = "zebra-network"
-version = "1.0.0-beta.42"
-source = "git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1#fef500a72840d4b7c89d68e14980eeda43869873"
+version = "1.0.0-beta.43"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "byteorder",
  "bytes",
  "chrono",
@@ -5987,95 +5716,47 @@ dependencies = [
  "regex",
  "serde",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.13",
+ "tokio-util",
  "tower 0.4.13",
  "tracing",
  "tracing-error",
  "tracing-futures",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
-]
-
-[[package]]
-name = "zebra-network"
-version = "1.0.0-beta.42"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8f6581ef84f57969a5aff7d62b747f7b2e83fd37"
-dependencies = [
- "bitflags 2.6.0",
- "byteorder",
- "bytes",
- "chrono",
- "dirs",
- "futures",
- "hex",
- "humantime-serde",
- "indexmap 2.7.0",
- "itertools 0.13.0",
- "lazy_static",
- "metrics",
- "num-integer",
- "ordered-map",
- "pin-project",
- "rand 0.8.5",
- "rayon",
- "regex",
- "serde",
- "tempfile",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-util 0.7.13",
- "tower 0.4.13",
- "tracing",
- "tracing-error",
- "tracing-futures",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
+ "zebra-chain",
 ]
 
 [[package]]
 name = "zebra-node-services"
-version = "1.0.0-beta.42"
-source = "git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1#fef500a72840d4b7c89d68e14980eeda43869873"
+version = "1.0.0-beta.43"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
 dependencies = [
  "color-eyre",
  "jsonrpc-core",
- "reqwest 0.11.27",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
-]
-
-[[package]]
-name = "zebra-node-services"
-version = "1.0.0-beta.42"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8f6581ef84f57969a5aff7d62b747f7b2e83fd37"
-dependencies = [
- "color-eyre",
- "jsonrpc-core",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "tokio",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
+ "zebra-chain",
 ]
 
 [[package]]
 name = "zebra-rpc"
-version = "1.0.0-beta.42"
-source = "git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1#fef500a72840d4b7c89d68e14980eeda43869873"
+version = "1.0.0-beta.43"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "color-eyre",
  "futures",
  "hex",
+ "http-body-util",
+ "hyper",
  "indexmap 2.7.0",
- "jsonrpc-core",
- "jsonrpc-derive",
- "jsonrpc-http-server",
+ "jsonrpsee",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-types",
  "nix",
  "rand 0.8.5",
  "serde",
@@ -6085,68 +5766,28 @@ dependencies = [
  "tracing",
  "zcash_address 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_primitives 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
- "zebra-consensus 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
- "zebra-network 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
- "zebra-node-services 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
- "zebra-script 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
- "zebra-state 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
-]
-
-[[package]]
-name = "zebra-rpc"
-version = "1.0.0-beta.42"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8f6581ef84f57969a5aff7d62b747f7b2e83fd37"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "color-eyre",
- "futures",
- "hex",
- "indexmap 2.7.0",
- "jsonrpc-core",
- "jsonrpc-derive",
- "jsonrpc-http-server",
- "nix",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "tokio",
- "tower 0.4.13",
- "tracing",
- "zcash_primitives 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
- "zebra-consensus 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
- "zebra-network 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
- "zebra-node-services 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
- "zebra-script 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
- "zebra-state 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
+ "zebra-chain",
+ "zebra-consensus",
+ "zebra-network",
+ "zebra-node-services",
+ "zebra-script",
+ "zebra-state",
 ]
 
 [[package]]
 name = "zebra-script"
-version = "1.0.0-beta.42"
-source = "git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1#fef500a72840d4b7c89d68e14980eeda43869873"
+version = "1.0.0-beta.43"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.9",
  "zcash_script",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
-]
-
-[[package]]
-name = "zebra-script"
-version = "1.0.0-beta.42"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8f6581ef84f57969a5aff7d62b747f7b2e83fd37"
-dependencies = [
- "thiserror",
- "zcash_script",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
+ "zebra-chain",
 ]
 
 [[package]]
 name = "zebra-state"
-version = "1.0.0-beta.42"
-source = "git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1#fef500a72840d4b7c89d68e14980eeda43869873"
+version = "1.0.0-beta.43"
+source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#3275e0cfcab7b56211e4a6f8b539cb9b3e75fca8"
 dependencies = [
  "bincode",
  "chrono",
@@ -6168,43 +5809,11 @@ dependencies = [
  "semver",
  "serde",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.9",
  "tokio",
  "tower 0.4.13",
  "tracing",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.0.1)",
-]
-
-[[package]]
-name = "zebra-state"
-version = "1.0.0-beta.42"
-source = "git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2#8f6581ef84f57969a5aff7d62b747f7b2e83fd37"
-dependencies = [
- "bincode",
- "chrono",
- "dirs",
- "futures",
- "hex",
- "hex-literal",
- "human_bytes",
- "humantime-serde",
- "indexmap 2.7.0",
- "itertools 0.13.0",
- "lazy_static",
- "metrics",
- "mset",
- "rayon",
- "regex",
- "rlimit",
- "rocksdb",
- "semver",
- "serde",
- "tempfile",
- "thiserror",
- "tokio",
- "tower 0.4.13",
- "tracing",
- "zebra-chain 1.0.0-beta.42 (git+https://github.com/idky137/zebra.git?branch=add_public_func_for_zaino_pt2)",
+ "zebra-chain",
 ]
 
 [[package]]
@@ -6308,15 +5917,15 @@ name = "zingo-netutils"
 version = "0.1.0"
 source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_004#f9f3e5f6da261ec6b7bd1282905534fdc328cb41"
 dependencies = [
- "http 1.2.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.5.1",
- "hyper-rustls 0.27.3",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "prost",
- "thiserror",
- "tokio-rustls 0.26.0",
+ "thiserror 1.0.69",
+ "tokio-rustls",
  "tonic",
  "tower 0.5.1",
  "webpki-roots 0.25.4",
@@ -6347,7 +5956,7 @@ dependencies = [
  "sapling-crypto",
  "sha2",
  "shardtree",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
  "tracing",
@@ -6385,7 +5994,7 @@ dependencies = [
  "futures",
  "group",
  "hex",
- "http 1.2.0",
+ "http",
  "incrementalmerkletree",
  "indoc",
  "json",
@@ -6399,10 +6008,10 @@ dependencies = [
  "proptest",
  "prost",
  "rand 0.8.5",
- "reqwest 0.12.9",
+ "reqwest",
  "ring",
  "rust-embed",
- "rustls 0.23.19",
+ "rustls",
  "sapling-crypto",
  "secp256k1",
  "secrecy",
@@ -6414,7 +6023,7 @@ dependencies = [
  "tempdir",
  "tempfile",
  "test-case",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tonic",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,8 @@ zebra-state = { git = "https://github.com/idky137/zebra.git", branch = "add_publ
 zebra-rpc = { git = "https://github.com/idky137/zebra.git", branch = "add_public_func_for_zaino_pt2" }
 
 # Zcash-Local-Net
-zcash_local_net = { git = "https://github.com/zingolabs/zcash-local-net.git", rev = "92b509aa152baf7c5b336bed9462dd751799ae76", features = [ "test_fixtures" ] }
+# zcash_local_net = { git = "https://github.com/zingolabs/zcash-local-net.git", rev = "92b509aa152baf7c5b336bed9462dd751799ae76", features = [ "test_fixtures" ] }
+zcash_local_net = { git = "https://github.com/idky137/zcash-local-net.git", branch = "zaino_zebra_dep", features = [ "test_fixtures" ] }
 
 # Miscellaneous
 tokio = { version = "1.38", features = ["full"] }

--- a/zaino-fetch/Cargo.toml
+++ b/zaino-fetch/Cargo.toml
@@ -15,6 +15,7 @@ zcash_protocol = { workspace = true }
 # Zebra
 zebra-chain = { workspace = true }
 zebra-rpc = { workspace = true }
+zebra-state = { workspace = true }
 
 # Miscellaneous Workspace
 tokio = { workspace = true, features = ["full"] }

--- a/zaino-fetch/src/jsonrpc/connector.rs
+++ b/zaino-fetch/src/jsonrpc/connector.rs
@@ -48,6 +48,20 @@ pub struct RpcError {
     pub data: Option<Value>,
 }
 
+impl RpcError {
+    /// Creates a new `RpcError` from a `LegacyCode`.
+    pub fn new_from_legacycode(
+        code: zebra_rpc::server::error::LegacyCode,
+        message: impl Into<String>,
+    ) -> Self {
+        RpcError {
+            code: code as i64,
+            message: message.into(),
+            data: None,
+        }
+    }
+}
+
 impl fmt::Display for RpcError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "RPC Error (code: {}): {}", self.code, self.message)

--- a/zaino-fetch/src/jsonrpc/response.rs
+++ b/zaino-fetch/src/jsonrpc/response.rs
@@ -1,5 +1,7 @@
 //! Response types for jsonRPC client.
 
+use hex::FromHex;
+
 /// Response to a `getinfo` RPC request.
 ///
 /// This is used for the output parameter of [`JsonRpcConnector::get_info`].
@@ -84,6 +86,12 @@ impl From<GetBalanceResponse> for zebra_rpc::methods::AddressBalance {
 /// This is used for the output parameter of [`JsonRpcConnector::send_raw_transaction`].
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct SendTransactionResponse(#[serde(with = "hex")] pub zebra_chain::transaction::Hash);
+
+impl From<SendTransactionResponse> for zebra_rpc::methods::SentTransactionHash {
+    fn from(value: SendTransactionResponse) -> Self {
+        zebra_rpc::methods::SentTransactionHash::new(value.0)
+    }
+}
 
 /// Response to a `getbestblockhash` and `getblockhash` RPC request.
 ///
@@ -380,6 +388,24 @@ impl<'de> serde::Deserialize<'de> for GetTreestateResponse {
     }
 }
 
+impl TryFrom<GetTreestateResponse> for zebra_rpc::methods::trees::GetTreestate {
+    type Error = zebra_chain::serialization::SerializationError;
+
+    fn try_from(value: GetTreestateResponse) -> Result<Self, Self::Error> {
+        let parsed_hash = zebra_chain::block::Hash::from_hex(&value.hash)?;
+        let sapling_bytes = hex::decode(value.sapling.inner().inner().as_bytes())?;
+        let orchard_bytes = hex::decode(value.orchard.inner().inner().as_bytes())?;
+
+        Ok(zebra_rpc::methods::trees::GetTreestate::from_parts(
+            parsed_hash,
+            zebra_chain::block::Height(value.height as u32),
+            value.time,
+            Some(sapling_bytes),
+            Some(orchard_bytes),
+        ))
+    }
+}
+
 /// A wrapper struct for a zebra serialized transaction.
 ///
 /// Stores bytes that are guaranteed to be deserializable into a [`Transaction`].
@@ -455,10 +481,10 @@ pub enum GetTransactionResponse {
         hex: SerializedTransaction,
         /// The height of the block in the best chain that contains the transaction, or -1 if
         /// the transaction is in the mempool.
-        height: i32,
+        height: Option<i32>,
         /// The confirmations of the block in the best chain that contains the transaction,
         /// or 0 if the transaction is in the mempool.
-        confirmations: u32,
+        confirmations: Option<u32>,
     },
 }
 
@@ -467,36 +493,59 @@ impl<'de> serde::Deserialize<'de> for GetTransactionResponse {
     where
         D: serde::Deserializer<'de>,
     {
-        let v = serde_json::Value::deserialize(deserializer)?;
-        if v.get("height").is_some() && v.get("confirmations").is_some() {
-            let hex = serde_json::from_value(v["hex"].clone()).map_err(serde::de::Error::custom)?;
-            let height = v["height"]
+        let tx_value = serde_json::Value::deserialize(deserializer)?;
+        if tx_value.get("height").is_some() && tx_value.get("confirmations").is_some() {
+            let hex = serde_json::from_value(tx_value["hex"].clone())
+                .map_err(serde::de::Error::custom)?;
+            let height = tx_value["height"]
                 .as_i64()
                 .ok_or_else(|| serde::de::Error::custom("Missing or invalid height"))?
                 as i32;
-            let confirmations = v["confirmations"]
+            let confirmations = tx_value["confirmations"]
                 .as_u64()
                 .ok_or_else(|| serde::de::Error::custom("Missing or invalid confirmations"))?
                 as u32;
             let obj = GetTransactionResponse::Object {
                 hex,
-                height,
-                confirmations,
+                height: Some(height),
+                confirmations: Some(confirmations),
             };
             Ok(obj)
-        } else if v.get("hex").is_some() && v.get("txid").is_some() {
-            let hex = serde_json::from_value(v["hex"].clone()).map_err(serde::de::Error::custom)?;
+        } else if tx_value.get("hex").is_some() && tx_value.get("txid").is_some() {
+            let hex = serde_json::from_value(tx_value["hex"].clone())
+                .map_err(serde::de::Error::custom)?;
             let obj = GetTransactionResponse::Object {
                 hex,
-                height: -1,
-                confirmations: 0,
+                height: Some(-1),
+                confirmations: Some(0),
             };
             Ok(obj)
         } else {
             let raw = GetTransactionResponse::Raw(
-                serde_json::from_value(v.clone()).map_err(serde::de::Error::custom)?,
+                serde_json::from_value(tx_value.clone()).map_err(serde::de::Error::custom)?,
             );
             Ok(raw)
+        }
+    }
+}
+
+impl From<GetTransactionResponse> for zebra_rpc::methods::GetRawTransaction {
+    fn from(value: GetTransactionResponse) -> Self {
+        match value {
+            GetTransactionResponse::Raw(serialized_transaction) => {
+                zebra_rpc::methods::GetRawTransaction::Raw(serialized_transaction.0)
+            }
+            GetTransactionResponse::Object {
+                hex,
+                height,
+                confirmations,
+            } => zebra_rpc::methods::GetRawTransaction::Object(
+                zebra_rpc::methods::TransactionObject {
+                    hex: hex.0,
+                    height: height.and_then(|h| if h >= 0 { Some(h as u32) } else { None }),
+                    confirmations,
+                },
+            ),
         }
     }
 }
@@ -579,6 +628,20 @@ pub struct GetSubtreesResponse {
     /// The generic subtree root type is a hex-encoded Sapling or Orchard subtree root string.
     // #[serde(skip_serializing_if = "Vec::is_empty")]
     pub subtrees: Vec<SubtreeRpcData>,
+}
+
+impl From<GetSubtreesResponse> for zebra_rpc::methods::trees::GetSubtrees {
+    fn from(value: GetSubtreesResponse) -> Self {
+        zebra_rpc::methods::trees::GetSubtrees {
+            pool: value.pool,
+            start_index: value.start_index,
+            subtrees: value
+                .subtrees
+                .into_iter()
+                .map(|wrapped_subtree| wrapped_subtree.0)
+                .collect(),
+        }
+    }
 }
 
 /// Wrapper struct for a zebra Scrypt.
@@ -665,4 +728,17 @@ pub struct GetUtxosResponse {
 
     /// The block height, numeric.
     pub height: zebra_chain::block::Height,
+}
+
+impl From<GetUtxosResponse> for zebra_rpc::methods::GetAddressUtxos {
+    fn from(value: GetUtxosResponse) -> Self {
+        zebra_rpc::methods::GetAddressUtxos::from_parts(
+            value.address,
+            value.txid,
+            zebra_state::OutputIndex::from_index(value.output_index),
+            value.script.0,
+            value.satoshis,
+            value.height,
+        )
+    }
 }

--- a/zaino-state/Cargo.toml
+++ b/zaino-state/Cargo.toml
@@ -38,6 +38,8 @@ zaino-serve = { path = "../zaino-serve" }
 # Test Utilities
 zcash_local_net = { workspace = true, features = ["test_fixtures"] }
 
+# ZingoLib
+zingolib = { workspace = true }
 
 [build-dependencies]
 whoami = { workspace = true }

--- a/zaino-state/src/config.rs
+++ b/zaino-state/src/config.rs
@@ -41,3 +41,41 @@ impl StateServiceConfig {
         }
     }
 }
+
+/// Holds config data for [`FetchService`].
+#[derive(Debug, Clone)]
+pub struct FetchServiceConfig {
+    /// Validator JsonRPC address.
+    pub validator_rpc_address: std::net::SocketAddr,
+    /// Validator JsonRPC user.
+    pub validator_rpc_user: String,
+    /// Validator JsonRPC password.
+    pub validator_rpc_password: String,
+    /// StateService RPC timeout
+    pub service_timeout: u32,
+    /// StateService RPC max channel size.
+    pub service_channel_size: u32,
+    /// StateService network type.
+    pub network: zebra_chain::parameters::Network,
+}
+
+impl FetchServiceConfig {
+    /// Returns a new instance of [`FetchServiceConfig`].
+    pub fn new(
+        validator_rpc_address: std::net::SocketAddr,
+        validator_rpc_user: Option<String>,
+        validator_rpc_password: Option<String>,
+        service_timeout: Option<u32>,
+        service_channel_size: Option<u32>,
+        network: zebra_chain::parameters::Network,
+    ) -> Self {
+        FetchServiceConfig {
+            validator_rpc_address,
+            validator_rpc_user: validator_rpc_user.unwrap_or("xxxxxx".to_string()),
+            validator_rpc_password: validator_rpc_password.unwrap_or("xxxxxx".to_string()),
+            service_timeout: service_timeout.unwrap_or(30),
+            service_channel_size: service_channel_size.unwrap_or(32),
+            network,
+        }
+    }
+}

--- a/zaino-state/src/error.rs
+++ b/zaino-state/src/error.rs
@@ -39,3 +39,43 @@ pub enum StateServiceError {
     #[error("Generic error: {0}")]
     Generic(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
+
+/// Errors related to the `StateService`.
+#[derive(Debug, thiserror::Error)]
+pub enum FetchServiceError {
+    /// Custom Errors. *Remove before production.
+    #[error("Custom error: {0}")]
+    Custom(String),
+
+    /// Error from a Tokio JoinHandle.
+    #[error("Join error: {0}")]
+    JoinError(#[from] tokio::task::JoinError),
+
+    /// Error from JsonRpcConnector.
+    #[error("JsonRpcConnector error: {0}")]
+    JsonRpcConnectorError(#[from] zaino_fetch::jsonrpc::error::JsonRpcConnectorError),
+
+    /// RPC error in compatibility with zcashd.
+    #[error("RPC error: {0:?}")]
+    RpcError(#[from] zaino_fetch::jsonrpc::connector::RpcError),
+
+    /// Tonic gRPC error.
+    #[error("Tonic status error: {0}")]
+    TonicStatusError(#[from] tonic::Status),
+
+    /// Serialization error.
+    #[error("Serialization error: {0}")]
+    SerializationError(#[from] zebra_chain::serialization::SerializationError),
+
+    /// Integer conversion error.
+    #[error("Integer conversion error: {0}")]
+    TryFromIntError(#[from] std::num::TryFromIntError),
+
+    /// std::io::Error
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    /// A generic boxed error.
+    #[error("Generic error: {0}")]
+    Generic(#[from] Box<dyn std::error::Error + Send + Sync>),
+}

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -154,12 +154,17 @@ impl Indexer for FetchService {
         &self,
         address_strings: AddressStrings,
     ) -> Result<AddressBalance, Self::Error> {
-        // Ok(self
-        //     .fetcher
-        //     .get_address_balance(address_strings.addresses)
-        //     .await?
-        //     .into())
-        todo!()
+        Ok(self
+            .fetcher
+            .get_address_balance(address_strings.valid_address_strings().map_err(|code| {
+                FetchServiceError::RpcError(zaino_fetch::jsonrpc::connector::RpcError {
+                    code: code as i32 as i64,
+                    message: "Invalid address provided".to_string(),
+                    data: None,
+                })
+            })?)
+            .await?
+            .into())
     }
 
     /// Sends the raw bytes of a signed transaction to the local node's mempool, if the transaction is valid.
@@ -222,7 +227,7 @@ impl Indexer for FetchService {
             .fetcher
             .get_block(hash_or_height, verbosity)
             .await?
-            .into())
+            .try_into()?)
     }
 
     /// Returns all transaction ids in the memory pool, as a JSON array.

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -1,0 +1,377 @@
+//! Zcash chain fetch and tx submission service backed by zcashds JsonRPC service.
+
+use crate::{
+    config::FetchServiceConfig,
+    error::FetchServiceError,
+    get_build_info,
+    indexer::Indexer,
+    status::{AtomicStatus, StatusType},
+    ServiceMetadata,
+};
+use tonic::async_trait;
+use zaino_fetch::jsonrpc::connector::{test_node_and_return_uri, JsonRpcConnector};
+use zebra_chain::subtree::NoteCommitmentSubtreeIndex;
+use zebra_rpc::methods::{
+    trees::{GetSubtrees, GetTreestate},
+    AddressBalance, AddressStrings, GetAddressTxIdsRequest, GetAddressUtxos, GetBlock,
+    GetBlockChainInfo, GetInfo, GetRawTransaction, SentTransactionHash,
+};
+
+/// Chain fetch service backed by Zcashds JsonRPC service.
+#[derive(Debug)]
+pub struct FetchService {
+    /// JsonRPC Client.
+    fetcher: JsonRpcConnector,
+    // TODO: Add Internal Non-Finalised State
+    /// Sync task handle.
+    // sync_task_handle: tokio::task::JoinHandle<()>,
+    /// Service metadata.
+    data: ServiceMetadata,
+    /// StateService config data.
+    config: FetchServiceConfig,
+    /// Thread-safe status indicator.
+    status: AtomicStatus,
+}
+
+impl FetchService {
+    /// Initializes a new StateService instance and starts sync process.
+    pub async fn spawn(config: FetchServiceConfig) -> Result<Self, FetchServiceError> {
+        let rpc_uri = test_node_and_return_uri(
+            &config.validator_rpc_address.port(),
+            Some(config.validator_rpc_user.clone()),
+            Some(config.validator_rpc_password.clone()),
+        )
+        .await?;
+
+        let fetcher = JsonRpcConnector::new(
+            rpc_uri,
+            Some(config.validator_rpc_user.clone()),
+            Some(config.validator_rpc_password.clone()),
+        )
+        .await?;
+
+        let zebra_build_data = fetcher.get_info().await?;
+
+        let data = ServiceMetadata {
+            build_info: get_build_info(),
+            network: config.network.clone(),
+            zebra_build: zebra_build_data.build,
+            zebra_subversion: zebra_build_data.subversion,
+        };
+
+        let state_service = Self {
+            fetcher,
+            data,
+            config,
+            status: AtomicStatus::new(StatusType::Spawning.into()),
+        };
+
+        state_service.status.store(StatusType::Syncing.into());
+
+        // TODO: Wait for Non-Finalised state to sync or for mempool to come online.
+
+        state_service.status.store(StatusType::Ready.into());
+
+        Ok(state_service)
+    }
+
+    /// Fetches the current status
+    pub fn status(&self) -> StatusType {
+        self.status.load().into()
+    }
+
+    /// Shuts down the StateService.
+    pub fn close(&mut self) {
+        // self.sync_task_handle.abort();
+    }
+}
+
+impl Drop for FetchService {
+    fn drop(&mut self) {
+        self.close()
+    }
+}
+
+#[async_trait]
+impl Indexer for FetchService {
+    type Error = FetchServiceError;
+
+    /// Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
+    ///
+    /// zcashd reference: [`getinfo`](https://zcash.github.io/rpc/getinfo.html)
+    /// method: post
+    /// tags: control
+    ///
+    /// # Notes
+    ///
+    /// [The zcashd reference](https://zcash.github.io/rpc/getinfo.html) might not show some fields
+    /// in Zebra's [`GetInfo`]. Zebra uses the field names and formats from the
+    /// [zcashd code](https://github.com/zcash/zcash/blob/v4.6.0-1/src/rpc/misc.cpp#L86-L87).
+    ///
+    /// Some fields from the zcashd reference are missing from Zebra's [`GetInfo`]. It only contains the fields
+    /// [required for lightwalletd support.](https://github.com/zcash/lightwalletd/blob/v0.4.9/common/common.go#L91-L95)
+    async fn get_info(&self) -> Result<GetInfo, Self::Error> {
+        Ok(self.fetcher.get_info().await?.into())
+    }
+
+    /// Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
+    ///
+    /// zcashd reference: [`getblockchaininfo`](https://zcash.github.io/rpc/getblockchaininfo.html)
+    /// method: post
+    /// tags: blockchain
+    ///
+    /// # Notes
+    ///
+    /// Some fields from the zcashd reference are missing from Zebra's [`GetBlockChainInfo`]. It only contains the fields
+    /// [required for lightwalletd support.](https://github.com/zcash/lightwalletd/blob/v0.4.9/common/common.go#L72-L89)
+    async fn get_blockchain_info(&self) -> Result<GetBlockChainInfo, Self::Error> {
+        Ok(self.fetcher.get_blockchain_info().await?.into())
+    }
+
+    /// Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
+    ///
+    /// zcashd reference: [`getaddressbalance`](https://zcash.github.io/rpc/getaddressbalance.html)
+    /// method: post
+    /// tags: address
+    ///
+    /// # Parameters
+    ///
+    /// - `address_strings`: (object, example={"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}) A JSON map with a single entry
+    ///     - `addresses`: (array of strings) A list of base-58 encoded addresses.
+    ///
+    /// # Notes
+    ///
+    /// zcashd also accepts a single string parameter instead of an array of strings, but Zebra
+    /// doesn't because lightwalletd always calls this RPC with an array of addresses.
+    ///
+    /// zcashd also returns the total amount of Zatoshis received by the addresses, but Zebra
+    /// doesn't because lightwalletd doesn't use that information.
+    ///
+    /// The RPC documentation says that the returned object has a string `balance` field, but
+    /// zcashd actually [returns an
+    /// integer](https://github.com/zcash/lightwalletd/blob/bdaac63f3ee0dbef62bde04f6817a9f90d483b00/common/common.go#L128-L130).
+    async fn get_address_balance(
+        &self,
+        address_strings: AddressStrings,
+    ) -> Result<AddressBalance, Self::Error> {
+        // Ok(self
+        //     .fetcher
+        //     .get_address_balance(address_strings.addresses)
+        //     .await?
+        //     .into())
+        todo!()
+    }
+
+    /// Sends the raw bytes of a signed transaction to the local node's mempool, if the transaction is valid.
+    /// Returns the [`SentTransactionHash`] for the transaction, as a JSON string.
+    ///
+    /// zcashd reference: [`sendrawtransaction`](https://zcash.github.io/rpc/sendrawtransaction.html)
+    /// method: post
+    /// tags: transaction
+    ///
+    /// # Parameters
+    ///
+    /// - `raw_transaction_hex`: (string, required, example="signedhex") The hex-encoded raw transaction bytes.
+    ///
+    /// # Notes
+    ///
+    /// zcashd accepts an optional `allowhighfees` parameter. Zebra doesn't support this parameter,
+    /// because lightwalletd doesn't use it.
+    async fn send_raw_transaction(
+        &self,
+        raw_transaction_hex: String,
+    ) -> Result<SentTransactionHash, Self::Error> {
+        // Ok(self
+        //     .fetcher
+        //     .send_raw_transaction(raw_transaction_hex)
+        //     .await?
+        //     .into())
+        todo!()
+    }
+
+    /// Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
+    /// If the block is not in Zebra's state, returns
+    /// [error code `-8`.](https://github.com/zcash/zcash/issues/5758) if a height was
+    /// passed or -5 if a hash was passed.
+    ///
+    /// zcashd reference: [`getblock`](https://zcash.github.io/rpc/getblock.html)
+    /// method: post
+    /// tags: blockchain
+    ///
+    /// # Parameters
+    ///
+    /// - `hash_or_height`: (string, required, example="1") The hash or height for the block to be returned.
+    /// - `verbosity`: (number, optional, default=1, example=1) 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
+    ///
+    /// # Notes
+    ///
+    /// Zebra previously partially supported verbosity=1 by returning only the
+    /// fields required by lightwalletd ([`lightwalletd` only reads the `tx`
+    /// field of the result](https://github.com/zcash/lightwalletd/blob/dfac02093d85fb31fb9a8475b884dd6abca966c7/common/common.go#L152)).
+    /// That verbosity level was migrated to "3"; so while lightwalletd will
+    /// still work by using verbosity=1, it will sync faster if it is changed to
+    /// use verbosity=3.
+    ///
+    /// The undocumented `chainwork` field is not returned.
+    async fn get_block(
+        &self,
+        hash_or_height: String,
+        verbosity: Option<u8>,
+    ) -> Result<GetBlock, Self::Error> {
+        Ok(self
+            .fetcher
+            .get_block(hash_or_height, verbosity)
+            .await?
+            .into())
+    }
+
+    /// Returns all transaction ids in the memory pool, as a JSON array.
+    ///
+    /// zcashd reference: [`getrawmempool`](https://zcash.github.io/rpc/getrawmempool.html)
+    /// method: post
+    /// tags: blockchain
+    async fn get_raw_mempool(&self) -> Result<Vec<String>, Self::Error> {
+        // Ok(self.fetcher.get_raw_mempool().await?.into())
+        todo!()
+    }
+
+    /// Returns information about the given block's Sapling & Orchard tree state.
+    ///
+    /// zcashd reference: [`z_gettreestate`](https://zcash.github.io/rpc/z_gettreestate.html)
+    /// method: post
+    /// tags: blockchain
+    ///
+    /// # Parameters
+    ///
+    /// - `hash | height`: (string, required, example="00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5") The block hash or height.
+    ///
+    /// # Notes
+    ///
+    /// The zcashd doc reference above says that the parameter "`height` can be
+    /// negative where -1 is the last known valid block". On the other hand,
+    /// `lightwalletd` only uses positive heights, so Zebra does not support
+    /// negative heights.
+    async fn z_get_treestate(&self, hash_or_height: String) -> Result<GetTreestate, Self::Error> {
+        // Ok(self.fetcher.get_treestate(hash_or_height).await?.into())
+        todo!()
+    }
+
+    /// Returns information about a range of Sapling or Orchard subtrees.
+    ///
+    /// zcashd reference: [`z_getsubtreesbyindex`](https://zcash.github.io/rpc/z_getsubtreesbyindex.html) - TODO: fix link
+    /// method: post
+    /// tags: blockchain
+    ///
+    /// # Parameters
+    ///
+    /// - `pool`: (string, required) The pool from which subtrees should be returned. Either "sapling" or "orchard".
+    /// - `start_index`: (number, required) The index of the first 2^16-leaf subtree to return.
+    /// - `limit`: (number, optional) The maximum number of subtree values to return.
+    ///
+    /// # Notes
+    ///
+    /// While Zebra is doing its initial subtree index rebuild, subtrees will become available
+    /// starting at the chain tip. This RPC will return an empty list if the `start_index` subtree
+    /// exists, but has not been rebuilt yet. This matches `zcashd`'s behaviour when subtrees aren't
+    /// available yet. (But `zcashd` does its rebuild before syncing any blocks.)
+    async fn z_get_subtrees_by_index(
+        &self,
+        pool: String,
+        start_index: NoteCommitmentSubtreeIndex,
+        limit: Option<NoteCommitmentSubtreeIndex>,
+    ) -> Result<GetSubtrees, Self::Error> {
+        // Ok(self
+        //     .fetcher
+        //     .get_subtrees_by_index(pool, start_index, limit)
+        //     .await?
+        //     .into())
+        todo!()
+    }
+
+    /// Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
+    ///
+    /// zcashd reference: [`getrawtransaction`](https://zcash.github.io/rpc/getrawtransaction.html)
+    /// method: post
+    /// tags: transaction
+    ///
+    /// # Parameters
+    ///
+    /// - `txid`: (string, required, example="mytxid") The transaction ID of the transaction to be returned.
+    /// - `verbose`: (number, optional, default=0, example=1) If 0, return a string of hex-encoded data, otherwise return a JSON object.
+    ///
+    /// # Notes
+    ///
+    /// We don't currently support the `blockhash` parameter since lightwalletd does not
+    /// use it.
+    ///
+    /// In verbose mode, we only expose the `hex` and `height` fields since
+    /// lightwalletd uses only those:
+    /// <https://github.com/zcash/lightwalletd/blob/631bb16404e3d8b045e74a7c5489db626790b2f6/common/common.go#L119>
+    async fn get_raw_transaction(
+        &self,
+        txid_hex: String,
+        verbose: Option<u8>,
+    ) -> Result<GetRawTransaction, Self::Error> {
+        // Ok(self
+        //     .fetcher
+        //     .get_raw_transaction(txid_hex, verbose)
+        //     .await?
+        //     .into())
+        todo!()
+    }
+
+    /// Returns the transaction ids made by the provided transparent addresses.
+    ///
+    /// zcashd reference: [`getaddresstxids`](https://zcash.github.io/rpc/getaddresstxids.html)
+    /// method: post
+    /// tags: address
+    ///
+    /// # Parameters
+    ///
+    /// - `request`: (object, required, example={\"addresses\": [\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"], \"start\": 1000, \"end\": 2000}) A struct with the following named fields:
+    ///     - `addresses`: (json array of string, required) The addresses to get transactions from.
+    ///     - `start`: (numeric, required) The lower height to start looking for transactions (inclusive).
+    ///     - `end`: (numeric, required) The top height to stop looking for transactions (inclusive).
+    ///
+    /// # Notes
+    ///
+    /// Only the multi-argument format is used by lightwalletd and this is what we currently support:
+    /// <https://github.com/zcash/lightwalletd/blob/631bb16404e3d8b045e74a7c5489db626790b2f6/common/common.go#L97-L102>
+    async fn get_address_tx_ids(
+        &self,
+        request: GetAddressTxIdsRequest,
+    ) -> Result<Vec<String>, Self::Error> {
+        // Ok(self
+        //     .fetcher
+        //     .get_address_txids(request.addresses, request.start, request.end)
+        //     .await?
+        //     .into())
+        todo!()
+    }
+
+    /// Returns all unspent outputs for a list of addresses.
+    ///
+    /// zcashd reference: [`getaddressutxos`](https://zcash.github.io/rpc/getaddressutxos.html)
+    /// method: post
+    /// tags: address
+    ///
+    /// # Parameters
+    ///
+    /// - `addresses`: (array, required, example={\"addresses\": [\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"]}) The addresses to get outputs from.
+    ///
+    /// # Notes
+    ///
+    /// lightwalletd always uses the multi-address request, without chaininfo:
+    /// <https://github.com/zcash/lightwalletd/blob/master/frontend/service.go#L402>
+    async fn get_address_utxos(
+        &self,
+        address_strings: AddressStrings,
+    ) -> Result<Vec<GetAddressUtxos>, Self::Error> {
+        // Ok(self
+        //     .fetcher
+        //     .get_address_utxos(address_strings.addresses)
+        //     .await?
+        //     .into())
+        todo!()
+    }
+}

--- a/zaino-state/src/lib.rs
+++ b/zaino-state/src/lib.rs
@@ -7,6 +7,7 @@ use zebra_chain::parameters::Network;
 
 pub mod config;
 pub mod error;
+pub mod fetch;
 pub mod indexer;
 pub mod state;
 pub mod status;

--- a/zaino-state/src/state.rs
+++ b/zaino-state/src/state.rs
@@ -1,4 +1,4 @@
-//! Holds Wrapper functionality for Zebra's `ReadStateService`.
+//! Zcash chain fetch and tx submission service backed by Zebras [`ReadStateService`].
 
 use chrono::Utc;
 use hex::ToHex;


### PR DESCRIPTION
This PR is the initial work to add the FetchService to zaino-state. (FetchService is the jsonRPC backed (zaino-fetch::connector::JsonRpcConnector) zcash chain fetch service. 

- Add FetchService Struct.
- Implements Indexer trait for FetchService.
- Updates zebra dep and fixes resulting errors.
- Adds tests for Fetchservice.

 - Closes https://github.com/zingolabs/zaino/issues/122,  Work towards https://github.com/zingolabs/zaino/issues/123

NOTE: This work is being completed now, while zebra's regtest mode is being tested, as it can be tested using zcashd, but StateService requires a reliable Zebrad regtest mode for testing.


Built atop #139, #140, #142. As uses functionality in those PRs.