### PR TITLE
Compact block cache pt2

### DIFF
--- a/integration-tests/tests/wallet_to_validator.rs
+++ b/integration-tests/tests/wallet_to_validator.rs
@@ -21,7 +21,7 @@ mod wallet_basic {
     }
 
     async fn connect_to_node_get_info(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
         let clients = test_manager
@@ -46,7 +46,7 @@ mod wallet_basic {
     }
 
     async fn send_to_orchard(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
         let clients = test_manager
@@ -101,7 +101,7 @@ mod wallet_basic {
     }
 
     async fn send_to_sapling(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
         let clients = test_manager
@@ -157,7 +157,7 @@ mod wallet_basic {
     }
 
     async fn send_to_transparent(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
         let clients = test_manager
@@ -217,7 +217,6 @@ mod wallet_basic {
             )
             .await
             .unwrap();
-        
 
         dbg!(unfinalised_transactions.clone());
 
@@ -248,7 +247,6 @@ mod wallet_basic {
             250_000
         );
 
-
         assert_eq!(unfinalised_transactions, finalised_transactions);
         // test_manager.local_net.print_stdout();
 
@@ -266,7 +264,7 @@ mod wallet_basic {
     }
 
     async fn send_to_all(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
         let clients = test_manager
@@ -368,7 +366,7 @@ mod wallet_basic {
     }
 
     async fn shield(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
         let clients = test_manager
@@ -439,7 +437,7 @@ mod wallet_basic {
     }
 
     async fn monitor_unverified_mempool(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
         let clients = test_manager

--- a/zaino-state/src/config.rs
+++ b/zaino-state/src/config.rs
@@ -57,11 +57,29 @@ pub struct FetchServiceConfig {
     pub service_timeout: u32,
     /// StateService RPC max channel size.
     pub service_channel_size: u32,
+    /// Capacity of the Dashmaps used for the Mempool and BlockCache NonFinalisedState.
+    ///
+    /// NOTE: map_capacity and shard map must both be set for either to be used.
+    pub map_capacity: Option<usize>,
+    /// Number of shard used in the DashMap used for the Mempool and BlockCache NonFinalisedState.
+    ///
+    /// shard_amount should greater than 0 and be a power of two.
+    /// If a shard_amount which is not a power of two is provided, the function will panic.
+    ///
+    /// NOTE: map_capacity and shard map must both be set for either to be used.
+    pub map_shard_amount: Option<usize>,
+    /// Block Cache database file path.
+    pub db_path: PathBuf,
+    /// Block Cache database maximum size in gb.
+    pub db_size: Option<usize>,
     /// Network type.
     pub network: zebra_chain::parameters::Network,
     /// Disables internal sync and stops zaino waiting on server sync.
     /// Used for testing.
     pub no_sync: bool,
+    /// Disables FinalisedState.
+    /// Used for testing.
+    pub no_db: bool,
 }
 
 impl FetchServiceConfig {
@@ -72,8 +90,13 @@ impl FetchServiceConfig {
         validator_rpc_password: Option<String>,
         service_timeout: Option<u32>,
         service_channel_size: Option<u32>,
+        map_capacity: Option<usize>,
+        map_shard_amount: Option<usize>,
+        db_path: PathBuf,
+        db_size: Option<usize>,
         network: zebra_chain::parameters::Network,
         no_sync: bool,
+        no_db: bool,
     ) -> Self {
         FetchServiceConfig {
             validator_rpc_address,
@@ -82,8 +105,13 @@ impl FetchServiceConfig {
             // NOTE: This timeout is currently long to ease development but should be reduced before production.
             service_timeout: service_timeout.unwrap_or(60),
             service_channel_size: service_channel_size.unwrap_or(32),
+            map_capacity,
+            map_shard_amount,
+            db_path,
+            db_size,
             network,
             no_sync,
+            no_db,
         }
     }
 }

--- a/zaino-state/src/config.rs
+++ b/zaino-state/src/config.rs
@@ -58,15 +58,11 @@ pub struct FetchServiceConfig {
     /// StateService RPC max channel size.
     pub service_channel_size: u32,
     /// Capacity of the Dashmaps used for the Mempool and BlockCache NonFinalisedState.
-    ///
-    /// NOTE: map_capacity and shard map must both be set for either to be used.
     pub map_capacity: Option<usize>,
     /// Number of shard used in the DashMap used for the Mempool and BlockCache NonFinalisedState.
     ///
     /// shard_amount should greater than 0 and be a power of two.
     /// If a shard_amount which is not a power of two is provided, the function will panic.
-    ///
-    /// NOTE: map_capacity and shard map must both be set for either to be used.
     pub map_shard_amount: Option<usize>,
     /// Block Cache database file path.
     pub db_path: PathBuf,

--- a/zaino-state/src/error.rs
+++ b/zaino-state/src/error.rs
@@ -73,17 +73,9 @@ impl From<StateServiceError> for tonic::Status {
 /// Errors related to the `FetchService`.
 #[derive(Debug, thiserror::Error)]
 pub enum FetchServiceError {
-    /// Custom Errors. *Remove before production.
-    #[error("Custom error: {0}")]
-    Custom(String),
-
     /// Critical Errors, Restart Zaino.
     #[error("Critical error: {0}")]
     Critical(String),
-
-    /// Error from a Tokio JoinHandle.
-    #[error("Join error: {0}")]
-    JoinError(#[from] tokio::task::JoinError),
 
     /// Error from JsonRpcConnector.
     #[error("JsonRpcConnector error: {0}")]
@@ -120,24 +112,12 @@ pub enum FetchServiceError {
     /// Chain parse error.
     #[error("Chain parse error: {0}")]
     ChainParseError(#[from] zaino_fetch::chain::error::ParseError),
-
-    /// std::io::Error
-    #[error("IO error: {0}")]
-    IoError(#[from] std::io::Error),
-
-    /// A generic boxed error.
-    #[error("Generic error: {0}")]
-    Generic(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl From<FetchServiceError> for tonic::Status {
     fn from(error: FetchServiceError) -> Self {
         match error {
-            FetchServiceError::Custom(message) => tonic::Status::internal(message),
             FetchServiceError::Critical(message) => tonic::Status::internal(message),
-            FetchServiceError::JoinError(err) => {
-                tonic::Status::internal(format!("Join error: {}", err))
-            }
             FetchServiceError::JsonRpcConnectorError(err) => {
                 tonic::Status::internal(format!("JsonRpcConnector error: {}", err))
             }
@@ -163,12 +143,6 @@ impl From<FetchServiceError> for tonic::Status {
             FetchServiceError::ChainParseError(err) => {
                 tonic::Status::internal(format!("Chain parse error: {}", err))
             }
-            FetchServiceError::IoError(err) => {
-                tonic::Status::internal(format!("IO error: {}", err))
-            }
-            FetchServiceError::Generic(err) => {
-                tonic::Status::internal(format!("Generic error: {}", err))
-            }
         }
     }
 }
@@ -176,17 +150,9 @@ impl From<FetchServiceError> for tonic::Status {
 /// Errors related to the `Mempool`.
 #[derive(Debug, thiserror::Error)]
 pub enum MempoolError {
-    /// Custom Errors. *Remove before production.
-    #[error("Custom error: {0}")]
-    Custom(String),
-
     /// Critical Errors, Restart Zaino.
     #[error("Critical error: {0}")]
     Critical(String),
-
-    /// Error from a Tokio JoinHandle.
-    #[error("Join error: {0}")]
-    JoinError(#[from] tokio::task::JoinError),
 
     /// Error from JsonRpcConnector.
     #[error("JsonRpcConnector error: {0}")]
@@ -199,27 +165,6 @@ pub enum MempoolError {
     /// Unexpected status-related error.
     #[error("Status error: {0:?}")]
     StatusError(StatusError),
-
-    /// Error from sending to a Tokio MPSC channel.
-    #[error("Send error: {0}")]
-    SendError(
-        #[from]
-        tokio::sync::mpsc::error::SendError<
-            Result<(crate::mempool::MempoolKey, crate::mempool::MempoolValue), StatusError>,
-        >,
-    ),
-
-    /// UTF-8 conversion error.
-    #[error("UTF-8 conversion error: {0}")]
-    Utf8Error(#[from] std::str::Utf8Error),
-
-    /// Integer parsing error.
-    #[error("Integer parsing error: {0}")]
-    ParseIntError(#[from] std::num::ParseIntError),
-
-    /// A generic boxed error.
-    #[error("Generic error: {0}")]
-    Generic(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// Errors related to the `BlockCache`.
@@ -285,25 +230,9 @@ pub enum NonFinalisedStateError {
     #[error("JsonRpcConnector error: {0}")]
     JsonRpcConnectorError(#[from] zaino_fetch::jsonrpc::error::JsonRpcConnectorError),
 
-    /// Error from a Tokio Watch Reciever.
-    #[error("Join error: {0}")]
-    WatchRecvError(#[from] tokio::sync::watch::error::RecvError),
-
     /// Unexpected status-related error.
     #[error("Status error: {0:?}")]
     StatusError(StatusError),
-
-    /// Error from sending to a Tokio MPSC channel.
-    #[error("Send error: {0}")]
-    SendError(
-        #[from]
-        tokio::sync::mpsc::error::SendError<
-            Result<(crate::mempool::MempoolKey, crate::mempool::MempoolValue), StatusError>,
-        >,
-    ),
-    /// A generic boxed error.
-    #[error("Generic error: {0}")]
-    Generic(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// Errors related to the `FinalisedState`.
@@ -321,7 +250,7 @@ pub enum FinalisedStateError {
     #[error("Critical error: {0}")]
     Critical(String),
 
-    /// Error from the LLDM database.
+    /// Error from the LMDB database.
     #[error("LMDB database error: {0}")]
     LmdbError(#[from] lmdb::Error),
 
@@ -340,10 +269,6 @@ pub enum FinalisedStateError {
     /// std::io::Error
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
-
-    /// A generic boxed error.
-    #[error("Generic error: {0}")]
-    Generic(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// A general error type to represent error StatusTypes.

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -393,11 +393,7 @@ impl ZcashIndexer for FetchServiceSubscriber {
     ) -> Result<GetSubtrees, Self::Error> {
         Ok(self
             .fetcher
-            .get_subtrees_by_index(
-                pool,
-                start_index.0,
-                limit.map(|limit_index| limit_index.0),
-            )
+            .get_subtrees_by_index(pool, start_index.0, limit.map(|limit_index| limit_index.0))
             .await?
             .into())
     }
@@ -1863,9 +1859,10 @@ mod tests {
     }
 
     async fn launch_fetch_service(validator: &str, chain_cache: Option<std::path::PathBuf>) {
-        let mut test_manager = TestManager::launch(validator, None, chain_cache, false, false)
-            .await
-            .unwrap();
+        let mut test_manager =
+            TestManager::launch(validator, None, chain_cache, false, true, true, false)
+                .await
+                .unwrap();
 
         let fetch_service = FetchService::spawn(
             FetchServiceConfig::new(
@@ -1877,7 +1874,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -1901,7 +1908,7 @@ mod tests {
     }
 
     async fn fetch_service_get_address_balance(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -1932,7 +1939,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -1965,7 +1982,7 @@ mod tests {
     }
 
     async fn fetch_service_get_block_raw(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, false, false)
+        let mut test_manager = TestManager::launch(validator, None, None, false, true, true, false)
             .await
             .unwrap();
 
@@ -1979,7 +1996,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2003,7 +2030,7 @@ mod tests {
     }
 
     async fn fetch_service_get_block_object(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, false, false)
+        let mut test_manager = TestManager::launch(validator, None, None, false, true, true, false)
             .await
             .unwrap();
 
@@ -2017,7 +2044,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2041,7 +2078,7 @@ mod tests {
     }
 
     async fn fetch_service_get_raw_mempool(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
         let clients = test_manager
@@ -2062,7 +2099,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2121,7 +2168,7 @@ mod tests {
     }
 
     async fn fetch_service_z_get_treestate(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -2154,7 +2201,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2178,7 +2235,7 @@ mod tests {
     }
 
     async fn fetch_service_z_get_subtrees_by_index(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -2211,7 +2268,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2235,7 +2302,7 @@ mod tests {
     }
 
     async fn fetch_service_get_raw_transaction(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -2268,7 +2335,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2292,7 +2369,7 @@ mod tests {
     }
 
     async fn fetch_service_get_address_tx_ids(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -2321,7 +2398,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2353,7 +2440,7 @@ mod tests {
     }
 
     async fn fetch_service_get_address_utxos(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -2383,7 +2470,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2412,7 +2509,7 @@ mod tests {
     }
 
     async fn fetch_service_get_latest_block(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -2426,7 +2523,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2450,7 +2557,7 @@ mod tests {
     }
 
     async fn fetch_service_get_block(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -2464,7 +2571,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2493,7 +2610,7 @@ mod tests {
     }
 
     async fn fetch_service_get_block_nullifiers(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -2507,7 +2624,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2538,7 +2665,7 @@ mod tests {
     }
 
     async fn fetch_service_get_block_range(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
         test_manager.local_net.generate_blocks(10).await.unwrap();
@@ -2553,7 +2680,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2596,7 +2733,7 @@ mod tests {
     }
 
     async fn fetch_service_get_block_range_nullifiers(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
         test_manager.local_net.generate_blocks(10).await.unwrap();
@@ -2611,7 +2748,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2654,7 +2801,7 @@ mod tests {
     }
 
     async fn fetch_service_get_transaction_mined(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -2673,7 +2820,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2719,7 +2876,7 @@ mod tests {
     }
 
     async fn fetch_service_get_transaction_mempool(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -2738,7 +2895,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2783,7 +2950,7 @@ mod tests {
     }
 
     async fn fetch_service_get_taddress_txids(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -2803,7 +2970,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2859,7 +3036,7 @@ mod tests {
     }
 
     async fn fetch_service_get_taddress_balance(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -2879,7 +3056,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -2924,7 +3111,7 @@ mod tests {
     }
 
     async fn fetch_service_get_mempool_tx(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
         let clients = test_manager
@@ -2942,7 +3129,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -3033,7 +3230,7 @@ mod tests {
     }
 
     async fn fetch_service_get_mempool_stream(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -3052,7 +3249,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -3115,7 +3322,7 @@ mod tests {
     }
 
     async fn fetch_service_get_tree_state(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -3129,7 +3336,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -3160,7 +3377,7 @@ mod tests {
     }
 
     async fn fetch_service_get_latest_tree_state(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -3174,7 +3391,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -3195,7 +3422,7 @@ mod tests {
     }
 
     async fn fetch_service_get_subtree_roots(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -3209,7 +3436,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -3247,7 +3484,7 @@ mod tests {
     }
 
     async fn fetch_service_get_taddress_utxos(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -3267,7 +3504,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -3309,7 +3556,7 @@ mod tests {
     }
 
     async fn fetch_service_get_taddress_utxos_stream(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -3329,7 +3576,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),
@@ -3376,7 +3633,7 @@ mod tests {
     }
 
     async fn fetch_service_get_lightd_info(validator: &str) {
-        let mut test_manager = TestManager::launch(validator, None, None, true, true)
+        let mut test_manager = TestManager::launch(validator, None, None, true, true, true, true)
             .await
             .unwrap();
 
@@ -3390,7 +3647,17 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None,
+                test_manager
+                    .local_net
+                    .data_dir()
+                    .path()
+                    .to_path_buf()
+                    .join("zaino"),
+                None,
                 Network::new_regtest(Some(1), Some(1)),
+                true,
                 true,
             ),
             AtomicStatus::new(StatusType::Spawning.into()),

--- a/zaino-state/src/local_cache.rs
+++ b/zaino-state/src/local_cache.rs
@@ -18,6 +18,7 @@ use zebra_state::HashOrHeight;
 /// Zaino's internal compact block cache.
 ///
 /// Used by the FetchService for efficiency.
+#[derive(Debug)]
 pub struct BlockCache {
     fetcher: JsonRpcConnector,
     non_finalised_state: NonFinalisedState,

--- a/zaino-state/src/local_cache/finalised_state.rs
+++ b/zaino-state/src/local_cache/finalised_state.rs
@@ -54,6 +54,7 @@ impl<'de> Deserialize<'de> for DbCompactBlock {
 }
 
 /// A Zaino database request.
+#[derive(Debug)]
 struct DbRequest {
     hash_or_height: HashOrHeight,
     response_channel: tokio::sync::oneshot::Sender<Result<CompactBlock, FinalisedStateError>>,
@@ -73,6 +74,7 @@ impl DbRequest {
 }
 
 /// Fanalised part of the chain, held in an LMDB database.
+#[derive(Debug)]
 pub struct FinalisedState {
     /// Chain fetch service.
     fetcher: JsonRpcConnector,
@@ -102,7 +104,6 @@ impl FinalisedState {
     /// - db_path: File path of the db.
     /// - db_size: Max size of the db in gb.
     /// - block_reciever: Channel that recieves new blocks to add to the db.
-    /// - status: FinalisedState status.
     pub async fn spawn(
         fetcher: &JsonRpcConnector,
         block_receiver: tokio::sync::mpsc::Receiver<(Height, Hash, CompactBlock)>,

--- a/zaino-state/src/local_cache/finalised_state.rs
+++ b/zaino-state/src/local_cache/finalised_state.rs
@@ -180,7 +180,7 @@ impl FinalisedState {
                 loop {
                     match finalised_state.insert_block((height, hash, compact_block.clone())) {
                         Ok(_) => {
-                            println!("✅ Block at height {} successfully inserted.", height.0);
+                            println!("Block at height {} successfully inserted.", height.0);
                             break;
                         }
                         Err(FinalisedStateError::LmdbError(lmdb::Error::KeyExist)) => {
@@ -196,7 +196,7 @@ impl FinalisedState {
                                         continue;
                                     } else {
                                         println!(
-                                            "⚠️ Block at height {} already exists, skipping.",
+                                            "Block at height {} already exists, skipping.",
                                             height.0
                                         );
                                         break;
@@ -211,7 +211,7 @@ impl FinalisedState {
                             }
                         }
                         Err(FinalisedStateError::LmdbError(db_err)) => {
-                            eprintln!("❌ LMDB error inserting block {}: {:?}", height.0, db_err);
+                            eprintln!("LMDB error inserting block {}: {:?}", height.0, db_err);
                             finalised_state
                                 .status
                                 .store(StatusType::CriticalError.into());
@@ -219,13 +219,13 @@ impl FinalisedState {
                         }
                         Err(e) => {
                             eprintln!(
-                                "⚠️ Unknown error inserting block {}: {:?}. Retrying...",
+                                "Unknown error inserting block {}: {:?}. Retrying...",
                                 height.0, e
                             );
 
                             if retry_attempts == 0 {
                                 eprintln!(
-                                    "❌ Failed to insert block {} after multiple retries.",
+                                    "Failed to insert block {} after multiple retries.",
                                     height.0
                                 );
                                 finalised_state
@@ -244,7 +244,7 @@ impl FinalisedState {
                             {
                                 Ok((new_hash, new_compact_block)) => {
                                     eprintln!(
-                                        "🔄 Re-fetched block at height {}, retrying insert.",
+                                        "Re-fetched block at height {}, retrying insert.",
                                         height.0
                                     );
                                     hash = new_hash;
@@ -252,7 +252,7 @@ impl FinalisedState {
                                 }
                                 Err(fetch_err) => {
                                     eprintln!(
-                                        "❌ Failed to fetch block {} from validator: {:?}",
+                                        "Failed to fetch block {} from validator: {:?}",
                                         height.0, fetch_err
                                     );
                                     finalised_state
@@ -589,7 +589,7 @@ impl FinalisedState {
         }
 
         if let Err(e) = self.database.sync(true) {
-            eprintln!("❌ Error syncing LMDB before shutdown: {:?}", e);
+            eprintln!("Error syncing LMDB before shutdown: {:?}", e);
         }
     }
 }
@@ -605,7 +605,7 @@ impl Drop for FinalisedState {
         }
 
         if let Err(e) = self.database.sync(true) {
-            eprintln!("❌ Error syncing LMDB before shutdown: {:?}", e);
+            eprintln!("Error syncing LMDB before shutdown: {:?}", e);
         }
     }
 }

--- a/zaino-state/src/local_cache/non_finalised_state.rs
+++ b/zaino-state/src/local_cache/non_finalised_state.rs
@@ -44,19 +44,10 @@ impl NonFinalisedState {
         config: BlockCacheConfig,
     ) -> Result<Self, NonFinalisedStateError> {
         println!("Launching Non-Finalised State..");
-        let (heights_to_hashes, hashes_to_blocks) =
-            match (config.map_capacity, config.map_shard_amount) {
-                (Some(capacity), Some(shard_amount)) => (
-                    Broadcast::new_custom(capacity, shard_amount),
-                    Broadcast::new_custom(capacity, shard_amount),
-                ),
-                _ => (Broadcast::new_default(), Broadcast::new_default()),
-            };
-
         let mut non_finalised_state = NonFinalisedState {
             fetcher: fetcher.clone(),
-            heights_to_hashes,
-            hashes_to_blocks,
+            heights_to_hashes: Broadcast::new(config.map_capacity, config.map_shard_amount),
+            hashes_to_blocks: Broadcast::new(config.map_capacity, config.map_shard_amount),
             sync_task_handle: None,
             block_sender,
             status: AtomicStatus::new(StatusType::Spawning.into()),

--- a/zaino-state/src/local_cache/non_finalised_state.rs
+++ b/zaino-state/src/local_cache/non_finalised_state.rs
@@ -393,20 +393,6 @@ impl Drop for NonFinalisedState {
     }
 }
 
-// impl Clone for NonFinalisedState {
-//     fn clone(&self) -> Self {
-//         Self {
-//             fetcher: self.fetcher.clone(),
-//             heights_to_hashes: self.heights_to_hashes.clone(),
-//             hashes_to_blocks: self.hashes_to_blocks.clone(),
-//             sync_task_handle: None,
-//             block_sender: self.block_sender.clone(),
-//             status: self.status.clone(),
-//             config: self.config.clone(),
-//         }
-//     }
-// }
-
 /// A subscriber to a [`NonFinalisedState`].
 #[derive(Debug, Clone)]
 pub struct NonFinalisedStateSubscriber {

--- a/zaino-state/src/local_cache/non_finalised_state.rs
+++ b/zaino-state/src/local_cache/non_finalised_state.rs
@@ -111,7 +111,15 @@ impl NonFinalisedState {
     }
 
     async fn serve(&self) -> Result<tokio::task::JoinHandle<()>, NonFinalisedStateError> {
-        let non_finalised_state = self.clone();
+        let non_finalised_state = Self {
+            fetcher: self.fetcher.clone(),
+            heights_to_hashes: self.heights_to_hashes.clone(),
+            hashes_to_blocks: self.hashes_to_blocks.clone(),
+            sync_task_handle: None,
+            block_sender: self.block_sender.clone(),
+            status: self.status.clone(),
+            config: self.config.clone(),
+        };
 
         let sync_handle = tokio::spawn(async move {
             let mut best_block_hash: Hash;
@@ -385,19 +393,19 @@ impl Drop for NonFinalisedState {
     }
 }
 
-impl Clone for NonFinalisedState {
-    fn clone(&self) -> Self {
-        Self {
-            fetcher: self.fetcher.clone(),
-            heights_to_hashes: self.heights_to_hashes.clone(),
-            hashes_to_blocks: self.hashes_to_blocks.clone(),
-            sync_task_handle: None,
-            block_sender: self.block_sender.clone(),
-            status: self.status.clone(),
-            config: self.config.clone(),
-        }
-    }
-}
+// impl Clone for NonFinalisedState {
+//     fn clone(&self) -> Self {
+//         Self {
+//             fetcher: self.fetcher.clone(),
+//             heights_to_hashes: self.heights_to_hashes.clone(),
+//             hashes_to_blocks: self.hashes_to_blocks.clone(),
+//             sync_task_handle: None,
+//             block_sender: self.block_sender.clone(),
+//             status: self.status.clone(),
+//             config: self.config.clone(),
+//         }
+//     }
+// }
 
 /// A subscriber to a [`NonFinalisedState`].
 #[derive(Debug, Clone)]

--- a/zaino-state/src/mempool.rs
+++ b/zaino-state/src/mempool.rs
@@ -61,8 +61,10 @@ impl Mempool {
         let mut mempool = Mempool {
             fetcher: fetcher.clone(),
             state: match capacity_and_shard_amount {
-                Some((capacity, shard_amount)) => Broadcast::new_custom(capacity, shard_amount),
-                None => Broadcast::new_default(),
+                Some((capacity, shard_amount)) => {
+                    Broadcast::new(Some(capacity), Some(shard_amount))
+                }
+                None => Broadcast::new(None, None),
             },
             sync_task_handle: None,
             status: AtomicStatus::new(StatusType::Spawning.into()),

--- a/zaino-state/src/state.rs
+++ b/zaino-state/src/state.rs
@@ -1071,7 +1071,7 @@ mod tests {
 
     #[tokio::test]
     async fn launch_state_regtest_service_no_cache() {
-        let mut test_manager = TestManager::launch("zebrad", None, None, false, false)
+        let mut test_manager = TestManager::launch("zebrad", None, None, false, true, true, false)
             .await
             .unwrap();
 
@@ -1106,10 +1106,17 @@ mod tests {
 
     #[tokio::test]
     async fn launch_state_regtest_service_with_cache() {
-        let mut test_manager =
-            TestManager::launch("zebrad", None, ZEBRAD_CHAIN_CACHE_BIN.clone(), false, false)
-                .await
-                .unwrap();
+        let mut test_manager = TestManager::launch(
+            "zebrad",
+            None,
+            ZEBRAD_CHAIN_CACHE_BIN.clone(),
+            false,
+            true,
+            true,
+            false,
+        )
+        .await
+        .unwrap();
 
         let state_service = StateService::spawn(StateServiceConfig::new(
             zebra_state::Config {
@@ -1142,10 +1149,17 @@ mod tests {
 
     #[tokio::test]
     async fn state_service_regtest_get_info() {
-        let mut test_manager =
-            TestManager::launch("zebrad", None, ZEBRAD_CHAIN_CACHE_BIN.clone(), false, false)
-                .await
-                .unwrap();
+        let mut test_manager = TestManager::launch(
+            "zebrad",
+            None,
+            ZEBRAD_CHAIN_CACHE_BIN.clone(),
+            false,
+            true,
+            true,
+            false,
+        )
+        .await
+        .unwrap();
 
         let state_service = StateService::spawn(StateServiceConfig::new(
             zebra_state::Config {
@@ -1199,10 +1213,17 @@ mod tests {
 
     #[tokio::test]
     async fn state_service_regtest_get_blockchain_info() {
-        let mut test_manager =
-            TestManager::launch("zebrad", None, ZEBRAD_CHAIN_CACHE_BIN.clone(), false, false)
-                .await
-                .unwrap();
+        let mut test_manager = TestManager::launch(
+            "zebrad",
+            None,
+            ZEBRAD_CHAIN_CACHE_BIN.clone(),
+            false,
+            true,
+            true,
+            false,
+        )
+        .await
+        .unwrap();
 
         let state_service = StateService::spawn(StateServiceConfig::new(
             zebra_state::Config {
@@ -1277,7 +1298,7 @@ mod tests {
     /// Bug documented in https://github.com/zingolabs/zaino/issues/146.
     #[tokio::test]
     async fn state_service_get_blockchain_info_no_cache() {
-        let mut test_manager = TestManager::launch("zebrad", None, None, false, false)
+        let mut test_manager = TestManager::launch("zebrad", None, None, false, true, true, false)
             .await
             .unwrap();
         test_manager.local_net.generate_blocks(1).await.unwrap();
@@ -1365,10 +1386,17 @@ mod tests {
 
     #[tokio::test]
     async fn state_service_regtest_get_block_raw() {
-        let mut test_manager =
-            TestManager::launch("zebrad", None, ZEBRAD_CHAIN_CACHE_BIN.clone(), false, false)
-                .await
-                .unwrap();
+        let mut test_manager = TestManager::launch(
+            "zebrad",
+            None,
+            ZEBRAD_CHAIN_CACHE_BIN.clone(),
+            false,
+            true,
+            true,
+            false,
+        )
+        .await
+        .unwrap();
 
         let state_service = StateService::spawn(StateServiceConfig::new(
             zebra_state::Config {
@@ -1431,10 +1459,17 @@ mod tests {
 
     #[tokio::test]
     async fn state_service_regtest_get_block_object() {
-        let mut test_manager =
-            TestManager::launch("zebrad", None, ZEBRAD_CHAIN_CACHE_BIN.clone(), false, false)
-                .await
-                .unwrap();
+        let mut test_manager = TestManager::launch(
+            "zebrad",
+            None,
+            ZEBRAD_CHAIN_CACHE_BIN.clone(),
+            false,
+            true,
+            true,
+            false,
+        )
+        .await
+        .unwrap();
 
         let state_service = StateService::spawn(StateServiceConfig::new(
             zebra_state::Config {
@@ -1528,10 +1563,17 @@ mod tests {
     /// WARNING: This tests needs refactoring due to code removed in zaino-state.
     #[tokio::test]
     async fn state_service_regtest_get_block_compact() {
-        let mut test_manager =
-            TestManager::launch("zebrad", None, ZEBRAD_CHAIN_CACHE_BIN.clone(), false, false)
-                .await
-                .unwrap();
+        let mut test_manager = TestManager::launch(
+            "zebrad",
+            None,
+            ZEBRAD_CHAIN_CACHE_BIN.clone(),
+            false,
+            true,
+            true,
+            false,
+        )
+        .await
+        .unwrap();
 
         let state_service = StateService::spawn(StateServiceConfig::new(
             zebra_state::Config {
@@ -1577,10 +1619,17 @@ mod tests {
     /// WARNING: This tests needs refactoring due to code removed in zaino-state.
     #[tokio::test]
     async fn state_service_regtest_get_block_range() {
-        let mut test_manager =
-            TestManager::launch("zebrad", None, ZEBRAD_CHAIN_CACHE_BIN.clone(), false, false)
-                .await
-                .unwrap();
+        let mut test_manager = TestManager::launch(
+            "zebrad",
+            None,
+            ZEBRAD_CHAIN_CACHE_BIN.clone(),
+            false,
+            true,
+            true,
+            false,
+        )
+        .await
+        .unwrap();
         let block_range = BlockRange {
             start: Some(BlockId {
                 height: 50,
@@ -1643,6 +1692,8 @@ mod tests {
             Some(zcash_local_net::network::Network::Testnet),
             ZEBRAD_TESTNET_CACHE_BIN.clone(),
             false,
+            true,
+            true,
             false,
         )
         .await

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -357,8 +357,7 @@ impl TestManager {
             let zaino_grpc_listen_port = portpicker::pick_unused_port().expect("No ports free");
             // NOTE: queue and workerpool sizes may need to be changed here.
             let indexer_config = zainodlib::config::IndexerConfig {
-                tcp_active: true,
-                listen_port: Some(zaino_grpc_listen_port),
+                listen_port: zaino_grpc_listen_port,
                 zebrad_port: zebrad_rpc_listen_port,
                 node_user: Some("xxxxxx".to_string()),
                 node_password: Some("xxxxxx".to_string()),

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -374,6 +374,7 @@ impl TestManager {
                 network: network.to_string(),
                 no_sync: zaino_no_sync,
                 no_db: zaino_no_db,
+                no_state: false,
             };
             let handle = zainodlib::indexer::Indexer::new(indexer_config, online.clone())
                 .await

--- a/zainod/src/config.rs
+++ b/zainod/src/config.rs
@@ -51,6 +51,12 @@ pub struct IndexerConfig {
     /// Disables FinalisedState.
     /// Used for testing.
     pub no_db: bool,
+    /// Disables internal mempool and blockcache.
+    ///
+    /// For use by lightweight wallets that do not want to run any extra processes.
+    ///
+    /// NOTE: Currently unimplemented as will require either a Tonic backend or a JsonRPC server.
+    pub no_state: bool,
 }
 
 impl IndexerConfig {
@@ -101,6 +107,7 @@ impl Default for IndexerConfig {
             network: "Testnet".to_string(),
             no_sync: false,
             no_db: false,
+            no_state: false,
         }
     }
 }

--- a/zainod/src/config.rs
+++ b/zainod/src/config.rs
@@ -12,9 +12,9 @@ pub struct IndexerConfig {
     pub listen_port: u16,
     /// Full node / validator listen port.
     pub zebrad_port: u16,
-    /// Full node Username.
+    /// Full node / validator Username.
     pub node_user: Option<String>,
-    /// full node Password.
+    /// full node / validator Password.
     pub node_password: Option<String>,
     /// Maximum requests allowed in the request queue.
     pub max_queue_size: u16,
@@ -43,7 +43,7 @@ pub struct IndexerConfig {
     ///
     /// Only used by the FetchService.
     pub db_size: Option<usize>,
-    /// StateService network type.
+    /// Network chain type (Mainnet, Testnet, Regtest).
     pub network: String,
     /// Disables internal sync and stops zaino waiting on server sync.
     /// Used for testing.

--- a/zainod/src/config.rs
+++ b/zainod/src/config.rs
@@ -1,14 +1,15 @@
 //! Zaino config.
 
+use std::path::PathBuf;
+
 use crate::error::IndexerError;
 
 /// Config information required for Zaino.
 #[derive(Debug, Clone, serde::Deserialize)]
+#[serde(default)]
 pub struct IndexerConfig {
-    /// Sets the TcpIngestor's status.
-    pub tcp_active: bool,
     /// TcpIngestors listen port
-    pub listen_port: Option<u16>,
+    pub listen_port: u16,
     /// Full node / validator listen port.
     pub zebrad_port: u16,
     /// Full node Username.
@@ -21,8 +22,35 @@ pub struct IndexerConfig {
     pub max_worker_pool_size: u16,
     /// Minimum number of workers held in the workerpool when idle.
     pub idle_worker_pool_size: u16,
+    /// Capacity of the Dashmaps used for the Mempool.
+    /// Also use by the BlockCache::NonFinalisedState when using the FetchService.
+    ///
+    /// NOTE: map_capacity and shard map must both be set for either to be used.
+    pub map_capacity: Option<usize>,
+    /// Number of shard used in the DashMap used for the Mempool.
+    /// Also use by the BlockCache::NonFinalisedState when using the FetchService.
+    ///
+    /// shard_amount should greater than 0 and be a power of two.
+    /// If a shard_amount which is not a power of two is provided, the function will panic.
+    ///
+    /// NOTE: map_capacity and shard map must both be set for either to be used.
+    pub map_shard_amount: Option<usize>,
+    /// Block Cache database file path.
+    ///
+    /// This is Zaino's Compact Block Cache db if using the FetchService or Zebra's RocksDB if using the StateService.
+    pub db_path: PathBuf,
+    /// Block Cache database maximum size in gb.
+    ///
+    /// Only used by the FetchService.
+    pub db_size: Option<usize>,
     /// StateService network type.
     pub network: String,
+    /// Disables internal sync and stops zaino waiting on server sync.
+    /// Used for testing.
+    pub no_sync: bool,
+    /// Disables FinalisedState.
+    /// Used for testing.
+    pub no_db: bool,
 }
 
 impl IndexerConfig {
@@ -31,16 +59,6 @@ impl IndexerConfig {
     /// - Checks that at least 1 ingestor is active.
     /// - Checks listen port is given is tcp is active.
     pub(crate) fn check_config(&self) -> Result<(), IndexerError> {
-        if !self.tcp_active {
-            return Err(IndexerError::ConfigError(
-                "Cannot start server with no ingestors selected.".to_string(),
-            ));
-        }
-        if self.tcp_active && self.listen_port.is_none() {
-            return Err(IndexerError::ConfigError(
-                "TCP is active but no address provided.".to_string(),
-            ));
-        }
         if (self.network != "Regtest") && (self.network != "Testnet") && (self.network != "Mainnet")
         {
             return Err(IndexerError::ConfigError(
@@ -50,7 +68,7 @@ impl IndexerConfig {
         Ok(())
     }
 
-    ///
+    /// Returns the network type currently being used by the server.
     pub fn get_network(&self) -> Result<zebra_chain::parameters::Network, IndexerError> {
         match self.network.as_str() {
             "Regtest" => Ok(zebra_chain::parameters::Network::new_regtest(
@@ -59,11 +77,9 @@ impl IndexerConfig {
             )),
             "Testnet" => Ok(zebra_chain::parameters::Network::new_default_testnet()),
             "Mainnet" => Ok(zebra_chain::parameters::Network::Mainnet),
-            _ => {
-                Err(IndexerError::ConfigError(
-                    "Incorrect network name given.".to_string(),
-                ))
-            }
+            _ => Err(IndexerError::ConfigError(
+                "Incorrect network name given.".to_string(),
+            )),
         }
     }
 }
@@ -71,38 +87,38 @@ impl IndexerConfig {
 impl Default for IndexerConfig {
     fn default() -> Self {
         Self {
-            tcp_active: true,
-            listen_port: Some(8080),
+            listen_port: 8137,
             zebrad_port: 18232,
             node_user: Some("xxxxxx".to_string()),
             node_password: Some("xxxxxx".to_string()),
             max_queue_size: 1024,
             max_worker_pool_size: 32,
             idle_worker_pool_size: 4,
-            network: "Regtest".to_string(),
+            map_capacity: None,
+            map_shard_amount: None,
+            db_path: default_db_path(),
+            db_size: None,
+            network: "Testnet".to_string(),
+            no_sync: false,
+            no_db: false,
         }
     }
 }
 
-/// Attempts to load config data from a toml file at the specified path.
-pub fn load_config(file_path: &std::path::PathBuf) -> IndexerConfig {
-    let mut config = IndexerConfig::default();
-
-    if let Ok(contents) = std::fs::read_to_string(file_path) {
-        if let Ok(parsed_config) = toml::from_str::<IndexerConfig>(&contents) {
-            config = IndexerConfig {
-                tcp_active: parsed_config.tcp_active,
-                listen_port: parsed_config.listen_port.or(config.listen_port),
-                zebrad_port: parsed_config.zebrad_port,
-                node_user: parsed_config.node_user.or(config.node_user),
-                node_password: parsed_config.node_password.or(config.node_password),
-                max_queue_size: parsed_config.max_queue_size,
-                max_worker_pool_size: parsed_config.max_worker_pool_size,
-                idle_worker_pool_size: parsed_config.idle_worker_pool_size,
-                network: parsed_config.network,
-            };
-        }
+/// Loads the default file path for zaino's local db.
+fn default_db_path() -> PathBuf {
+    match std::env::var("HOME") {
+        Ok(home) => PathBuf::from(home).join(".cache").join("zaino"),
+        Err(_) => PathBuf::from("/tmp").join("zaino"),
     }
+}
 
-    config
+/// Attempts to load config data from a toml file at the specified path else returns a default config.
+pub fn load_config(file_path: &std::path::PathBuf) -> IndexerConfig {
+    if let Ok(contents) = std::fs::read_to_string(file_path) {
+        toml::from_str::<IndexerConfig>(&contents).unwrap_or_default()
+    } else {
+        eprintln!("Could not find config file at given path, using default config.");
+        IndexerConfig::default()
+    }
 }

--- a/zainod/src/indexer.rs
+++ b/zainod/src/indexer.rs
@@ -73,18 +73,14 @@ impl Indexer {
         set_ctrlc(online.clone());
         startup_message();
         println!("Launching Zaino..");
-        let indexer: Indexer = Indexer::new(config, online.clone(), false).await?;
+        let indexer: Indexer = Indexer::new(config, online.clone()).await?;
         indexer.serve().await?.await?
     }
 
     /// Creates a new Indexer.
     ///
     /// Currently only takes an IndexerConfig.
-    pub async fn new(
-        config: IndexerConfig,
-        online: Arc<AtomicBool>,
-        no_sync: bool,
-    ) -> Result<Self, IndexerError> {
+    pub async fn new(config: IndexerConfig, online: Arc<AtomicBool>) -> Result<Self, IndexerError> {
         config.check_config()?;
         let status = IndexerStatus::new(config.max_worker_pool_size);
         let tcp_ingestor_listen_addr = SocketAddr::new(
@@ -109,12 +105,17 @@ impl Indexer {
                     std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
                     config.zebrad_port,
                 ),
+                config.node_user.clone(),
+                config.node_password.clone(),
                 None,
                 None,
-                None,
-                None,
+                config.map_capacity,
+                config.map_shard_amount,
+                config.db_path.clone(),
+                config.db_size,
                 config.get_network()?,
-                no_sync,
+                config.no_sync,
+                config.no_db,
             ),
             status.service_status.clone(),
         )

--- a/zainod/src/indexer.rs
+++ b/zainod/src/indexer.rs
@@ -87,9 +87,10 @@ impl Indexer {
     ) -> Result<Self, IndexerError> {
         config.check_config()?;
         let status = IndexerStatus::new(config.max_worker_pool_size);
-        let tcp_ingestor_listen_addr: Option<SocketAddr> = config
-            .listen_port
-            .map(|port| SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), port));
+        let tcp_ingestor_listen_addr = SocketAddr::new(
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            config.listen_port,
+        );
         println!("Checking connection with node..");
         let zebrad_uri = test_node_and_return_uri(
             &config.zebrad_port,
@@ -121,7 +122,6 @@ impl Indexer {
         let server = Some(
             Server::spawn(
                 service.inner_ref().get_subscriber(),
-                config.tcp_active,
                 tcp_ingestor_listen_addr,
                 config.max_queue_size,
                 config.max_worker_pool_size,
@@ -157,12 +157,7 @@ impl Indexer {
             };
 
             self.status.indexer_status.store(StatusType::Ready.into());
-            println!(
-                "Zaino listening on port {:?}.",
-                self.config
-                    .listen_port
-                    .expect("Error fetching Zaino's listen prot from config.")
-            );
+            println!("Zaino listening on port {:?}.", self.config.listen_port);
             loop {
                 self.status.load();
                 // indexer.log_status();

--- a/zainod/zindexer.toml
+++ b/zainod/zindexer.toml
@@ -55,10 +55,10 @@ network = "Testnet"
     
 # Disables internal sync and stops zaino waiting on server to sync with p2p network.
 # Useful for testing.
-no_sync = false,
+no_sync = false
   
 # Disables the FinalisedState in the BlockCache 
 # 
 # Only used by the FetchServic.
 # Used for testing.
-no_db = false,
+no_db = false

--- a/zainod/zindexer.toml
+++ b/zainod/zindexer.toml
@@ -1,28 +1,64 @@
 # Configuration for Zaino
 
-# Sets the TcpIngestor's status (true or false)
-tcp_active = true
-
-# Optional TcpIngestors listen port (use None or specify a port number)
+# Zainod's gRPC server listen port.
 listen_port = 8137
 
-# Full node / validator listen port
+# Full node / validator listen port.
 zebrad_port = 18232
 
-# Optional full node Username
+# Optional full node / validator Username.
 node_user = "xxxxxx"
 
-# Optional full node Password
+# Optional full node / validator Password.
 node_password = "xxxxxx"
 
-# Maximum requests allowed in the request queue
+# Maximum requests allowed in Zainod's request queue.
 max_queue_size = 1024
 
-# Maximum workers allowed in the worker pool
+# Maximum workers allowed in Zainod's worker pool.
 max_worker_pool_size = 64
 
-# Minimum number of workers held in the worker pool when idle
+# Minimum number of workers maintained in the worker pool when idle.
 idle_worker_pool_size = 4
 
-# Network chain type (Mainnet, Testnet, Regtest)
+# Capacity of the Dashmaps used for the Mempool.
+# Also use by the BlockCache::NonFinalisedState when using the FetchService.
+# 
+# None by default.
+# map_capacity = None
+
+# Number of shard used in the DashMap used for the Mempool.
+# Also use by the BlockCache::NonFinalisedState when using the FetchService.
+#
+# shard_amount should greater than 0 and be a power of two.
+# If a shard_amount which is not a power of two is provided, the function will panic.
+#
+# None by default.
+# map_shard_amount = None
+    
+# Block Cache database file path.
+#
+# This is Zaino's Compact Block Cache db if using the FetchService or Zebra's RocksDB if using the StateService.
+#
+# None by default, this defaults to `$HOME/.cache/zaino/`
+# db_path = None
+    
+# Block Cache database maximum size in gb.
+#
+# Only used by the FetchService.
+# 
+# None by default
+# db_size = None
+    
+# Network chain type (Mainnet, Testnet, Regtest).
 network = "Testnet"
+    
+# Disables internal sync and stops zaino waiting on server to sync with p2p network.
+# Useful for testing.
+no_sync = false,
+  
+# Disables the FinalisedState in the BlockCache 
+# 
+# Only used by the FetchServic.
+# Used for testing.
+no_db = false,

--- a/zainod/zindexer.toml
+++ b/zainod/zindexer.toml
@@ -62,3 +62,11 @@ no_sync = false
 # Only used by the FetchServic.
 # Used for testing.
 no_db = false
+
+# Disables internal mempool and blockcache.
+#
+# For use by lightweight wallets that do not want to run any extra processes.
+#
+# NOTE: Currently unimplemented as will require either a Tonic backend or a JsonRPC server.
+# no_state = false
+    


### PR DESCRIPTION
This is the second PR adding the internal compact block cache to the FetchService in zaino-state. 

- Updates Zaino's config files and example config (zindexer.toml) by adding the new options required for integrating the BlockCache into the FetchService.
- Removes old (unused) config options.
- Updates Zaino-Testutils TestManager to handle new config options.
- Adds several review changes to the BlockCache.

The actual BlockCache integration will be done in the following PR.