### PR TITLE
Update mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,6 +931,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5214,6 +5228,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "dashmap",
  "futures",
  "hex",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,4 @@ tower = { version = "0.4", features = ["buffer", "util"] }
 async-trait = "0.1"
 chrono = "0.4"
 jsonrpc-core = "18.0.0"
+dashmap = "6.1"

--- a/zaino-fetch/src/chain/mempool.rs
+++ b/zaino-fetch/src/chain/mempool.rs
@@ -130,9 +130,17 @@ impl Mempool {
 
         let mut txids_to_exclude: HashSet<String> = HashSet::new();
         for exclude_txid in &exclude_txids {
+            // Convert to big endian (server format).
+            let server_exclude_txid: String = exclude_txid
+                .chars()
+                .collect::<Vec<_>>()
+                .chunks(2)
+                .rev()
+                .map(|chunk| chunk.iter().collect::<String>())
+                .collect();
             let matching_txids: Vec<&String> = mempool_txids
                 .iter()
-                .filter(|txid| txid.starts_with(exclude_txid))
+                .filter(|txid| txid.starts_with(&server_exclude_txid))
                 .collect();
 
             if matching_txids.len() == 1 {

--- a/zaino-state/Cargo.toml
+++ b/zaino-state/Cargo.toml
@@ -31,6 +31,7 @@ futures = { workspace = true }
 tonic = { workspace = true }
 http = { workspace = true }
 lazy-regex = { workspace = true }
+dashmap = { workspace = true }
 
 [dev-dependencies]
 zaino-testutils = { path = "../zaino-testutils" }

--- a/zaino-state/src/broadcast.rs
+++ b/zaino-state/src/broadcast.rs
@@ -1,0 +1,144 @@
+//! Holds zaino-state::Broadcast, a thread safe broadcaster used by the mempool and non-finalised state.
+
+use dashmap::DashMap;
+use std::{collections::HashSet, hash::Hash, sync::Arc};
+use tokio::sync::watch;
+
+use crate::status::StatusType;
+
+/// A generic, thread-safe broadcaster that manages mutable state and notifies clients of updates.
+pub struct Broadcast<K, V> {
+    state: Arc<DashMap<K, V>>,
+    notifier: watch::Sender<StatusType>,
+}
+
+impl<K: Eq + Hash + Clone, V: Clone> Broadcast<K, V> {
+    /// Creates a new Broadcast instance, uses default dashmap spec.
+    pub fn new_default() -> Self {
+        let (notifier, _) = watch::channel(StatusType::Spawning);
+        Self {
+            state: Arc::new(DashMap::new()),
+            notifier,
+        }
+    }
+
+    /// Creates a new Broadcast instance, exposes dashmap spec.
+    pub fn new_custom(capacity: usize, shard_amount: usize) -> Self {
+        let (notifier, _) = watch::channel(StatusType::Spawning);
+        Self {
+            state: Arc::new(DashMap::with_capacity_and_shard_amount(
+                capacity,
+                shard_amount,
+            )),
+            notifier,
+        }
+    }
+
+    /// Inserts or updates an entry in the state and broadcasts an update.
+    pub fn insert(&self, key: K, value: V, status: StatusType) {
+        self.state.insert(key, value);
+        let _ = self.notifier.send(status);
+    }
+
+    /// Inserts or updates an entry in the state and broadcasts an update.
+    pub fn insert_set(&self, set: Vec<(K, V)>, status: StatusType) {
+        for (key, value) in set {
+            self.state.insert(key, value);
+        }
+        let _ = self.notifier.send(status);
+    }
+
+    /// Removes an entry from the state and broadcasts an update.
+    pub fn remove(&self, key: &K, status: StatusType) {
+        self.state.remove(key);
+        let _ = self.notifier.send(status);
+    }
+
+    /// Retrieves a value from the state by key.
+    pub fn get(&self, key: &K) -> Option<Arc<V>> {
+        self.state
+            .get(key)
+            .map(|entry| Arc::new((*entry.value()).clone()))
+    }
+
+    /// Retrieves a set of values from the state by a list of keys.
+    pub fn get_set(&self, keys: &[K]) -> Vec<(K, Arc<V>)>
+    where
+        K: Clone,
+    {
+        keys.iter()
+            .filter_map(|key| {
+                self.state
+                    .get(key)
+                    .map(|entry| (key.clone(), Arc::new((*entry.value()).clone())))
+            })
+            .collect()
+    }
+
+    /// Checks if a key exists in the state.
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.state.contains_key(key)
+    }
+
+    /// Returns a receiver to listen for state update notifications.
+    pub fn subscribe(&self) -> watch::Receiver<StatusType> {
+        self.notifier.subscribe()
+    }
+
+    /// Provides read access to the internal state.
+    pub fn get_state(&self) -> Arc<DashMap<K, V>> {
+        Arc::clone(&self.state)
+    }
+
+    /// Returns the whole state excluding keys in the ignore list.
+    pub fn get_filtered_state(&self, ignore_list: &HashSet<K>) -> Vec<(K, V)>
+    where
+        K: Clone,
+        V: Clone,
+    {
+        self.state
+            .iter()
+            .filter(|entry| !ignore_list.contains(entry.key()))
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect()
+    }
+
+    /// Clears all entries from the state and broadcasts an update.
+    pub fn clear(&self, status: StatusType) {
+        self.state.clear();
+        let _ = self.notifier.send(status);
+    }
+
+    /// Returns the number of entries in the state.
+    pub fn len(&self) -> usize {
+        self.state.len()
+    }
+
+    /// Returns true if the state is empty.
+    pub fn is_empty(&self) -> bool {
+        self.state.is_empty()
+    }
+
+    /// Broadcasts an update.
+    pub fn notify(&self, status: StatusType) {
+        if self.notifier.send(status).is_err() {
+            eprintln!("No subscribers are currently listening for updates.");
+        }
+    }
+}
+
+impl<K: Eq + Hash + Clone, V: Clone> Default for Broadcast<K, V> {
+    fn default() -> Self {
+        Self::new_default()
+    }
+}
+
+impl<K: Eq + Hash + Clone + std::fmt::Debug, V: Clone + std::fmt::Debug> std::fmt::Debug
+    for Broadcast<K, V>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Broadcast")
+            .field("state", &self.state)
+            .finish()
+    }
+}

--- a/zaino-state/src/error.rs
+++ b/zaino-state/src/error.rs
@@ -160,3 +160,45 @@ impl From<FetchServiceError> for tonic::Status {
         }
     }
 }
+
+/// Errors related to the `StateService`.
+#[derive(Debug, thiserror::Error)]
+pub enum MempoolError {
+    /// Custom Errors. *Remove before production.
+    #[error("Custom error: {0}")]
+    Custom(String),
+
+    /// Error from a Tokio JoinHandle.
+    #[error("Join error: {0}")]
+    JoinError(#[from] tokio::task::JoinError),
+
+    /// Error from JsonRpcConnector.
+    #[error("JsonRpcConnector error: {0}")]
+    JsonRpcConnectorError(#[from] zaino_fetch::jsonrpc::error::JsonRpcConnectorError),
+
+    /// Error from a Tokio Watch Reciever.
+    #[error("Join error: {0}")]
+    WatchRecvError(#[from] tokio::sync::watch::error::RecvError),
+
+    /// Unexpected status-related error.
+    #[error("Status error: {0:?}")]
+    StatusError(StatusError),
+
+    /// Error from sending to a Tokio MPSC channel.
+    #[error("Send error: {0}")]
+    SendError(
+        #[from]
+        tokio::sync::mpsc::error::SendError<
+            Result<(crate::mempool::MempoolKey, crate::mempool::MempoolValue), StatusError>,
+        >,
+    ),
+
+    /// A generic boxed error.
+    #[error("Generic error: {0}")]
+    Generic(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// A general error type to represent error StatusTypes.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("Unexpected status error: {0:?}")]
+pub struct StatusError(pub crate::status::StatusType);

--- a/zaino-state/src/error.rs
+++ b/zaino-state/src/error.rs
@@ -85,6 +85,10 @@ pub enum FetchServiceError {
     #[error("JsonRpcConnector error: {0}")]
     JsonRpcConnectorError(#[from] zaino_fetch::jsonrpc::error::JsonRpcConnectorError),
 
+    /// Error from the mempool.
+    #[error("Mempool error: {0}")]
+    MempoolError(#[from] MempoolError),
+
     /// RPC error in compatibility with zcashd.
     #[error("RPC error: {0:?}")]
     RpcError(#[from] zaino_fetch::jsonrpc::connector::RpcError),
@@ -131,6 +135,9 @@ impl From<FetchServiceError> for tonic::Status {
             }
             FetchServiceError::JsonRpcConnectorError(err) => {
                 tonic::Status::internal(format!("JsonRpcConnector error: {}", err))
+            }
+            FetchServiceError::MempoolError(err) => {
+                tonic::Status::internal(format!("Mempool error: {}", err))
             }
             FetchServiceError::RpcError(err) => {
                 tonic::Status::internal(format!("RPC error: {:?}", err))

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -1092,6 +1092,17 @@ impl LightWalletIndexer for FetchServiceSubscriber {
         &self,
         _request: Exclude,
     ) -> Result<CompactTransactionStream, Self::Error> {
+        // let exclude_txids: Vec<String> = request
+        //     .txid
+        //     .iter()
+        //     .map(|txid_bytes| {
+        //         let reversed_txid_bytes: Vec<u8> = txid_bytes.iter().cloned().rev().collect();
+        //         hex::encode(&reversed_txid_bytes)
+        //     })
+        //     .collect();
+        // //
+
+        // todo!()
         Err(FetchServiceError::TonicStatusError(tonic::Status::new(
             tonic::Code::Unimplemented,
             "get_mempool_tx is not implemented in Zaino.",

--- a/zaino-state/src/lib.rs
+++ b/zaino-state/src/lib.rs
@@ -5,10 +5,12 @@
 
 use zebra_chain::parameters::Network;
 
+pub mod broadcast;
 pub mod config;
 pub mod error;
 pub mod fetch;
 pub mod indexer;
+pub mod mempool;
 pub mod state;
 pub mod status;
 pub mod stream;

--- a/zaino-state/src/mempool.rs
+++ b/zaino-state/src/mempool.rs
@@ -1,17 +1,291 @@
 //! Holds Zaino's mempool implementation.
 
-use crate::{broadcast::Broadcast, status::AtomicStatus};
+use std::collections::HashSet;
+
+use crate::{
+    broadcast::{Broadcast, BroadcastSubscriber},
+    error::{MempoolError, StatusError},
+    indexer::ZcashIndexer,
+    status::{AtomicStatus, StatusType},
+};
 use zebra_chain::block::Hash;
 
-pub struct Mempool {
-    state: Broadcast<String, String>,
-    best_block_hash: Hash,
-    sync_task_handle: tokio::task::JoinHandle<()>,
+/// Mempool key
+///
+/// Holds txid.
+#[derive(Debug, Clone, PartialEq, Hash, Eq)]
+pub struct MempoolKey(String);
+
+/// Mempool value.
+///
+/// NOTE: Currently holds a copy of txid,
+///       this could be updated to store the corresponding transaction as the value,
+///       this would enable the serving of mempool trasactions directly, significantly increasing efficiency.
+#[derive(Debug, Clone, PartialEq, Hash, Eq)]
+pub struct MempoolValue(String);
+
+/// Zcash mempool, uses dashmap for efficient serving of mempool tx.
+#[derive(Debug)]
+pub struct Mempool<F> {
+    /// Zcash chain fetch service.
+    fetcher: F,
+    /// Wrapper for a dashmap of mempool transactions.
+    state: Broadcast<MempoolKey, MempoolValue>,
+    /// Mempool sync handle.
+    sync_task_handle: Option<tokio::task::JoinHandle<()>>,
+    /// mempool status.
     status: AtomicStatus,
 }
 
-impl Mempool {
-    pub fn spawn() -> Self {
-        todo!()
+impl<F: Clone + ZcashIndexer> Mempool<F> {
+    /// Spawns a new [`Mempool`].
+    pub async fn spawn(
+        fetcher: &F,
+        capacity_and_shard_amount: Option<(usize, usize)>,
+    ) -> Result<Self, MempoolError> {
+        let mut mempool = Mempool {
+            fetcher: fetcher.clone(),
+            state: match capacity_and_shard_amount {
+                Some((capacity, shard_amount)) => Broadcast::new_custom(capacity, shard_amount),
+                None => Broadcast::new_default(),
+            },
+            sync_task_handle: None,
+            status: AtomicStatus::new(StatusType::Spawning.into()),
+        };
+
+        mempool.sync_task_handle = Some(mempool.serve().await?);
+
+        Ok(mempool)
+    }
+
+    async fn serve(&self) -> Result<tokio::task::JoinHandle<()>, MempoolError> {
+        let fetcher = self.fetcher.clone();
+        let state = self.state.clone();
+        let status = self.status.clone();
+        status.store(StatusType::Ready.into());
+
+        let sync_handle = tokio::spawn(async move {
+            let mut best_block_hash: Hash;
+            let mut check_block_hash: Hash;
+
+            match fetcher.get_blockchain_info().await {
+                Ok(chain_info) => {
+                    best_block_hash = chain_info.best_block_hash().clone();
+                }
+                Err(e) => {
+                    status.store(StatusType::RecoverableError.into());
+                    state.notify(status.into());
+                    eprintln!("{e}");
+                    return;
+                }
+            }
+
+            loop {
+                match fetcher.get_blockchain_info().await {
+                    Ok(chain_info) => {
+                        check_block_hash = chain_info.best_block_hash().clone();
+                    }
+                    Err(e) => {
+                        status.store(StatusType::RecoverableError.into());
+                        state.notify(status.into());
+                        eprintln!("{e}");
+                        return;
+                    }
+                }
+
+                if check_block_hash != best_block_hash {
+                    best_block_hash = check_block_hash;
+                    state.notify(StatusType::Syncing);
+                    state.clear();
+                }
+
+                match fetcher.get_raw_mempool().await {
+                    Ok(mempool_tx) => {
+                        state.insert_filtered_set(
+                            mempool_tx
+                                .into_iter()
+                                .map(|s| (MempoolKey(s.clone()), MempoolValue(s)))
+                                .collect(),
+                            StatusType::Ready,
+                        );
+                    }
+                    Err(e) => {
+                        status.store(StatusType::RecoverableError.into());
+                        state.notify(status.into());
+                        eprintln!("{e}");
+                        return;
+                    }
+                };
+
+                if status.load() == StatusType::Closing as usize {
+                    state.notify(status.into());
+                    return;
+                }
+
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        });
+
+        Ok(sync_handle)
+    }
+
+    /// Returns a [`MempoolSubscriber`].
+    pub fn subscriber(&self) -> MempoolSubscriber {
+        MempoolSubscriber {
+            subscriber: self.state.subscriber(),
+            seen_txids: HashSet::new(),
+        }
+    }
+
+    /// Returns the status of the mempool.
+    pub fn status(&self) -> StatusType {
+        self.status.load().into()
+    }
+
+    /// Sets the mempool to close gracefully.
+    pub async fn close(&mut self) {
+        self.status.store(StatusType::Closing.into());
+        self.state.notify(self.status());
+        if let Some(handle) = self.sync_task_handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+impl<F> Drop for Mempool<F> {
+    fn drop(&mut self) {
+        self.status.store(StatusType::Closing.into());
+        self.state.notify(StatusType::Closing);
+        if let Some(handle) = self.sync_task_handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+impl<F: Clone> Clone for Mempool<F> {
+    fn clone(&self) -> Self {
+        Self {
+            fetcher: self.fetcher.clone(),
+            state: self.state.clone(),
+            sync_task_handle: None,
+            status: self.status.clone(),
+        }
+    }
+}
+
+/// A subscriber to a [`Mempool`].
+#[derive(Debug, Clone)]
+pub struct MempoolSubscriber {
+    subscriber: BroadcastSubscriber<MempoolKey, MempoolValue>,
+    seen_txids: HashSet<MempoolKey>,
+}
+
+impl MempoolSubscriber {
+    /// Returns all tx currently in the mempool and updates seen_txids.
+    pub fn get_mempool(&mut self) -> Vec<(MempoolKey, MempoolValue)> {
+        let mempool_updates = self.subscriber.get_filtered_state(&HashSet::new());
+        for (mempool_key, _) in mempool_updates.clone() {
+            self.seen_txids.insert(mempool_key);
+        }
+        mempool_updates
+    }
+
+    /// Returns all tx currently in the mempool and updates seen_txids.
+    pub fn get_filtered_mempool(
+        &mut self,
+        ignore_list: HashSet<MempoolKey>,
+    ) -> Vec<(MempoolKey, MempoolValue)> {
+        let mempool_updates = self.subscriber.get_filtered_state(&ignore_list);
+        for (mempool_key, _) in mempool_updates.clone() {
+            self.seen_txids.insert(mempool_key);
+        }
+        mempool_updates
+    }
+
+    /// Returns txids not yet seen by the subscriber and updates seen_txids.
+    pub fn get_mempool_updates(&mut self) -> Vec<(MempoolKey, MempoolValue)> {
+        let mempool_updates = self.subscriber.get_filtered_state(&self.seen_txids);
+        for (mempool_key, _) in mempool_updates.clone() {
+            self.seen_txids.insert(mempool_key);
+        }
+        mempool_updates
+    }
+
+    /// Waits on update from mempool and updates the mempool, returning either the new mempool or the mempool updates, along with the mempool status.
+    pub async fn wait_on_update(
+        &mut self,
+    ) -> Result<(StatusType, Vec<(MempoolKey, MempoolValue)>), MempoolError> {
+        let update_status = self.subscriber.wait_on_notifier().await?;
+        match update_status {
+            StatusType::Ready => Ok((StatusType::Ready, self.get_mempool_updates())),
+            StatusType::Syncing => {
+                self.clear_seen();
+                Ok((StatusType::Syncing, self.get_mempool()))
+            }
+            StatusType::Closing => Ok((StatusType::Closing, Vec::new())),
+            status => return Err(MempoolError::StatusError(StatusError(status))),
+        }
+    }
+
+    /// Returns a stream of mempool txids, closes the channel when a new block has been mined.
+    pub async fn get_mempool_stream(
+        &mut self,
+    ) -> Result<
+        (
+            tokio::sync::mpsc::Receiver<Result<(MempoolKey, MempoolValue), StatusError>>,
+            tokio::task::JoinHandle<()>,
+        ),
+        MempoolError,
+    > {
+        let mut subscriber = self.clone();
+        let (channel_tx, channel_rx) = tokio::sync::mpsc::channel(32);
+
+        let streamer_handle = tokio::spawn(async move {
+            let mempool_result: Result<(), MempoolError> = async {
+                loop {
+                    let (mempool_status, mempool_updates) = subscriber.wait_on_update().await?;
+                    match mempool_status {
+                        StatusType::Ready => {
+                            for (mempool_key, mempool_value) in mempool_updates {
+                                channel_tx.send(Ok((mempool_key, mempool_value))).await?;
+                            }
+                        }
+                        StatusType::Syncing => {
+                            return Ok(());
+                        }
+                        StatusType::Closing => {
+                            return Err(MempoolError::StatusError(StatusError(
+                                StatusType::Closing,
+                            )));
+                        }
+                        status => {
+                            return Err(MempoolError::StatusError(StatusError(status)));
+                        }
+                    }
+                }
+            }
+            .await;
+
+            if let Err(mempool_error) = mempool_result {
+                eprintln!("Error in mempool stream: {:?}", mempool_error);
+                match mempool_error {
+                    MempoolError::StatusError(error_status) => {
+                        let _ = channel_tx.send(Err(error_status)).await;
+                    }
+                    _ => {
+                        let _ = channel_tx
+                            .send(Err(StatusError(StatusType::RecoverableError)))
+                            .await;
+                    }
+                }
+            }
+        });
+
+        Ok((channel_rx, streamer_handle))
+    }
+
+    /// Clears the subscribers seen_txids.
+    fn clear_seen(&mut self) {
+        self.seen_txids.clear();
     }
 }

--- a/zaino-state/src/mempool.rs
+++ b/zaino-state/src/mempool.rs
@@ -5,16 +5,16 @@ use std::collections::HashSet;
 use crate::{
     broadcast::{Broadcast, BroadcastSubscriber},
     error::{MempoolError, StatusError},
-    indexer::ZcashIndexer,
     status::{AtomicStatus, StatusType},
 };
+use zaino_fetch::jsonrpc::connector::JsonRpcConnector;
 use zebra_chain::block::Hash;
 
 /// Mempool key
 ///
 /// Holds txid.
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
-pub struct MempoolKey(String);
+pub struct MempoolKey(pub String);
 
 /// Mempool value.
 ///
@@ -22,13 +22,13 @@ pub struct MempoolKey(String);
 ///       this could be updated to store the corresponding transaction as the value,
 ///       this would enable the serving of mempool trasactions directly, significantly increasing efficiency.
 #[derive(Debug, Clone, PartialEq, Hash, Eq)]
-pub struct MempoolValue(String);
+pub struct MempoolValue(pub String);
 
 /// Zcash mempool, uses dashmap for efficient serving of mempool tx.
 #[derive(Debug)]
-pub struct Mempool<F> {
+pub struct Mempool {
     /// Zcash chain fetch service.
-    fetcher: F,
+    fetcher: JsonRpcConnector,
     /// Wrapper for a dashmap of mempool transactions.
     state: Broadcast<MempoolKey, MempoolValue>,
     /// Mempool sync handle.
@@ -37,10 +37,10 @@ pub struct Mempool<F> {
     status: AtomicStatus,
 }
 
-impl<F: Clone + ZcashIndexer> Mempool<F> {
+impl Mempool {
     /// Spawns a new [`Mempool`].
     pub async fn spawn(
-        fetcher: &F,
+        fetcher: &JsonRpcConnector,
         capacity_and_shard_amount: Option<(usize, usize)>,
     ) -> Result<Self, MempoolError> {
         let mut mempool = Mempool {
@@ -52,6 +52,18 @@ impl<F: Clone + ZcashIndexer> Mempool<F> {
             sync_task_handle: None,
             status: AtomicStatus::new(StatusType::Spawning.into()),
         };
+
+        mempool.state.insert_filtered_set(
+            mempool
+                .fetcher
+                .get_raw_mempool()
+                .await?
+                .transactions
+                .into_iter()
+                .map(|s| (MempoolKey(s.clone()), MempoolValue(s)))
+                .collect(),
+            StatusType::Ready,
+        );
 
         mempool.sync_task_handle = Some(mempool.serve().await?);
 
@@ -70,7 +82,7 @@ impl<F: Clone + ZcashIndexer> Mempool<F> {
 
             match fetcher.get_blockchain_info().await {
                 Ok(chain_info) => {
-                    best_block_hash = chain_info.best_block_hash().clone();
+                    best_block_hash = chain_info.best_block_hash.clone();
                 }
                 Err(e) => {
                     status.store(StatusType::RecoverableError.into());
@@ -83,7 +95,7 @@ impl<F: Clone + ZcashIndexer> Mempool<F> {
             loop {
                 match fetcher.get_blockchain_info().await {
                     Ok(chain_info) => {
-                        check_block_hash = chain_info.best_block_hash().clone();
+                        check_block_hash = chain_info.best_block_hash.clone();
                     }
                     Err(e) => {
                         status.store(StatusType::RecoverableError.into());
@@ -103,6 +115,7 @@ impl<F: Clone + ZcashIndexer> Mempool<F> {
                     Ok(mempool_tx) => {
                         state.insert_filtered_set(
                             mempool_tx
+                                .transactions
                                 .into_iter()
                                 .map(|s| (MempoolKey(s.clone()), MempoolValue(s)))
                                 .collect(),
@@ -122,7 +135,7 @@ impl<F: Clone + ZcashIndexer> Mempool<F> {
                     return;
                 }
 
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }
         });
 
@@ -134,6 +147,7 @@ impl<F: Clone + ZcashIndexer> Mempool<F> {
         MempoolSubscriber {
             subscriber: self.state.subscriber(),
             seen_txids: HashSet::new(),
+            status: self.status.clone(),
         }
     }
 
@@ -143,7 +157,7 @@ impl<F: Clone + ZcashIndexer> Mempool<F> {
     }
 
     /// Sets the mempool to close gracefully.
-    pub async fn close(&mut self) {
+    pub fn close(&mut self) {
         self.status.store(StatusType::Closing.into());
         self.state.notify(self.status());
         if let Some(handle) = self.sync_task_handle.take() {
@@ -152,7 +166,7 @@ impl<F: Clone + ZcashIndexer> Mempool<F> {
     }
 }
 
-impl<F> Drop for Mempool<F> {
+impl Drop for Mempool {
     fn drop(&mut self) {
         self.status.store(StatusType::Closing.into());
         self.state.notify(StatusType::Closing);
@@ -162,7 +176,7 @@ impl<F> Drop for Mempool<F> {
     }
 }
 
-impl<F: Clone> Clone for Mempool<F> {
+impl Clone for Mempool {
     fn clone(&self) -> Self {
         Self {
             fetcher: self.fetcher.clone(),
@@ -178,53 +192,21 @@ impl<F: Clone> Clone for Mempool<F> {
 pub struct MempoolSubscriber {
     subscriber: BroadcastSubscriber<MempoolKey, MempoolValue>,
     seen_txids: HashSet<MempoolKey>,
+    status: AtomicStatus,
 }
 
 impl MempoolSubscriber {
     /// Returns all tx currently in the mempool and updates seen_txids.
-    pub fn get_mempool(&mut self) -> Vec<(MempoolKey, MempoolValue)> {
-        let mempool_updates = self.subscriber.get_filtered_state(&HashSet::new());
-        for (mempool_key, _) in mempool_updates.clone() {
-            self.seen_txids.insert(mempool_key);
-        }
-        mempool_updates
+    pub fn get_mempool(&self) -> Vec<(MempoolKey, MempoolValue)> {
+        self.subscriber.get_filtered_state(&HashSet::new())
     }
 
     /// Returns all tx currently in the mempool and updates seen_txids.
     pub fn get_filtered_mempool(
-        &mut self,
+        &self,
         ignore_list: HashSet<MempoolKey>,
     ) -> Vec<(MempoolKey, MempoolValue)> {
-        let mempool_updates = self.subscriber.get_filtered_state(&ignore_list);
-        for (mempool_key, _) in mempool_updates.clone() {
-            self.seen_txids.insert(mempool_key);
-        }
-        mempool_updates
-    }
-
-    /// Returns txids not yet seen by the subscriber and updates seen_txids.
-    pub fn get_mempool_updates(&mut self) -> Vec<(MempoolKey, MempoolValue)> {
-        let mempool_updates = self.subscriber.get_filtered_state(&self.seen_txids);
-        for (mempool_key, _) in mempool_updates.clone() {
-            self.seen_txids.insert(mempool_key);
-        }
-        mempool_updates
-    }
-
-    /// Waits on update from mempool and updates the mempool, returning either the new mempool or the mempool updates, along with the mempool status.
-    pub async fn wait_on_update(
-        &mut self,
-    ) -> Result<(StatusType, Vec<(MempoolKey, MempoolValue)>), MempoolError> {
-        let update_status = self.subscriber.wait_on_notifier().await?;
-        match update_status {
-            StatusType::Ready => Ok((StatusType::Ready, self.get_mempool_updates())),
-            StatusType::Syncing => {
-                self.clear_seen();
-                Ok((StatusType::Syncing, self.get_mempool()))
-            }
-            StatusType::Closing => Ok((StatusType::Closing, Vec::new())),
-            status => return Err(MempoolError::StatusError(StatusError(status))),
-        }
+        self.subscriber.get_filtered_state(&ignore_list)
     }
 
     /// Returns a stream of mempool txids, closes the channel when a new block has been mined.
@@ -262,6 +244,9 @@ impl MempoolSubscriber {
                             return Err(MempoolError::StatusError(StatusError(status)));
                         }
                     }
+                    if subscriber.status.load() == StatusType::Closing as usize {
+                        return Err(MempoolError::StatusError(StatusError(StatusType::Closing)));
+                    }
                 }
             }
             .await;
@@ -282,6 +267,48 @@ impl MempoolSubscriber {
         });
 
         Ok((channel_rx, streamer_handle))
+    }
+
+    /// Returns the status of the mempool.
+    pub fn status(&self) -> StatusType {
+        self.status.load().into()
+    }
+
+    /// Returns all tx currently in the mempool and updates seen_txids.
+    fn get_mempool_and_update_seen(&mut self) -> Vec<(MempoolKey, MempoolValue)> {
+        let mempool_updates = self.subscriber.get_filtered_state(&HashSet::new());
+        for (mempool_key, _) in mempool_updates.clone() {
+            self.seen_txids.insert(mempool_key);
+        }
+        mempool_updates
+    }
+
+    /// Returns txids not yet seen by the subscriber and updates seen_txids.
+    fn get_mempool_updates_and_update_seen(&mut self) -> Vec<(MempoolKey, MempoolValue)> {
+        let mempool_updates = self.subscriber.get_filtered_state(&self.seen_txids);
+        for (mempool_key, _) in mempool_updates.clone() {
+            self.seen_txids.insert(mempool_key);
+        }
+        mempool_updates
+    }
+
+    /// Waits on update from mempool and updates the mempool, returning either the new mempool or the mempool updates, along with the mempool status.
+    async fn wait_on_update(
+        &mut self,
+    ) -> Result<(StatusType, Vec<(MempoolKey, MempoolValue)>), MempoolError> {
+        let update_status = self.subscriber.wait_on_notifier().await?;
+        match update_status {
+            StatusType::Ready => Ok((
+                StatusType::Ready,
+                self.get_mempool_updates_and_update_seen(),
+            )),
+            StatusType::Syncing => {
+                self.clear_seen();
+                Ok((StatusType::Syncing, self.get_mempool_and_update_seen()))
+            }
+            StatusType::Closing => Ok((StatusType::Closing, Vec::new())),
+            status => return Err(MempoolError::StatusError(StatusError(status))),
+        }
     }
 
     /// Clears the subscribers seen_txids.

--- a/zaino-state/src/mempool.rs
+++ b/zaino-state/src/mempool.rs
@@ -1,0 +1,17 @@
+//! Holds Zaino's mempool implementation.
+
+use crate::{broadcast::Broadcast, status::AtomicStatus};
+use zebra_chain::block::Hash;
+
+pub struct Mempool {
+    state: Broadcast<String, String>,
+    best_block_hash: Hash,
+    sync_task_handle: tokio::task::JoinHandle<()>,
+    status: AtomicStatus,
+}
+
+impl Mempool {
+    pub fn spawn() -> Self {
+        todo!()
+    }
+}


### PR DESCRIPTION
Adds the new mempool implementation in zaino-state and underlying "Broadcast" struct.

 - Adds "Broadcast" struct that uses dashmap for efficient state distribution.
 - Adds Mempool struct to zaino-state
 - (Adds Memepool trait)
 - Adds Mempool to FetchService and implements remaining grpc methods for FetchService.

 - Closes https://github.com/zingolabs/zaino/issues/116, https://github.com/zingolabs/zaino/issues/117, https://github.com/zingolabs/zaino/issues/119, https://github.com/zingolabs/zaino/issues/121

 - Build atop Read state service #140, Get block range #142, Add Fetch service to Zaino-State #149, #150. As uses functionality in those PRs.