### PR TITLE
Add lightwallet indexer trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5219,6 +5219,7 @@ dependencies = [
  "http",
  "indexmap 2.7.0",
  "jsonrpc-core",
+ "lazy-regex",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",

--- a/zaino-fetch/src/jsonrpc/connector.rs
+++ b/zaino-fetch/src/jsonrpc/connector.rs
@@ -9,7 +9,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{
     fmt,
-    sync::atomic::{AtomicI32, Ordering},
+    sync::{
+        atomic::{AtomicI32, Ordering},
+        Arc,
+    },
 };
 
 use crate::jsonrpc::{
@@ -71,10 +74,10 @@ impl fmt::Display for RpcError {
 impl std::error::Error for RpcError {}
 
 /// JsonRPC Client config data.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct JsonRpcConnector {
     url: Url,
-    id_counter: AtomicI32,
+    id_counter: Arc<AtomicI32>,
     user: Option<String>,
     password: Option<String>,
 }
@@ -89,7 +92,7 @@ impl JsonRpcConnector {
         let url = reqwest::Url::parse(&uri.to_string())?;
         Ok(Self {
             url,
-            id_counter: AtomicI32::new(0),
+            id_counter: Arc::new(AtomicI32::new(0)),
             user,
             password,
         })

--- a/zaino-state/Cargo.toml
+++ b/zaino-state/Cargo.toml
@@ -30,6 +30,7 @@ tokio-stream = { workspace = true }
 futures = { workspace = true }
 tonic = { workspace = true }
 http = { workspace = true }
+lazy-regex = { workspace = true }
 
 [dev-dependencies]
 zaino-testutils = { path = "../zaino-testutils" }

--- a/zaino-state/src/error.rs
+++ b/zaino-state/src/error.rs
@@ -101,6 +101,18 @@ pub enum FetchServiceError {
     #[error("Integer conversion error: {0}")]
     TryFromIntError(#[from] std::num::TryFromIntError),
 
+    /// UTF-8 conversion error.
+    #[error("UTF-8 conversion error: {0}")]
+    Utf8Error(#[from] std::str::Utf8Error),
+
+    /// Integer parsing error.
+    #[error("Integer parsing error: {0}")]
+    ParseIntError(#[from] std::num::ParseIntError),
+
+    /// Chain parse error.
+    #[error("Chain parse error: {0}")]
+    ChainParseError(#[from] zaino_fetch::chain::error::ParseError),
+
     /// std::io::Error
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
@@ -129,6 +141,15 @@ impl From<FetchServiceError> for tonic::Status {
             }
             FetchServiceError::TryFromIntError(err) => {
                 tonic::Status::internal(format!("Integer conversion error: {}", err))
+            }
+            FetchServiceError::Utf8Error(err) => {
+                tonic::Status::internal(format!("UTF-8 conversion error: {}", err))
+            }
+            FetchServiceError::ParseIntError(err) => {
+                tonic::Status::internal(format!("Integer parsing error: {}", err))
+            }
+            FetchServiceError::ChainParseError(err) => {
+                tonic::Status::internal(format!("Chain parse error: {}", err))
             }
             FetchServiceError::IoError(err) => {
                 tonic::Status::internal(format!("IO error: {}", err))

--- a/zaino-state/src/error.rs
+++ b/zaino-state/src/error.rs
@@ -40,6 +40,36 @@ pub enum StateServiceError {
     Generic(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
+impl From<StateServiceError> for tonic::Status {
+    fn from(error: StateServiceError) -> Self {
+        match error {
+            StateServiceError::Custom(message) => tonic::Status::internal(message),
+            StateServiceError::JoinError(err) => {
+                tonic::Status::internal(format!("Join error: {}", err))
+            }
+            StateServiceError::JsonRpcConnectorError(err) => {
+                tonic::Status::internal(format!("JsonRpcConnector error: {}", err))
+            }
+            StateServiceError::RpcError(err) => {
+                tonic::Status::internal(format!("RPC error: {:?}", err))
+            }
+            StateServiceError::TonicStatusError(err) => err,
+            StateServiceError::SerializationError(err) => {
+                tonic::Status::internal(format!("Serialization error: {}", err))
+            }
+            StateServiceError::TryFromIntError(err) => {
+                tonic::Status::internal(format!("Integer conversion error: {}", err))
+            }
+            StateServiceError::IoError(err) => {
+                tonic::Status::internal(format!("IO error: {}", err))
+            }
+            StateServiceError::Generic(err) => {
+                tonic::Status::internal(format!("Generic error: {}", err))
+            }
+        }
+    }
+}
+
 /// Errors related to the `StateService`.
 #[derive(Debug, thiserror::Error)]
 pub enum FetchServiceError {
@@ -78,4 +108,34 @@ pub enum FetchServiceError {
     /// A generic boxed error.
     #[error("Generic error: {0}")]
     Generic(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl From<FetchServiceError> for tonic::Status {
+    fn from(error: FetchServiceError) -> Self {
+        match error {
+            FetchServiceError::Custom(message) => tonic::Status::internal(message),
+            FetchServiceError::JoinError(err) => {
+                tonic::Status::internal(format!("Join error: {}", err))
+            }
+            FetchServiceError::JsonRpcConnectorError(err) => {
+                tonic::Status::internal(format!("JsonRpcConnector error: {}", err))
+            }
+            FetchServiceError::RpcError(err) => {
+                tonic::Status::internal(format!("RPC error: {:?}", err))
+            }
+            FetchServiceError::TonicStatusError(err) => err,
+            FetchServiceError::SerializationError(err) => {
+                tonic::Status::internal(format!("Serialization error: {}", err))
+            }
+            FetchServiceError::TryFromIntError(err) => {
+                tonic::Status::internal(format!("Integer conversion error: {}", err))
+            }
+            FetchServiceError::IoError(err) => {
+                tonic::Status::internal(format!("IO error: {}", err))
+            }
+            FetchServiceError::Generic(err) => {
+                tonic::Status::internal(format!("Generic error: {}", err))
+            }
+        }
+    }
 }

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -1045,7 +1045,10 @@ impl LightWalletIndexer for FetchService {
         &self,
         _request: Exclude,
     ) -> Result<CompactTransactionStream, Self::Error> {
-        unimplemented!()
+        Err(FetchServiceError::TonicStatusError(tonic::Status::new(
+            tonic::Code::Unimplemented,
+            "get_mempool_tx is not implemented in Zaino.",
+        )))
     }
 
     /// Return a stream of current Mempool transactions. This will keep the output stream open while
@@ -1053,7 +1056,10 @@ impl LightWalletIndexer for FetchService {
     ///
     /// NOTE: To be implemented with the mempool updgrade.
     async fn get_mempool_stream(&self) -> Result<RawTransactionStream, Self::Error> {
-        unimplemented!()
+        Err(FetchServiceError::TonicStatusError(tonic::Status::new(
+            tonic::Code::Unimplemented,
+            "get_mempool_stream is not implemented in Zaino.",
+        )))
     }
 
     /// GetTreeState returns the note commitment tree state corresponding to the given block.
@@ -1491,7 +1497,10 @@ impl LightWalletIndexer for FetchService {
     ///
     /// NOTE: Currently unimplemented in Zaino.
     async fn ping(&self, _request: Duration) -> Result<PingResponse, Self::Error> {
-        unimplemented!()
+        Err(FetchServiceError::TonicStatusError(tonic::Status::new(
+            tonic::Code::Unimplemented,
+            "ping is not implemented in Zaino.",
+        )))
     }
 }
 

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -12,25 +12,29 @@ use crate::{
     },
     ServiceMetadata,
 };
+use futures::StreamExt;
+use hex::FromHex;
+use tokio::time::timeout;
 use tonic::async_trait;
 use zaino_fetch::jsonrpc::connector::{test_node_and_return_uri, JsonRpcConnector};
 use zaino_proto::proto::{
-    compact_formats::CompactBlock,
+    compact_formats::{ChainMetadata, CompactBlock, CompactOrchardAction, CompactTx},
     service::{
-        AddressList, Balance, BlockId, BlockRange, ChainSpec, Duration, Exclude,
-        GetAddressUtxosArg, GetAddressUtxosReplyList, GetSubtreeRootsArg, LightdInfo, PingResponse,
-        RawTransaction, SendResponse, TransparentAddressBlockFilter, TreeState, TxFilter,
+        AddressList, Balance, BlockId, BlockRange, Duration, Exclude, GetAddressUtxosArg,
+        GetAddressUtxosReply, GetAddressUtxosReplyList, GetSubtreeRootsArg, LightdInfo,
+        PingResponse, RawTransaction, SendResponse, ShieldedProtocol, SubtreeRoot,
+        TransparentAddressBlockFilter, TreeState, TxFilter,
     },
 };
 use zebra_chain::subtree::NoteCommitmentSubtreeIndex;
 use zebra_rpc::methods::{
     trees::{GetSubtrees, GetTreestate},
     AddressBalance, AddressStrings, GetAddressTxIdsRequest, GetAddressUtxos, GetBlock,
-    GetBlockChainInfo, GetInfo, GetRawTransaction, SentTransactionHash,
+    GetBlockChainInfo, GetBlockTransaction, GetInfo, GetRawTransaction, SentTransactionHash,
 };
 
 /// Chain fetch service backed by Zcashds JsonRPC service.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FetchService {
     /// JsonRPC Client.
     fetcher: JsonRpcConnector,
@@ -40,7 +44,7 @@ pub struct FetchService {
     /// Service metadata.
     data: ServiceMetadata,
     /// StateService config data.
-    _config: FetchServiceConfig,
+    config: FetchServiceConfig,
     /// Thread-safe status indicator.
     status: AtomicStatus,
 }
@@ -74,7 +78,7 @@ impl FetchService {
         let state_service = Self {
             fetcher,
             data,
-            _config: config,
+            config,
             status: AtomicStatus::new(StatusType::Spawning.into()),
         };
 
@@ -411,44 +415,367 @@ impl LightWalletIndexer for FetchService {
     type Error = FetchServiceError;
 
     /// Return the height of the tip of the best chain
-    async fn get_latest_block(&self, request: ChainSpec) -> Result<BlockId, Self::Error> {
-        unimplemented!()
+    async fn get_latest_block(&self) -> Result<BlockId, Self::Error> {
+        let blockchain_info = self.get_blockchain_info().await?;
+
+        Ok(BlockId {
+            height: blockchain_info.blocks().0 as u64,
+            hash: blockchain_info
+                .best_block_hash()
+                .bytes_in_display_order()
+                .to_vec(),
+        })
     }
 
     /// Return the compact block corresponding to the given block identifier
+    ///
+    /// NOTE: This implementation is slow due to the absense on an internal CompactBlock cache.
     async fn get_block(&self, request: BlockId) -> Result<CompactBlock, Self::Error> {
-        unimplemented!()
+        let height: u32 = match request.height.try_into() {
+            Ok(height) => height,
+            Err(_) => {
+                return Err(FetchServiceError::TonicStatusError(
+                    tonic::Status::invalid_argument(
+                        "Error: Height out of range. Failed to convert to u32.",
+                    ),
+                ));
+            }
+        };
+        match self.get_compact_block(&height).await {
+            Ok(block) => Ok(block),
+            Err(e) => {
+                let chain_height = self.get_blockchain_info().await?.blocks().0;
+                if height >= chain_height {
+                    Err(FetchServiceError::TonicStatusError(tonic::Status::out_of_range(
+                            format!(
+                                "Error: Height out of range [{}]. Height requested is greater than the best chain tip [{}].",
+                                height, chain_height,
+                            )
+                        )))
+                } else {
+                    // TODO: Hide server error from clients before release. Currently useful for dev purposes.
+                    Err(FetchServiceError::TonicStatusError(tonic::Status::unknown(
+                        format!(
+                            "Error: Failed to retrieve block from node. Server Error: {}",
+                            e,
+                        ),
+                    )))
+                }
+            }
+        }
     }
 
     /// Same as GetBlock except actions contain only nullifiers
+    ///
+    /// NOTE: This implementation is slow due to the absense on an internal CompactBlock cache.
     async fn get_block_nullifiers(&self, request: BlockId) -> Result<CompactBlock, Self::Error> {
-        unimplemented!()
+        let height: u32 = match request.height.try_into() {
+            Ok(height) => height,
+            Err(_) => {
+                return Err(FetchServiceError::TonicStatusError(
+                    tonic::Status::invalid_argument(
+                        "Error: Height out of range. Failed to convert to u32.",
+                    ),
+                ));
+            }
+        };
+        match self.get_nullifiers(&height).await {
+            Ok(block) => Ok(block),
+            Err(e) => {
+                let chain_height = self.get_blockchain_info().await?.blocks().0;
+                if height >= chain_height {
+                    Err(FetchServiceError::TonicStatusError(tonic::Status::out_of_range(
+                            format!(
+                                "Error: Height out of range [{}]. Height requested is greater than the best chain tip [{}].",
+                                height, chain_height,
+                            )
+                        )))
+                } else {
+                    // TODO: Hide server error from clients before release. Currently useful for dev purposes.
+                    Err(FetchServiceError::TonicStatusError(tonic::Status::unknown(
+                        format!(
+                            "Error: Failed to retrieve block from node. Server Error: {}",
+                            e,
+                        ),
+                    )))
+                }
+            }
+        }
     }
 
     /// Return a list of consecutive compact blocks
+    ///
+    /// NOTE: This implementation is slow due to the absense on an internal CompactBlock cache.
     async fn get_block_range(
         &self,
         request: BlockRange,
     ) -> Result<CompactBlockStream, Self::Error> {
-        unimplemented!()
+        let mut start: u32 = match request.start {
+            Some(block_id) => match block_id.height.try_into() {
+                Ok(height) => height,
+                Err(_) => {
+                    return Err(FetchServiceError::TonicStatusError(
+                        tonic::Status::invalid_argument(
+                            "Error: Start height out of range. Failed to convert to u32.",
+                        ),
+                    ));
+                }
+            },
+            None => {
+                return Err(FetchServiceError::TonicStatusError(
+                    tonic::Status::invalid_argument("Error: No start height given."),
+                ));
+            }
+        };
+        let mut end: u32 = match request.end {
+            Some(block_id) => match block_id.height.try_into() {
+                Ok(height) => height,
+                Err(_) => {
+                    return Err(FetchServiceError::TonicStatusError(
+                        tonic::Status::invalid_argument(
+                            "Error: End height out of range. Failed to convert to u32.",
+                        ),
+                    ));
+                }
+            },
+            None => {
+                return Err(FetchServiceError::TonicStatusError(
+                    tonic::Status::invalid_argument("Error: No start height given."),
+                ));
+            }
+        };
+        let rev_order = if start > end {
+            (start, end) = (end, start);
+            true
+        } else {
+            false
+        };
+        let chain_height = self.get_blockchain_info().await?.blocks().0;
+        let fetch_service_clone = self.clone();
+        let service_timeout = self.config.service_timeout;
+        let (channel_tx, channel_rx) =
+            tokio::sync::mpsc::channel(self.config.service_channel_size as usize);
+        tokio::spawn(async move {
+            let timeout = timeout(std::time::Duration::from_secs(service_timeout as u64), async {
+                    for height in start..=end {
+                        let height = if rev_order {
+                            end - (height - start)
+                        } else {
+                            height
+                        };
+                        match fetch_service_clone.get_compact_block(
+                            &height,
+                        ).await {
+                            Ok(block) => {
+                                if channel_tx.send(Ok(block)).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                if height >= chain_height {
+                                    match channel_tx
+                                        .send(Err(tonic::Status::out_of_range(format!(
+                                            "Error: Height out of range [{}]. Height requested is greater than the best chain tip [{}].",
+                                            height, chain_height,
+                                        ))))
+                                        .await
+
+                                    {
+                                        Ok(_) => break,
+                                        Err(e) => {
+                                            eprintln!("Error: Channel closed unexpectedly: {}", e);
+                                            break;
+                                        }
+                                    }
+                                } else {
+                                    // TODO: Hide server error from clients before release. Currently useful for dev purposes.
+                                    if channel_tx
+                                        .send(Err(tonic::Status::unknown(e.to_string())))
+                                        .await
+                                        .is_err()
+                                    {
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                })
+                .await;
+            match timeout {
+                Ok(_) => {}
+                Err(_) => {
+                    channel_tx
+                        .send(Err(tonic::Status::deadline_exceeded(
+                            "Error: get_block_range gRPC request timed out.",
+                        )))
+                        .await
+                        .ok();
+                }
+            }
+        });
+        Ok(CompactBlockStream::new(channel_rx))
     }
 
     /// Same as GetBlockRange except actions contain only nullifiers
+    ///
+    /// NOTE: This implementation is slow due to the absense on an internal CompactBlock cache.
     async fn get_block_range_nullifiers(
         &self,
         request: BlockRange,
     ) -> Result<CompactBlockStream, Self::Error> {
-        unimplemented!()
+        let mut start: u32 = match request.start {
+            Some(block_id) => match block_id.height.try_into() {
+                Ok(height) => height,
+                Err(_) => {
+                    return Err(FetchServiceError::TonicStatusError(
+                        tonic::Status::invalid_argument(
+                            "Error: Start height out of range. Failed to convert to u32.",
+                        ),
+                    ));
+                }
+            },
+            None => {
+                return Err(FetchServiceError::TonicStatusError(
+                    tonic::Status::invalid_argument("Error: No start height given."),
+                ));
+            }
+        };
+        let mut end: u32 = match request.end {
+            Some(block_id) => match block_id.height.try_into() {
+                Ok(height) => height,
+                Err(_) => {
+                    return Err(FetchServiceError::TonicStatusError(
+                        tonic::Status::invalid_argument(
+                            "Error: End height out of range. Failed to convert to u32.",
+                        ),
+                    ));
+                }
+            },
+            None => {
+                return Err(FetchServiceError::TonicStatusError(
+                    tonic::Status::invalid_argument("Error: No start height given."),
+                ));
+            }
+        };
+        let rev_order = if start > end {
+            (start, end) = (end, start);
+            true
+        } else {
+            false
+        };
+        let chain_height = self.get_blockchain_info().await?.blocks().0;
+        let fetch_service_clone = self.clone();
+        let service_timeout = self.config.service_timeout;
+        let (channel_tx, channel_rx) =
+            tokio::sync::mpsc::channel(self.config.service_channel_size as usize);
+        tokio::spawn(async move {
+            let timeout = timeout(std::time::Duration::from_secs(service_timeout as u64), async {
+                    for height in start..=end {
+                        let height = if rev_order {
+                            end - (height - start)
+                        } else {
+                            height
+                        };
+                        match fetch_service_clone.get_nullifiers(
+                            &height,
+                        ).await {
+                            Ok(block) => {
+                                if channel_tx.send(Ok(block)).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                if height >= chain_height {
+                                    match channel_tx
+                                        .send(Err(tonic::Status::out_of_range(format!(
+                                            "Error: Height out of range [{}]. Height requested is greater than the best chain tip [{}].",
+                                            height, chain_height,
+                                        ))))
+                                        .await
+
+                                    {
+                                        Ok(_) => break,
+                                        Err(e) => {
+                                            eprintln!("Error: Channel closed unexpectedly: {}", e);
+                                            break;
+                                        }
+                                    }
+                                } else {
+                                    // TODO: Hide server error from clients before release. Currently useful for dev purposes.
+                                    if channel_tx
+                                        .send(Err(tonic::Status::unknown(e.to_string())))
+                                        .await
+                                        .is_err()
+                                    {
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                })
+                .await;
+            match timeout {
+                Ok(_) => {}
+                Err(_) => {
+                    channel_tx
+                        .send(Err(tonic::Status::deadline_exceeded(
+                            "Error: get_block_range gRPC request timed out.",
+                        )))
+                        .await
+                        .ok();
+                }
+            }
+        });
+        Ok(CompactBlockStream::new(channel_rx))
     }
 
     /// Return the requested full (not compact) transaction (as from zcashd)
     async fn get_transaction(&self, request: TxFilter) -> Result<RawTransaction, Self::Error> {
-        unimplemented!()
+        let hash = request.hash;
+        if hash.len() == 32 {
+            let reversed_hash = hash.iter().rev().copied().collect::<Vec<u8>>();
+            let hash_hex = hex::encode(reversed_hash);
+            let tx = self.get_raw_transaction(hash_hex, Some(1)).await?;
+
+            let (hex, height) = if let GetRawTransaction::Object(tx_object) = tx {
+                (tx_object.hex, tx_object.height)
+            } else {
+                return Err(FetchServiceError::TonicStatusError(
+                    tonic::Status::not_found("Error: Transaction not received"),
+                ));
+            };
+            let height: u64 = match height {
+                Some(h) => h.try_into().map_err(|_e| {
+                    tonic::Status::unknown(
+                        "Error: Invalid response from server - Height conversion failed",
+                    )
+                })?,
+                // Zebra returns None for mempool transactions, convert to -1.
+                None => u64::MAX,
+            };
+
+            Ok(RawTransaction {
+                data: hex.as_ref().to_vec(),
+                height,
+            })
+        } else {
+            Err(FetchServiceError::TonicStatusError(
+                tonic::Status::invalid_argument("Error: Transaction hash incorrect"),
+            ))
+        }
     }
 
     /// Submit the given transaction to the Zcash network
     async fn send_transaction(&self, request: RawTransaction) -> Result<SendResponse, Self::Error> {
-        unimplemented!()
+        let hex_tx = hex::encode(request.data);
+        let tx_output = self.send_raw_transaction(hex_tx).await?;
+
+        Ok(SendResponse {
+            error_code: 0,
+            error_message: tx_output.inner().to_string(),
+        })
     }
 
     /// Return the txids corresponding to the given t-address within the given block range
@@ -456,22 +783,251 @@ impl LightWalletIndexer for FetchService {
         &self,
         request: TransparentAddressBlockFilter,
     ) -> Result<RawTransactionStream, Self::Error> {
-        unimplemented!()
+        let chain_height = self.get_blockchain_info().await?.blocks().0;
+        let (start, end) =
+            match request.range {
+                Some(range) => match (range.start, range.end) {
+                    (Some(start), Some(end)) => {
+                        let start = match u32::try_from(start.height) {
+                            Ok(height) => height.min(chain_height),
+                            Err(_) => return Err(FetchServiceError::TonicStatusError(
+                                tonic::Status::invalid_argument(
+                                    "Error: Start height out of range. Failed to convert to u32.",
+                                ),
+                            )),
+                        };
+                        let end =
+                            match u32::try_from(end.height) {
+                                Ok(height) => height.min(chain_height),
+                                Err(_) => return Err(FetchServiceError::TonicStatusError(
+                                    tonic::Status::invalid_argument(
+                                        "Error: End height out of range. Failed to convert to u32.",
+                                    ),
+                                )),
+                            };
+                        if start > end {
+                            (end, start)
+                        } else {
+                            (start, end)
+                        }
+                    }
+                    _ => {
+                        return Err(FetchServiceError::TonicStatusError(
+                            tonic::Status::invalid_argument("Error: Incomplete block range given."),
+                        ))
+                    }
+                },
+                None => {
+                    return Err(FetchServiceError::TonicStatusError(
+                        tonic::Status::invalid_argument("Error: No block range given."),
+                    ))
+                }
+            };
+        let txids = self
+            .get_address_tx_ids(GetAddressTxIdsRequest::from_parts(
+                vec![request.address],
+                start,
+                end,
+            ))
+            .await?;
+        let fetch_service_clone = self.clone();
+        let service_timeout = self.config.service_timeout;
+        let (channel_tx, channel_rx) =
+            tokio::sync::mpsc::channel(self.config.service_channel_size as usize);
+        tokio::spawn(async move {
+            let timeout = timeout(std::time::Duration::from_secs(service_timeout as u64), async {
+                    for txid in txids {
+                        let transaction = fetch_service_clone.get_raw_transaction(txid, Some(1)).await;
+                        match transaction {
+                            Ok(GetRawTransaction::Object(transaction_obj)) => {
+                                let height: u64 = match transaction_obj.height {
+                                    Some(h) => h.try_into().map_err(|_e| {
+                                        tonic::Status::unknown(
+                                            "Error: Invalid response from server - Height conversion failed",
+                                        )
+                                    }).unwrap_or(u64::MAX),
+                                    None => u64::MAX,
+                                };
+                                if channel_tx
+                                    .send(Ok(RawTransaction {
+                                        data: transaction_obj.hex.as_ref().to_vec(),
+                                        height: height as u64,
+                                    }))
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
+                            Ok(GetRawTransaction::Raw(_)) => {
+                                if channel_tx
+                                    .send(Err(tonic::Status::unknown(
+                                    "Received raw transaction type, this should not be impossible.",
+                                    )))
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                // TODO: Hide server error from clients before release. Currently useful for dev purposes.
+                                if channel_tx
+                                    .send(Err(tonic::Status::unknown(e.to_string())))
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                })
+                .await;
+            match timeout {
+                Ok(_) => {}
+                Err(_) => {
+                    channel_tx
+                        .send(Err(tonic::Status::internal(
+                            "Error: get_taddress_txids gRPC request timed out",
+                        )))
+                        .await
+                        .ok();
+                }
+            }
+        });
+        Ok(RawTransactionStream::new(channel_rx))
     }
 
     /// Returns the total balance for a list of taddrs
     async fn get_taddress_balance(&self, request: AddressList) -> Result<Balance, Self::Error> {
-        unimplemented!()
+        let taddrs = AddressStrings::new_valid(request.addresses).map_err(|legacy_code| {
+            FetchServiceError::RpcError(
+                zaino_fetch::jsonrpc::connector::RpcError::new_from_legacycode(
+                    legacy_code,
+                    "Error in Validator.",
+                ),
+            )
+        })?;
+        let balance = self.z_get_address_balance(taddrs).await?;
+        let checked_balance: i64 = match i64::try_from(balance.balance) {
+            Ok(balance) => balance,
+            Err(_) => {
+                return Err(FetchServiceError::TonicStatusError(tonic::Status::unknown(
+                    "Error: Error converting balance from u64 to i64.",
+                )));
+            }
+        };
+        Ok(Balance {
+            value_zat: checked_balance,
+        })
     }
 
     /// Returns the total balance for a list of taddrs
-    ///
-    /// TODO: Update input type.
     async fn get_taddress_balance_stream(
         &self,
-        request: AddressStream,
+        mut request: AddressStream,
     ) -> Result<Balance, Self::Error> {
-        unimplemented!()
+        let fetch_service_clone = self.clone();
+        let service_timeout = self.config.service_timeout;
+        let (channel_tx, mut channel_rx) =
+            tokio::sync::mpsc::channel::<String>(self.config.service_channel_size as usize);
+        let fetcher_task_handle = tokio::spawn(async move {
+            let fetcher_timeout = timeout(
+                std::time::Duration::from_secs(service_timeout as u64),
+                async {
+                    let mut total_balance: u64 = 0;
+                    loop {
+                        match channel_rx.recv().await {
+                            Some(taddr) => {
+                                let taddrs = AddressStrings::new_valid(vec![taddr]).map_err(
+                                    |legacy_code| {
+                                        FetchServiceError::RpcError(
+                                            zaino_fetch::jsonrpc::connector::RpcError::new_from_legacycode(
+                                                legacy_code,
+                                                "Error in Validator.",
+                                            ),
+                                        )
+                                    },
+                                )?;
+                                let balance = fetch_service_clone
+                                        .z_get_address_balance(taddrs)
+                                        .await?;
+                                total_balance += balance.balance;
+                            }
+                            None => {
+                                return Ok(total_balance);
+                            }
+                        }
+                    }
+                },
+            )
+            .await;
+            match fetcher_timeout {
+                Ok(result) => result,
+                Err(_) => Err(tonic::Status::deadline_exceeded(
+                    "Error: get_taddress_balance_stream request timed out.",
+                )),
+            }
+        });
+        // NOTE: This timeout is so slow due to the blockcache not being implemented. This should be reduced to 30s once functionality is in place.
+        // TODO: Make [rpc_timout] a configurable system variable with [default = 30s] and [mempool_rpc_timout = 4*rpc_timeout]
+        let addr_recv_timeout = timeout(
+            std::time::Duration::from_secs(service_timeout as u64),
+            async {
+                while let Some(address_result) = request.next().await {
+                    // TODO: Hide server error from clients before release. Currently useful for dev purposes.
+                    let address = address_result.map_err(|e| {
+                        tonic::Status::unknown(format!("Failed to read from stream: {}", e))
+                    })?;
+                    if channel_tx.send(address.address).await.is_err() {
+                        // TODO: Hide server error from clients before release. Currently useful for dev purposes.
+                        return Err(tonic::Status::unknown(
+                            "Error: Failed to send address to balance task.",
+                        ));
+                    }
+                }
+                drop(channel_tx);
+                Ok::<(), tonic::Status>(())
+            },
+        )
+        .await;
+        match addr_recv_timeout {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                fetcher_task_handle.abort();
+                return Err(FetchServiceError::TonicStatusError(e));
+            }
+            Err(_) => {
+                fetcher_task_handle.abort();
+                return Err(FetchServiceError::TonicStatusError(
+                    tonic::Status::deadline_exceeded(
+                        "Error: get_taddress_balance_stream request timed out in address loop.",
+                    ),
+                ));
+            }
+        }
+        match fetcher_task_handle.await {
+            Ok(Ok(total_balance)) => {
+                let checked_balance: i64 = match i64::try_from(total_balance) {
+                    Ok(balance) => balance,
+                    Err(_) => {
+                        // TODO: Hide server error from clients before release. Currently useful for dev purposes.
+                        return Err(FetchServiceError::TonicStatusError(tonic::Status::unknown(
+                            "Error: Error converting balance from u64 to i64.",
+                        )));
+                    }
+                };
+                Ok(Balance {
+                    value_zat: checked_balance,
+                })
+            }
+            Ok(Err(e)) => Err(FetchServiceError::TonicStatusError(e)),
+            // TODO: Hide server error from clients before release. Currently useful for dev purposes.
+            Err(e) => Err(FetchServiceError::TonicStatusError(tonic::Status::unknown(
+                format!("Fetcher Task failed: {}", e),
+            ))),
+        }
     }
 
     /// Return the compact transactions currently in the mempool; the results
@@ -483,15 +1039,19 @@ impl LightWalletIndexer for FetchService {
     /// more bandwidth-efficient; if two or more transactions in the mempool
     /// match a shortened txid, they are all sent (none is excluded). Transactions
     /// in the exclude list that don't exist in the mempool are ignored.
+    ///
+    /// NOTE: To be implemented with the mempool updgrade.
     async fn get_mempool_tx(
         &self,
-        request: Exclude,
+        _request: Exclude,
     ) -> Result<CompactTransactionStream, Self::Error> {
         unimplemented!()
     }
 
     /// Return a stream of current Mempool transactions. This will keep the output stream open while
     /// there are mempool transactions. It will close the returned stream when a new block is mined.
+    ///
+    /// NOTE: To be implemented with the mempool updgrade.
     async fn get_mempool_stream(&self) -> Result<RawTransactionStream, Self::Error> {
         unimplemented!()
     }
@@ -501,12 +1061,84 @@ impl LightWalletIndexer for FetchService {
     /// values also (even though they can be obtained using GetBlock).
     /// The block can be specified by either height or hash.
     async fn get_tree_state(&self, request: BlockId) -> Result<TreeState, Self::Error> {
-        unimplemented!()
+        let chain_info = self.get_blockchain_info().await?;
+        let hash_or_height = if request.height != 0 {
+            match u32::try_from(request.height) {
+                Ok(height) => {
+                    if height > chain_info.blocks().0 {
+                        return Err(FetchServiceError::TonicStatusError(tonic::Status::out_of_range(
+                            format!(
+                                "Error: Height out of range [{}]. Height requested is greater than the best chain tip [{}].",
+                                height, chain_info.blocks().0,
+                            ))
+                        ));
+                    } else {
+                        height.to_string()
+                    }
+                }
+                Err(_) => {
+                    return Err(FetchServiceError::TonicStatusError(
+                        tonic::Status::invalid_argument(
+                            "Error: Height out of range. Failed to convert to u32.",
+                        ),
+                    ));
+                }
+            }
+        } else {
+            hex::encode(request.hash)
+        };
+        match self.z_get_treestate(hash_or_height).await {
+            Ok(state) => {
+                let (hash, height, time, sapling, orchard) = state.into_parts();
+                Ok(TreeState {
+                    network: chain_info.chain(),
+                    height: height.0 as u64,
+                    hash: hash.to_string(),
+                    time,
+                    sapling_tree: sapling.map(hex::encode).unwrap_or_default(),
+                    orchard_tree: orchard.map(hex::encode).unwrap_or_default(),
+                })
+            }
+            Err(e) => {
+                // TODO: Hide server error from clients before release. Currently useful for dev purposes.
+                Err(FetchServiceError::TonicStatusError(tonic::Status::unknown(
+                    format!(
+                        "Error: Failed to retrieve treestate from node. Server Error: {}",
+                        e,
+                    ),
+                )))
+            }
+        }
     }
 
     /// GetLatestTreeState returns the note commitment tree state corresponding to the chain tip.
     async fn get_latest_tree_state(&self) -> Result<TreeState, Self::Error> {
-        unimplemented!()
+        let chain_info = self.get_blockchain_info().await?;
+        match self
+            .z_get_treestate(chain_info.blocks().0.to_string())
+            .await
+        {
+            Ok(state) => {
+                let (hash, height, time, sapling, orchard) = state.into_parts();
+                Ok(TreeState {
+                    network: chain_info.chain(),
+                    height: height.0 as u64,
+                    hash: hash.to_string(),
+                    time,
+                    sapling_tree: sapling.map(hex::encode).unwrap_or_default(),
+                    orchard_tree: orchard.map(hex::encode).unwrap_or_default(),
+                })
+            }
+            Err(e) => {
+                // TODO: Hide server error from clients before release. Currently useful for dev purposes.
+                Err(FetchServiceError::TonicStatusError(tonic::Status::unknown(
+                    format!(
+                        "Error: Failed to retrieve treestate from node. Server Error: {}",
+                        e,
+                    ),
+                )))
+            }
+        }
     }
 
     /// Returns a stream of information about roots of subtrees of the Sapling and Orchard
@@ -515,7 +1147,156 @@ impl LightWalletIndexer for FetchService {
         &self,
         request: GetSubtreeRootsArg,
     ) -> Result<SubtreeRootReplyStream, Self::Error> {
-        unimplemented!()
+        let pool = match ShieldedProtocol::try_from(request.shielded_protocol) {
+            Ok(protocol) => protocol.as_str_name(),
+            Err(_) => {
+                return Err(FetchServiceError::TonicStatusError(
+                    tonic::Status::invalid_argument("Error: Invalid shielded protocol value."),
+                ))
+            }
+        };
+        let start_index = match u16::try_from(request.start_index) {
+            Ok(value) => value,
+            Err(_) => {
+                return Err(FetchServiceError::TonicStatusError(
+                    tonic::Status::invalid_argument("Error: start_index value exceeds u16 range."),
+                ))
+            }
+        };
+        let limit = if request.max_entries == 0 {
+            None
+        } else {
+            match u16::try_from(request.max_entries) {
+                Ok(value) => Some(value),
+                Err(_) => {
+                    return Err(FetchServiceError::TonicStatusError(
+                        tonic::Status::invalid_argument(
+                            "Error: max_entries value exceeds u16 range.",
+                        ),
+                    ))
+                }
+            }
+        };
+        let subtrees = self
+            .z_get_subtrees_by_index(
+                pool.to_string(),
+                NoteCommitmentSubtreeIndex(start_index),
+                limit.and_then(|limit| Some(NoteCommitmentSubtreeIndex(limit))),
+            )
+            .await?;
+        let fetch_service_clone = self.clone();
+        let service_timeout = self.config.service_timeout;
+        let (channel_tx, channel_rx) =
+            tokio::sync::mpsc::channel(self.config.service_channel_size as usize);
+        tokio::spawn(async move {
+            let timeout = timeout(
+                std::time::Duration::from_secs(service_timeout as u64),
+                async {
+                    for subtree in subtrees.subtrees {
+                        match fetch_service_clone
+                            .z_get_block(subtree.end_height.0.to_string(), Some(1))
+                            .await
+                        {
+                            Ok(GetBlock::Object { hash, height, .. }) => {
+                                let checked_height = match height {
+                                    Some(h) => h.0 as u64,
+                                    None => {
+                                        match channel_tx
+                                            .send(Err(tonic::Status::unknown(
+                                                "Error: No block height returned by node.",
+                                            )))
+                                            .await
+                                        {
+                                            Ok(_) => break,
+                                            Err(e) => {
+                                                eprintln!(
+                                                    "Error: Channel closed unexpectedly: {}",
+                                                    e
+                                                );
+                                                break;
+                                            }
+                                        }
+                                    }
+                                };
+                                let checked_root_hash = match hex::decode(&subtree.root) {
+                                    Ok(hash) => hash,
+                                    Err(e) => {
+                                        match channel_tx
+                                            .send(Err(tonic::Status::unknown(format!(
+                                                "Error: Failed to hex decode root hash: {}.",
+                                                e
+                                            ))))
+                                            .await
+                                        {
+                                            Ok(_) => break,
+                                            Err(e) => {
+                                                eprintln!(
+                                                    "Error: Channel closed unexpectedly: {}",
+                                                    e
+                                                );
+                                                break;
+                                            }
+                                        }
+                                    }
+                                };
+                                if channel_tx
+                                    .send(Ok(SubtreeRoot {
+                                        root_hash: checked_root_hash,
+                                        completing_block_hash: hash
+                                            .0
+                                            .bytes_in_display_order()
+                                            .to_vec(),
+                                        completing_block_height: checked_height,
+                                    }))
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
+                            Ok(GetBlock::Raw(_)) => {
+                                // TODO: Hide server error from clients before release. Currently useful for dev purposes.
+                                if channel_tx
+                                .send(Err(tonic::Status::unknown(
+                                    "Error: Received raw block type, this should not be possible.",
+                                )))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                            }
+                            Err(e) => {
+                                // TODO: Hide server error from clients before release. Currently useful for dev purposes.
+                                if channel_tx
+                                    .send(Err(tonic::Status::unknown(format!(
+                                        "Error: Could not fetch block at height [{}] from node: {}",
+                                        subtree.end_height.0, e
+                                    ))))
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                },
+            )
+            .await;
+            match timeout {
+                Ok(_) => {}
+                Err(_) => {
+                    channel_tx
+                        .send(Err(tonic::Status::deadline_exceeded(
+                            "Error: get_mempool_stream gRPC request timed out",
+                        )))
+                        .await
+                        .ok();
+                }
+            }
+        });
+        Ok(SubtreeRootReplyStream::new(channel_rx))
     }
 
     /// Returns all unspent outputs for a list of addresses.
@@ -527,7 +1308,53 @@ impl LightWalletIndexer for FetchService {
         &self,
         request: GetAddressUtxosArg,
     ) -> Result<GetAddressUtxosReplyList, Self::Error> {
-        unimplemented!()
+        let taddrs = AddressStrings::new_valid(request.addresses).map_err(|legacy_code| {
+            FetchServiceError::RpcError(
+                zaino_fetch::jsonrpc::connector::RpcError::new_from_legacycode(
+                    legacy_code,
+                    "Error in Validator.",
+                ),
+            )
+        })?;
+        let utxos = self.z_get_address_utxos(taddrs).await?;
+        let mut address_utxos: Vec<GetAddressUtxosReply> = Vec::new();
+        let mut entries: u32 = 0;
+        for utxo in utxos {
+            let (address, txid, output_index, script, satoshis, height) = utxo.into_parts();
+            if (height.0 as u64) < request.start_height {
+                continue;
+            }
+            entries += 1;
+            if request.max_entries > 0 && entries > request.max_entries {
+                break;
+            }
+            let checked_index = match i32::try_from(output_index.index()) {
+                Ok(index) => index,
+                Err(_) => {
+                    return Err(FetchServiceError::TonicStatusError(tonic::Status::unknown(
+                        "Error: Index out of range. Failed to convert to i32.",
+                    )));
+                }
+            };
+            let checked_satoshis = match i64::try_from(satoshis) {
+                Ok(satoshis) => satoshis,
+                Err(_) => {
+                    return Err(FetchServiceError::TonicStatusError(tonic::Status::unknown(
+                        "Error: Satoshis out of range. Failed to convert to i64.",
+                    )));
+                }
+            };
+            let utxo_reply = GetAddressUtxosReply {
+                address: address.to_string(),
+                txid: txid.0.to_vec(),
+                index: checked_index,
+                script: script.as_raw_bytes().to_vec(),
+                value_zat: checked_satoshis,
+                height: height.0 as u64,
+            };
+            address_utxos.push(utxo_reply)
+        }
+        Ok(GetAddressUtxosReplyList { address_utxos })
     }
 
     /// Returns all unspent outputs for a list of addresses.
@@ -539,17 +1366,240 @@ impl LightWalletIndexer for FetchService {
         &self,
         request: GetAddressUtxosArg,
     ) -> Result<UtxoReplyStream, Self::Error> {
-        unimplemented!()
+        let taddrs = AddressStrings::new_valid(request.addresses).map_err(|legacy_code| {
+            FetchServiceError::RpcError(
+                zaino_fetch::jsonrpc::connector::RpcError::new_from_legacycode(
+                    legacy_code,
+                    "Error in Validator.",
+                ),
+            )
+        })?;
+        let utxos = self.z_get_address_utxos(taddrs).await?;
+        let service_timeout = self.config.service_timeout;
+        let (channel_tx, channel_rx) =
+            tokio::sync::mpsc::channel(self.config.service_channel_size as usize);
+        tokio::spawn(async move {
+            let timeout = timeout(
+                std::time::Duration::from_secs(service_timeout as u64),
+                async {
+                    let mut entries: u32 = 0;
+                    for utxo in utxos {
+                        let (address, txid, output_index, script, satoshis, height) =
+                            utxo.into_parts();
+                        if (height.0 as u64) < request.start_height {
+                            continue;
+                        }
+                        entries += 1;
+                        if request.max_entries > 0 && entries > request.max_entries {
+                            break;
+                        }
+                        let checked_index = match i32::try_from(output_index.index()) {
+                            Ok(index) => index,
+                            Err(_) => {
+                                let _ = channel_tx
+                                    .send(Err(tonic::Status::unknown(
+                                        "Error: Index out of range. Failed to convert to i32.",
+                                    )))
+                                    .await;
+                                return;
+                            }
+                        };
+                        let checked_satoshis = match i64::try_from(satoshis) {
+                            Ok(satoshis) => satoshis,
+                            Err(_) => {
+                                let _ = channel_tx
+                                    .send(Err(tonic::Status::unknown(
+                                        "Error: Satoshis out of range. Failed to convert to i64.",
+                                    )))
+                                    .await;
+                                return;
+                            }
+                        };
+                        let utxo_reply = GetAddressUtxosReply {
+                            address: address.to_string(),
+                            txid: txid.0.to_vec(),
+                            index: checked_index,
+                            script: script.as_raw_bytes().to_vec(),
+                            value_zat: checked_satoshis,
+                            height: height.0 as u64,
+                        };
+                        if channel_tx.send(Ok(utxo_reply)).await.is_err() {
+                            return;
+                        }
+                    }
+                },
+            )
+            .await;
+            match timeout {
+                Ok(_) => {}
+                Err(_) => {
+                    channel_tx
+                        .send(Err(tonic::Status::deadline_exceeded(
+                            "Error: get_mempool_stream gRPC request timed out",
+                        )))
+                        .await
+                        .ok();
+                }
+            }
+        });
+        Ok(UtxoReplyStream::new(channel_rx))
     }
 
     /// Return information about this lightwalletd instance and the blockchain
     async fn get_lightd_info(&self) -> Result<LightdInfo, Self::Error> {
-        unimplemented!()
+        let blockchain_info = self.get_blockchain_info().await?;
+        let sapling_id = zebra_rpc::methods::ConsensusBranchIdHex::new(
+            zebra_chain::parameters::ConsensusBranchId::from_hex("76b809bb")
+                .map_err(|_e| {
+                    tonic::Status::internal(
+                        "Internal Error - Consesnsus Branch ID hex conversion failed",
+                    )
+                })?
+                .into(),
+        );
+        let sapling_activation_height = blockchain_info
+            .upgrades()
+            .get(&sapling_id)
+            .map_or(zebra_chain::block::Height(1), |sapling_json| {
+                sapling_json.into_parts().1
+            });
+
+        let consensus_branch_id = zebra_chain::parameters::ConsensusBranchId::from(
+            blockchain_info.consensus().into_parts().0,
+        )
+        .to_string();
+
+        Ok(LightdInfo {
+            version: self.data.build_info.version(),
+            vendor: "ZingoLabs ZainoD".to_string(),
+            taddr_support: true,
+            chain_name: blockchain_info.chain(),
+            sapling_activation_height: sapling_activation_height.0 as u64,
+            consensus_branch_id,
+            block_height: blockchain_info.blocks().0 as u64,
+            git_commit: self.data.build_info.commit_hash(),
+            branch: self.data.build_info.branch(),
+            build_date: self.data.build_info.build_date(),
+            build_user: self.data.build_info.build_user(),
+            estimated_height: blockchain_info.estimated_height().0 as u64,
+            zcashd_build: self.data.zebra_build(),
+            zcashd_subversion: self.data.zebra_subversion(),
+        })
     }
 
     /// Testing-only, requires lightwalletd --ping-very-insecure (do not enable in production)
-    async fn ping(&self, request: Duration) -> Result<PingResponse, Self::Error> {
+    ///
+    /// NOTE: Currently unimplemented in Zaino.
+    async fn ping(&self, _request: Duration) -> Result<PingResponse, Self::Error> {
         unimplemented!()
+    }
+}
+
+impl FetchService {
+    /// Fetches CompactBlock from the validator.
+    ///
+    /// Uses 2 calls as z_get_block verbosity=1 is required to fetch txids from zcashd.
+    ///
+    /// NOTE: This implementation is slow due to the absense on an internal CompactBlock cache.
+    async fn get_compact_block(&self, height: &u32) -> Result<CompactBlock, FetchServiceError> {
+        match self.z_get_block(height.to_string(), Some(1)).await {
+            Ok(GetBlock::Object {
+                hash, tx, trees, ..
+            }) => match self.z_get_block(hash.0.to_string(), Some(0)).await {
+                Ok(GetBlock::Object { .. }) => Err(FetchServiceError::TonicStatusError(
+                    tonic::Status::internal("Received block object instead of raw block hex."),
+                )),
+                Ok(GetBlock::Raw(block_hex)) => {
+                    let tx_ids: Result<Vec<_>, _> = tx
+                        .into_iter()
+                        .map(|tx| {
+                            match tx {
+                        GetBlockTransaction::Hash(hash) => Ok(hash.to_string()),
+                        GetBlockTransaction::Object(_) => Err(FetchServiceError::TonicStatusError(
+                            tonic::Status::invalid_argument(
+                                "Found transaction of `Object` type, expected only `Hash` types.",
+                            ),
+                        )),
+                    }
+                        })
+                        .collect();
+                    let tx_ids = tx_ids?;
+                    Ok(zaino_fetch::chain::block::FullBlock::parse_from_hex(
+                        block_hex.as_ref(),
+                        Some(Self::display_txids_to_server(tx_ids)?),
+                    )?
+                    .into_compact(
+                        u32::try_from(trees.sapling())?,
+                        u32::try_from(trees.orchard())?,
+                    )?)
+                }
+                Err(e) => Err(e.into()),
+            },
+            Ok(GetBlock::Raw(_)) => Err(FetchServiceError::TonicStatusError(
+                tonic::Status::internal("Received raw block hex instead of block object."),
+            )),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Takes a vec of big endian hex encoded txids and returns them as a vec of little endian raw bytes.
+    fn display_txids_to_server(txids: Vec<String>) -> Result<Vec<Vec<u8>>, FetchServiceError> {
+        txids
+            .iter()
+            .map(|txid| {
+                txid.as_bytes()
+                    .chunks(2)
+                    .map(|chunk| {
+                        let hex_pair =
+                            std::str::from_utf8(chunk).map_err(FetchServiceError::from)?;
+                        u8::from_str_radix(hex_pair, 16).map_err(FetchServiceError::from)
+                    })
+                    .rev()
+                    .collect::<Result<Vec<u8>, _>>()
+            })
+            .collect::<Result<Vec<Vec<u8>>, _>>()
+    }
+
+    /// Returns a compact block holding only action nullifiers.
+    ///
+    /// NOTE: This implementation is slow due to the absense on an internal CompactBlock cache.
+    async fn get_nullifiers(&self, height: &u32) -> Result<CompactBlock, FetchServiceError> {
+        match self.get_compact_block(height).await {
+            Ok(block) => Ok(CompactBlock {
+                proto_version: block.proto_version,
+                height: block.height,
+                hash: block.hash,
+                prev_hash: block.prev_hash,
+                time: block.time,
+                header: block.header,
+                vtx: block
+                    .vtx
+                    .into_iter()
+                    .map(|tx| CompactTx {
+                        index: tx.index,
+                        hash: tx.hash,
+                        fee: tx.fee,
+                        spends: tx.spends,
+                        outputs: Vec::new(),
+                        actions: tx
+                            .actions
+                            .into_iter()
+                            .map(|action| CompactOrchardAction {
+                                nullifier: action.nullifier,
+                                cmx: Vec::new(),
+                                ephemeral_key: Vec::new(),
+                                ciphertext: Vec::new(),
+                            })
+                            .collect(),
+                    })
+                    .collect(),
+                chain_metadata: Some(ChainMetadata {
+                    sapling_commitment_tree_size: 0,
+                    orchard_commitment_tree_size: 0,
+                }),
+            }),
+            Err(e) => Err(e),
+        }
     }
 }
 

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -4,7 +4,7 @@ use crate::{
     config::FetchServiceConfig,
     error::FetchServiceError,
     get_build_info,
-    indexer::Indexer,
+    indexer::ZcashIndexer,
     status::{AtomicStatus, StatusType},
     ServiceMetadata,
 };
@@ -93,7 +93,7 @@ impl Drop for FetchService {
 }
 
 #[async_trait]
-impl Indexer for FetchService {
+impl ZcashIndexer for FetchService {
     type Error = FetchServiceError;
 
     /// Returns software information from the RPC server, as a [`GetInfo`] JSON struct.

--- a/zaino-state/src/indexer.rs
+++ b/zaino-state/src/indexer.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use zaino_proto::proto::{
     compact_formats::CompactBlock,
     service::{
-        Address, AddressList, Balance, BlockId, BlockRange, ChainSpec, Duration, Exclude,
+        AddressList, Balance, BlockId, BlockRange, ChainSpec, Duration, Exclude,
         GetAddressUtxosArg, GetAddressUtxosReplyList, GetSubtreeRootsArg, LightdInfo, PingResponse,
         RawTransaction, SendResponse, TransparentAddressBlockFilter, TreeState, TxFilter,
     },
@@ -18,8 +18,8 @@ use zebra_rpc::methods::{
 };
 
 use crate::stream::{
-    CompactBlockStream, CompactTransactionStream, RawTransactionStream, SubtreeRootReplyStream,
-    UtxoReplyStream,
+    AddressStream, CompactBlockStream, CompactTransactionStream, RawTransactionStream,
+    SubtreeRootReplyStream, UtxoReplyStream,
 };
 
 /// Zcash RPC method signatures.
@@ -80,7 +80,7 @@ pub trait ZcashIndexer: Send + Sync + 'static {
     /// The RPC documentation says that the returned object has a string `balance` field, but
     /// zcashd actually [returns an
     /// integer](https://github.com/zcash/lightwalletd/blob/bdaac63f3ee0dbef62bde04f6817a9f90d483b00/common/common.go#L128-L130).
-    async fn get_address_balance(
+    async fn z_get_address_balance(
         &self,
         address_strings: AddressStrings,
     ) -> Result<AddressBalance, Self::Error>;
@@ -129,7 +129,7 @@ pub trait ZcashIndexer: Send + Sync + 'static {
     /// use verbosity=3.
     ///
     /// The undocumented `chainwork` field is not returned.
-    async fn get_block(
+    async fn z_get_block(
         &self,
         hash_or_height: String,
         verbosity: Option<u8>,
@@ -246,7 +246,7 @@ pub trait ZcashIndexer: Send + Sync + 'static {
     ///
     /// lightwalletd always uses the multi-address request, without chaininfo:
     /// <https://github.com/zcash/lightwalletd/blob/master/frontend/service.go#L402>
-    async fn get_address_utxos(
+    async fn z_get_address_utxos(
         &self,
         address_strings: AddressStrings,
     ) -> Result<Vec<GetAddressUtxos>, Self::Error>;
@@ -299,7 +299,7 @@ pub trait LightWalletIndexer: Send + Sync + 'static {
     /// TODO: Update input type.
     async fn get_taddress_balance_stream(
         &self,
-        request: tonic::Streaming<Address>,
+        request: AddressStream,
     ) -> Result<Balance, Self::Error>;
 
     /// Return the compact transactions currently in the mempool; the results

--- a/zaino-state/src/indexer.rs
+++ b/zaino-state/src/indexer.rs
@@ -5,9 +5,9 @@ use async_trait::async_trait;
 use zaino_proto::proto::{
     compact_formats::CompactBlock,
     service::{
-        AddressList, Balance, BlockId, BlockRange, ChainSpec, Duration, Exclude,
-        GetAddressUtxosArg, GetAddressUtxosReplyList, GetSubtreeRootsArg, LightdInfo, PingResponse,
-        RawTransaction, SendResponse, TransparentAddressBlockFilter, TreeState, TxFilter,
+        AddressList, Balance, BlockId, BlockRange, Duration, Exclude, GetAddressUtxosArg,
+        GetAddressUtxosReplyList, GetSubtreeRootsArg, LightdInfo, PingResponse, RawTransaction,
+        SendResponse, TransparentAddressBlockFilter, TreeState, TxFilter,
     },
 };
 use zebra_chain::subtree::NoteCommitmentSubtreeIndex;
@@ -261,7 +261,7 @@ pub trait LightWalletIndexer: Send + Sync + 'static {
     type Error: std::error::Error + Send + Sync + 'static + Into<tonic::Status>;
 
     /// Return the height of the tip of the best chain
-    async fn get_latest_block(&self, request: ChainSpec) -> Result<BlockId, Self::Error>;
+    async fn get_latest_block(&self) -> Result<BlockId, Self::Error>;
 
     /// Return the compact block corresponding to the given block identifier
     async fn get_block(&self, request: BlockId) -> Result<CompactBlock, Self::Error>;
@@ -360,5 +360,7 @@ pub trait LightWalletIndexer: Send + Sync + 'static {
     async fn get_lightd_info(&self) -> Result<LightdInfo, Self::Error>;
 
     /// Testing-only, requires lightwalletd --ping-very-insecure (do not enable in production)
+    ///
+    /// NOTE: Currently unimplemented in Zaino.
     async fn ping(&self, request: Duration) -> Result<PingResponse, Self::Error>;
 }

--- a/zaino-state/src/indexer.rs
+++ b/zaino-state/src/indexer.rs
@@ -2,6 +2,14 @@
 
 use async_trait::async_trait;
 
+use zaino_proto::proto::{
+    compact_formats::CompactBlock,
+    service::{
+        Address, AddressList, Balance, BlockId, BlockRange, ChainSpec, Duration, Exclude,
+        GetAddressUtxosArg, GetAddressUtxosReplyList, GetSubtreeRootsArg, LightdInfo, PingResponse,
+        RawTransaction, SendResponse, TransparentAddressBlockFilter, TreeState, TxFilter,
+    },
+};
 use zebra_chain::subtree::NoteCommitmentSubtreeIndex;
 use zebra_rpc::methods::{
     trees::{GetSubtrees, GetTreestate},
@@ -9,11 +17,16 @@ use zebra_rpc::methods::{
     GetBlockChainInfo, GetInfo, GetRawTransaction, SentTransactionHash,
 };
 
+use crate::stream::{
+    CompactBlockStream, CompactTransactionStream, RawTransactionStream, SubtreeRootReplyStream,
+    UtxoReplyStream,
+};
+
 /// Zcash RPC method signatures.
 ///
 /// Doc comments taken from Zebra for consistency.
 #[async_trait]
-pub trait Indexer {
+pub trait ZcashIndexer: Send + Sync + 'static {
     /// Uses undelying error type of implementer.
     type Error: std::error::Error + Send + Sync + 'static;
 
@@ -237,4 +250,115 @@ pub trait Indexer {
         &self,
         address_strings: AddressStrings,
     ) -> Result<Vec<GetAddressUtxos>, Self::Error>;
+}
+
+/// LightWallet RPC method signatures.
+///
+/// Doc comments taken from Zaino-Proto for consistency.
+#[async_trait]
+pub trait LightWalletIndexer: Send + Sync + 'static {
+    /// Uses undelying error type of implementer.
+    type Error: std::error::Error + Send + Sync + 'static + Into<tonic::Status>;
+
+    /// Return the height of the tip of the best chain
+    async fn get_latest_block(&self, request: ChainSpec) -> Result<BlockId, Self::Error>;
+
+    /// Return the compact block corresponding to the given block identifier
+    async fn get_block(&self, request: BlockId) -> Result<CompactBlock, Self::Error>;
+
+    /// Same as GetBlock except actions contain only nullifiers
+    async fn get_block_nullifiers(&self, request: BlockId) -> Result<CompactBlock, Self::Error>;
+
+    /// Return a list of consecutive compact blocks
+    async fn get_block_range(&self, request: BlockRange)
+        -> Result<CompactBlockStream, Self::Error>;
+
+    /// Same as GetBlockRange except actions contain only nullifiers
+    async fn get_block_range_nullifiers(
+        &self,
+        request: BlockRange,
+    ) -> Result<CompactBlockStream, Self::Error>;
+
+    /// Return the requested full (not compact) transaction (as from zcashd)
+    async fn get_transaction(&self, request: TxFilter) -> Result<RawTransaction, Self::Error>;
+
+    /// Submit the given transaction to the Zcash network
+    async fn send_transaction(&self, request: RawTransaction) -> Result<SendResponse, Self::Error>;
+
+    /// Return the txids corresponding to the given t-address within the given block range
+    async fn get_taddress_txids(
+        &self,
+        request: TransparentAddressBlockFilter,
+    ) -> Result<RawTransactionStream, Self::Error>;
+
+    /// Returns the total balance for a list of taddrs
+    async fn get_taddress_balance(&self, request: AddressList) -> Result<Balance, Self::Error>;
+
+    /// Returns the total balance for a list of taddrs
+    ///
+    /// TODO: Update input type.
+    async fn get_taddress_balance_stream(
+        &self,
+        request: tonic::Streaming<Address>,
+    ) -> Result<Balance, Self::Error>;
+
+    /// Return the compact transactions currently in the mempool; the results
+    /// can be a few seconds out of date. If the Exclude list is empty, return
+    /// all transactions; otherwise return all *except* those in the Exclude list
+    /// (if any); this allows the client to avoid receiving transactions that it
+    /// already has (from an earlier call to this rpc). The transaction IDs in the
+    /// Exclude list can be shortened to any number of bytes to make the request
+    /// more bandwidth-efficient; if two or more transactions in the mempool
+    /// match a shortened txid, they are all sent (none is excluded). Transactions
+    /// in the exclude list that don't exist in the mempool are ignored.
+    async fn get_mempool_tx(
+        &self,
+        request: Exclude,
+    ) -> Result<CompactTransactionStream, Self::Error>;
+
+    /// Return a stream of current Mempool transactions. This will keep the output stream open while
+    /// there are mempool transactions. It will close the returned stream when a new block is mined.
+    async fn get_mempool_stream(&self) -> Result<RawTransactionStream, Self::Error>;
+
+    /// GetTreeState returns the note commitment tree state corresponding to the given block.
+    /// See section 3.7 of the Zcash protocol specification. It returns several other useful
+    /// values also (even though they can be obtained using GetBlock).
+    /// The block can be specified by either height or hash.
+    async fn get_tree_state(&self, request: BlockId) -> Result<TreeState, Self::Error>;
+
+    /// GetLatestTreeState returns the note commitment tree state corresponding to the chain tip.
+    async fn get_latest_tree_state(&self) -> Result<TreeState, Self::Error>;
+
+    /// Returns a stream of information about roots of subtrees of the Sapling and Orchard
+    /// note commitment trees.
+    async fn get_subtree_roots(
+        &self,
+        request: GetSubtreeRootsArg,
+    ) -> Result<SubtreeRootReplyStream, Self::Error>;
+
+    /// Returns all unspent outputs for a list of addresses.
+    ///
+    /// Ignores all utxos below block height [GetAddressUtxosArg.start_height].
+    /// Returns max [GetAddressUtxosArg.max_entries] utxos, or unrestricted if [GetAddressUtxosArg.max_entries] = 0.
+    /// Utxos are collected and returned as a single Vec.
+    async fn get_address_utxos(
+        &self,
+        request: GetAddressUtxosArg,
+    ) -> Result<GetAddressUtxosReplyList, Self::Error>;
+
+    /// Returns all unspent outputs for a list of addresses.
+    ///
+    /// Ignores all utxos below block height [GetAddressUtxosArg.start_height].
+    /// Returns max [GetAddressUtxosArg.max_entries] utxos, or unrestricted if [GetAddressUtxosArg.max_entries] = 0.
+    /// Utxos are returned in a stream.
+    async fn get_address_utxos_stream(
+        &self,
+        request: GetAddressUtxosArg,
+    ) -> Result<UtxoReplyStream, Self::Error>;
+
+    /// Return information about this lightwalletd instance and the blockchain
+    async fn get_lightd_info(&self) -> Result<LightdInfo, Self::Error>;
+
+    /// Testing-only, requires lightwalletd --ping-very-insecure (do not enable in production)
+    async fn ping(&self, request: Duration) -> Result<PingResponse, Self::Error>;
 }


### PR DESCRIPTION
This PR adds the LightwalletIndexer trait and moves FetchService based grpc impls from zaino-serve to zaino-state::fetch.rs.

- Adds LightWalletIndexer to zaino-state::indexer.rs and renames Indexer to ZcashIndexer.
- Wraps Id_counter in JsonRpcConnector in an arc to make JsonRpcCpnnector clonable.
- Adds AddressStream type to zaino-fetch::streams.rs
- Moves gRPC methods to zaino-state::fetch.rs (NOTE: these impls will be used once the encompassing IndexerService has been implemented.

 - Closes https://github.com/zingolabs/zaino/issues/123, https://github.com/zingolabs/zaino/issues/125

 - Build atop https://github.com/zingolabs/zaino/pull/140, https://github.com/zingolabs/zaino/pull/142, #149. As uses functionality in those PRs.

