### PR TITLE
Compact block cache pt3

### DIFF
--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -12,7 +12,7 @@
 3) Run `$ zebrad --config #PATH_TO_CONF/zebrad.toml start`
 4) Run `$ zainod --config #PATH_TO_CONF/zindexer.toml`
 
-NOTE: Unless the `no_db` option is set to true in the config file zaino will sync its internal `CompactBlock` cache with the validator it is connected to on launch. This can be a very slow process the first time Zaino's DB is synced with a new chain and zaino will not be operable until the database is fully synced. If Zaino exits durin this process the database is saved in its current state, enabling the chain to be synced in several stages.
+NOTE: Unless the `no_db` option is set to true in the config file zaino will sync its internal `CompactBlock` cache with the validator it is connected to on launch. This can be a very slow process the first time Zaino's DB is synced with a new chain and zaino will not be operable until the database is fully synced. If Zaino exits during this process the database is saved in its current state, enabling the chain to be synced in several stages.
 
 - To launch Zingo-Cli running through Zaino [from #PATH_TO/zingolib]:
 5) Run `$ cargo run --release --package zingo-cli -- --chain "CHAIN_TYPE" --server "ZAINO_LISTEN_ADDR" --data-dir #PATH_TO_WALLET_DATA_DIR`

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -12,7 +12,7 @@
 3) Run `$ zebrad --config #PATH_TO_CONF/zebrad.toml start`
 4) Run `$ zainod --config #PATH_TO_CONF/zindexer.toml`
 
-NOTE: Unless the `no_db` option if set to true in the config file zaino will sync its internal `CompactBlock` cache with the validator it is connected to on launch. This can be a very slow process the first time Zaino's DB is synced with a new chain and zaino will not be operable until the database is fully synced. If Zaino exits durin this process the database is saved in its current state, enabling the chain to be synced in several stages.
+NOTE: Unless the `no_db` option is set to true in the config file zaino will sync its internal `CompactBlock` cache with the validator it is connected to on launch. This can be a very slow process the first time Zaino's DB is synced with a new chain and zaino will not be operable until the database is fully synced. If Zaino exits durin this process the database is saved in its current state, enabling the chain to be synced in several stages.
 
 - To launch Zingo-Cli running through Zaino [from #PATH_TO/zingolib]:
 5) Run `$ cargo run --release --package zingo-cli -- --chain "CHAIN_TYPE" --server "ZAINO_LISTEN_ADDR" --data-dir #PATH_TO_WALLET_DATA_DIR`

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -12,6 +12,8 @@
 3) Run `$ zebrad --config #PATH_TO_CONF/zebrad.toml start`
 4) Run `$ zainod --config #PATH_TO_CONF/zindexer.toml`
 
+NOTE: Unless the `no_db` option if set to true in the config file zaino will sync its internal `CompactBlock` cache with the validator it is connected to on launch. This can be a very slow process the first time Zaino's DB is synced with a new chain and zaino will not be operable until the database is fully synced. If Zaino exits durin this process the database is saved in its current state, enabling the chain to be synced in several stages.
+
 - To launch Zingo-Cli running through Zaino [from #PATH_TO/zingolib]:
 5) Run `$ cargo run --release --package zingo-cli -- --chain "CHAIN_TYPE" --server "ZAINO_LISTEN_ADDR" --data-dir #PATH_TO_WALLET_DATA_DIR`
 

--- a/zaino-state/src/config.rs
+++ b/zaino-state/src/config.rs
@@ -162,3 +162,17 @@ impl BlockCacheConfig {
         }
     }
 }
+
+impl From<FetchServiceConfig> for BlockCacheConfig {
+    fn from(value: FetchServiceConfig) -> Self {
+        Self {
+            map_capacity: value.map_capacity,
+            map_shard_amount: value.map_shard_amount,
+            db_path: value.db_path,
+            db_size: value.db_size,
+            network: value.network,
+            no_sync: value.no_sync,
+            no_db: value.no_db,
+        }
+    }
+}

--- a/zaino-state/src/error.rs
+++ b/zaino-state/src/error.rs
@@ -100,22 +100,6 @@ pub enum FetchServiceError {
     /// Serialization error.
     #[error("Serialization error: {0}")]
     SerializationError(#[from] zebra_chain::serialization::SerializationError),
-
-    /// Integer conversion error.
-    #[error("Integer conversion error: {0}")]
-    TryFromIntError(#[from] std::num::TryFromIntError),
-
-    /// UTF-8 conversion error.
-    #[error("UTF-8 conversion error: {0}")]
-    Utf8Error(#[from] std::str::Utf8Error),
-
-    /// Integer parsing error.
-    #[error("Integer parsing error: {0}")]
-    ParseIntError(#[from] std::num::ParseIntError),
-
-    /// Chain parse error.
-    #[error("Chain parse error: {0}")]
-    ChainParseError(#[from] zaino_fetch::chain::error::ParseError),
 }
 
 impl From<FetchServiceError> for tonic::Status {
@@ -137,18 +121,6 @@ impl From<FetchServiceError> for tonic::Status {
             FetchServiceError::TonicStatusError(err) => err,
             FetchServiceError::SerializationError(err) => {
                 tonic::Status::internal(format!("Serialization error: {}", err))
-            }
-            FetchServiceError::TryFromIntError(err) => {
-                tonic::Status::internal(format!("Integer conversion error: {}", err))
-            }
-            FetchServiceError::Utf8Error(err) => {
-                tonic::Status::internal(format!("UTF-8 conversion error: {}", err))
-            }
-            FetchServiceError::ParseIntError(err) => {
-                tonic::Status::internal(format!("Integer parsing error: {}", err))
-            }
-            FetchServiceError::ChainParseError(err) => {
-                tonic::Status::internal(format!("Chain parse error: {}", err))
             }
         }
     }

--- a/zaino-state/src/error.rs
+++ b/zaino-state/src/error.rs
@@ -81,6 +81,10 @@ pub enum FetchServiceError {
     #[error("JsonRpcConnector error: {0}")]
     JsonRpcConnectorError(#[from] zaino_fetch::jsonrpc::error::JsonRpcConnectorError),
 
+    /// Error from the block cache.
+    #[error("Mempool error: {0}")]
+    BlockCacheError(#[from] BlockCacheError),
+
     /// Error from the mempool.
     #[error("Mempool error: {0}")]
     MempoolError(#[from] MempoolError),
@@ -120,6 +124,9 @@ impl From<FetchServiceError> for tonic::Status {
             FetchServiceError::Critical(message) => tonic::Status::internal(message),
             FetchServiceError::JsonRpcConnectorError(err) => {
                 tonic::Status::internal(format!("JsonRpcConnector error: {}", err))
+            }
+            FetchServiceError::BlockCacheError(err) => {
+                tonic::Status::internal(format!("BlockCache error: {}", err))
             }
             FetchServiceError::MempoolError(err) => {
                 tonic::Status::internal(format!("Mempool error: {}", err))

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -6,7 +6,7 @@ use crate::{
     config::FetchServiceConfig,
     error::FetchServiceError,
     indexer::{IndexerSubscriber, LightWalletIndexer, ZcashIndexer, ZcashService},
-    local_cache::BlockCache,
+    local_cache::{BlockCache, BlockCacheSubscriber},
     mempool::{Mempool, MempoolSubscriber},
     status::{AtomicStatus, StatusType},
     stream::{
@@ -116,6 +116,7 @@ impl ZcashService for FetchService {
     fn get_subscriber(&self) -> IndexerSubscriber<FetchServiceSubscriber> {
         IndexerSubscriber::new(FetchServiceSubscriber {
             fetcher: self.fetcher.clone(),
+            block_cache: self.block_cache.subscriber(),
             mempool: self.mempool.subscriber(),
             data: self.data.clone(),
             config: self.config.clone(),
@@ -147,7 +148,8 @@ impl Drop for FetchService {
 pub struct FetchServiceSubscriber {
     /// JsonRPC Client.
     fetcher: JsonRpcConnector,
-    // TODO: Add Internal Non-Finalised State
+    /// Local compact block cache.
+    block_cache: BlockCacheSubscriber,
     /// Internal mempool.
     mempool: MempoolSubscriber,
     /// Service metadata.

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -31,7 +31,7 @@ use crate::{
     config::FetchServiceConfig,
     error::FetchServiceError,
     indexer::{IndexerSubscriber, LightWalletIndexer, ZcashIndexer, ZcashService},
-    local_cache::{display_txids_to_server, BlockCache, BlockCacheSubscriber},
+    local_cache::{BlockCache, BlockCacheSubscriber},
     mempool::{Mempool, MempoolSubscriber},
     status::{AtomicStatus, StatusType},
     stream::{

--- a/zaino-state/src/local_cache.rs
+++ b/zaino-state/src/local_cache.rs
@@ -248,7 +248,7 @@ mod tests {
     use super::*;
     use core::panic;
     use zaino_testutils::TestManager;
-    use zcash_local_net::validator::Validator;
+    use zingo_infra_services::validator::Validator;
 
     async fn create_test_manager_and_block_cache(
         validator: &str,
@@ -376,15 +376,15 @@ mod tests {
         for _ in 1..=batches {
             // Generate blocks
             //
-            // NOTE: Generating blocks with zcashd blocks the tokio main thread, stopping background processes from running,
+            // NOTE: Generating blocks with zcashd blocks the tokio main thread???, stopping background processes from running,
             //       for this reason we generate blocks 1 at a time and sleep to let other tasks run.
             for height in 1..=100 {
                 println!("Generating block at height: {}", height);
                 test_manager.local_net.generate_blocks(1).await.unwrap();
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }
 
-            tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
 
             // Check chain height in validator, non-finalised state and finalised state.
             let validator_height = dbg!(json_service.get_blockchain_info().await.unwrap().blocks.0);

--- a/zaino-state/src/local_cache.rs
+++ b/zaino-state/src/local_cache.rs
@@ -11,7 +11,9 @@ use zaino_fetch::{
     chain::block::FullBlock,
     jsonrpc::{connector::JsonRpcConnector, response::GetBlockResponse},
 };
-use zaino_proto::proto::compact_formats::CompactBlock;
+use zaino_proto::proto::compact_formats::{
+    ChainMetadata, CompactBlock, CompactOrchardAction, CompactTx,
+};
 use zebra_chain::block::{Hash, Height};
 use zebra_state::HashOrHeight;
 
@@ -31,6 +33,7 @@ impl BlockCache {
         fetcher: &JsonRpcConnector,
         config: BlockCacheConfig,
     ) -> Result<Self, BlockCacheError> {
+        println!("Launching Local Block Cache..");
         let (channel_tx, channel_rx) = tokio::sync::mpsc::channel(100);
 
         let finalised_state = if !config.no_db {
@@ -124,6 +127,49 @@ impl BlockCacheSubscriber {
         }
     }
 
+    /// Returns a compact block holding only action nullifiers.
+    pub async fn get_compact_block_nullifiers(
+        &self,
+        hash_or_height: String,
+    ) -> Result<CompactBlock, BlockCacheError> {
+        match self.get_compact_block(hash_or_height).await {
+            Ok(block) => Ok(CompactBlock {
+                proto_version: block.proto_version,
+                height: block.height,
+                hash: block.hash,
+                prev_hash: block.prev_hash,
+                time: block.time,
+                header: block.header,
+                vtx: block
+                    .vtx
+                    .into_iter()
+                    .map(|tx| CompactTx {
+                        index: tx.index,
+                        hash: tx.hash,
+                        fee: tx.fee,
+                        spends: tx.spends,
+                        outputs: Vec::new(),
+                        actions: tx
+                            .actions
+                            .into_iter()
+                            .map(|action| CompactOrchardAction {
+                                nullifier: action.nullifier,
+                                cmx: Vec::new(),
+                                ephemeral_key: Vec::new(),
+                                ciphertext: Vec::new(),
+                            })
+                            .collect(),
+                    })
+                    .collect(),
+                chain_metadata: Some(ChainMetadata {
+                    sapling_commitment_tree_size: 0,
+                    orchard_commitment_tree_size: 0,
+                }),
+            }),
+            Err(e) => Err(e),
+        }
+    }
+
     /// Returns the height of the latest block in the [`BlockCache`].
     pub async fn get_chain_height(&self) -> Result<Height, BlockCacheError> {
         self.non_finalised_state
@@ -195,4 +241,189 @@ fn display_txids_to_server(txids: Vec<String>) -> Result<Vec<Vec<u8>>, BlockCach
                 .collect::<Result<Vec<u8>, _>>()
         })
         .collect::<Result<Vec<Vec<u8>>, _>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::panic;
+    use zaino_testutils::TestManager;
+    use zcash_local_net::validator::Validator;
+
+    async fn create_test_manager_and_block_cache(
+        validator: &str,
+        chain_cache: Option<std::path::PathBuf>,
+        enable_zaino: bool,
+        zaino_no_sync: bool,
+        zaino_no_db: bool,
+        enable_clients: bool,
+    ) -> (
+        TestManager,
+        JsonRpcConnector,
+        BlockCache,
+        BlockCacheSubscriber,
+    ) {
+        let test_manager = TestManager::launch(
+            validator,
+            None,
+            chain_cache,
+            enable_zaino,
+            zaino_no_sync,
+            zaino_no_db,
+            enable_clients,
+        )
+        .await
+        .unwrap();
+
+        let zebra_uri = format!("http://127.0.0.1:{}", test_manager.zebrad_rpc_listen_port)
+            .parse::<http::Uri>()
+            .expect("Failed to convert URL to URI");
+
+        let json_service = JsonRpcConnector::new(
+            zebra_uri,
+            Some("xxxxxx".to_string()),
+            Some("xxxxxx".to_string()),
+        )
+        .await
+        .unwrap();
+
+        let network = match test_manager.network.to_string().as_str() {
+            "Regtest" => zebra_chain::parameters::Network::new_regtest(Some(1), Some(1)),
+            "Testnet" => zebra_chain::parameters::Network::new_default_testnet(),
+            "Mainnet" => zebra_chain::parameters::Network::Mainnet,
+            _ => panic!("Incorrect newtork type found."),
+        };
+
+        let block_cache_config = BlockCacheConfig {
+            map_capacity: None,
+            map_shard_amount: None,
+            db_path: test_manager.data_dir.clone(),
+            db_size: None,
+            network,
+            no_sync: zaino_no_sync,
+            no_db: zaino_no_db,
+        };
+
+        let block_cache = BlockCache::spawn(&json_service, block_cache_config)
+            .await
+            .unwrap();
+
+        let block_cache_subscriber = block_cache.subscriber();
+
+        (
+            test_manager,
+            json_service,
+            block_cache,
+            block_cache_subscriber,
+        )
+    }
+
+    #[tokio::test]
+    async fn zcashd_local_cache_launch_no_db() {
+        launch_local_cache("zcashd", true).await;
+    }
+
+    #[tokio::test]
+    async fn zebrad_local_cache_launch_no_db() {
+        launch_local_cache("zebrad", true).await;
+    }
+
+    #[tokio::test]
+    async fn zcashd_local_cache_launch_with_db() {
+        launch_local_cache("zcashd", false).await;
+    }
+
+    #[tokio::test]
+    async fn zebrad_local_cache_launch_with_db() {
+        launch_local_cache("zebrad", false).await;
+    }
+
+    async fn launch_local_cache(validator: &str, no_db: bool) {
+        let (_test_manager, _json_service, _block_cache, block_cache_subscriber) =
+            create_test_manager_and_block_cache(validator, None, false, true, no_db, false).await;
+
+        dbg!(block_cache_subscriber.status());
+    }
+
+    #[tokio::test]
+    async fn zebrad_local_cache_process_100_blocks() {
+        launch_local_cache_process_n_block_batches("zebrad", 1).await;
+    }
+
+    #[tokio::test]
+    async fn zcashd_local_cache_process_100_blocks() {
+        launch_local_cache_process_n_block_batches("zcashd", 1).await;
+    }
+
+    #[tokio::test]
+    async fn zebrad_local_cache_process_200_blocks() {
+        launch_local_cache_process_n_block_batches("zebrad", 2).await;
+    }
+
+    #[tokio::test]
+    async fn zcashd_local_cache_process_200_blocks() {
+        launch_local_cache_process_n_block_batches("zcashd", 2).await;
+    }
+
+    /// Launches a testmanager and block cache and generates `n*100` blocks, checking blocks are stored and fetched correctly.
+    async fn launch_local_cache_process_n_block_batches(validator: &str, batches: u32) {
+        let (test_manager, json_service, mut block_cache, mut block_cache_subscriber) =
+            create_test_manager_and_block_cache(validator, None, false, true, false, false).await;
+
+        let finalised_state = block_cache.finalised_state.take().unwrap();
+        let finalised_state_subscriber = block_cache_subscriber.finalised_state.take().unwrap();
+
+        for _ in 1..=batches {
+            // Generate blocks
+            //
+            // NOTE: Generating blocks with zcashd blocks the tokio main thread, stopping background processes from running,
+            //       for this reason we generate blocks 1 at a time and sleep to let other tasks run.
+            for height in 1..=100 {
+                println!("Generating block at height: {}", height);
+                test_manager.local_net.generate_blocks(1).await.unwrap();
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+
+            // Check chain height in validator, non-finalised state and finalised state.
+            let validator_height = dbg!(json_service.get_blockchain_info().await.unwrap().blocks.0);
+            let non_finalised_state_height =
+                dbg!(block_cache_subscriber.get_chain_height().await.unwrap().0);
+            let finalised_state_height =
+                dbg!(dbg!(finalised_state.get_db_height()).unwrap_or(Height(0)).0);
+
+            assert_eq!(&validator_height, &non_finalised_state_height);
+            assert_eq!(
+                (&non_finalised_state_height.saturating_sub(101)),
+                &finalised_state_height
+            );
+
+            // Fetch blocks in non-finalised state.
+            let mut non_finalised_state_blocks = Vec::new();
+            for height in (finalised_state_height + 1)..=non_finalised_state_height {
+                let block = block_cache_subscriber
+                    .non_finalised_state
+                    .get_compact_block(HashOrHeight::Height(Height(height)))
+                    .await
+                    .unwrap();
+                non_finalised_state_blocks.push(block);
+            }
+
+            // Fetch blocks in finalised state.
+            let mut finalised_state_blocks = Vec::new();
+            for height in 1..=finalised_state_height {
+                let block = finalised_state_subscriber
+                    .get_compact_block(HashOrHeight::Height(Height(height)))
+                    .await
+                    .unwrap();
+                finalised_state_blocks.push(block);
+            }
+
+            dbg!(non_finalised_state_blocks.first());
+            dbg!(non_finalised_state_blocks.last());
+            dbg!(finalised_state_blocks.first());
+            dbg!(finalised_state_blocks.last());
+        }
+    }
 }

--- a/zaino-state/src/local_cache.rs
+++ b/zaino-state/src/local_cache.rs
@@ -128,6 +128,8 @@ impl BlockCacheSubscriber {
     }
 
     /// Returns a compact block holding only action nullifiers.
+    ///
+    /// NOTE: Currently this only returns Orchard nullifiers to follow Lightwalletd functionality but Sapling could be added if required by wallets.
     pub async fn get_compact_block_nullifiers(
         &self,
         hash_or_height: String,
@@ -227,7 +229,7 @@ pub(crate) async fn fetch_block_from_node(
 }
 
 /// Takes a vec of big endian hex encoded txids and returns them as a vec of little endian raw bytes.
-fn display_txids_to_server(txids: Vec<String>) -> Result<Vec<Vec<u8>>, BlockCacheError> {
+pub(crate) fn display_txids_to_server(txids: Vec<String>) -> Result<Vec<Vec<u8>>, BlockCacheError> {
     txids
         .iter()
         .map(|txid| {

--- a/zaino-state/src/local_cache/finalised_state.rs
+++ b/zaino-state/src/local_cache/finalised_state.rs
@@ -345,10 +345,12 @@ impl FinalisedState {
                 // This means the whole non-finalised state is old.
                 // We fetch the first block in the chain here as the later refill logic always starts from [reorg_height + 1].
                 Err(_) => {
-                    let mut txn = self.database.begin_rw_txn()?;
-                    txn.clear_db(self.heights_to_hashes)?;
-                    txn.clear_db(self.hashes_to_blocks)?;
-                    txn.commit()?;
+                    {
+                        let mut txn = self.database.begin_rw_txn()?;
+                        txn.clear_db(self.heights_to_hashes)?;
+                        txn.clear_db(self.hashes_to_blocks)?;
+                        txn.commit()?;
+                    }
                     loop {
                         match fetch_block_from_node(
                             &self.fetcher,

--- a/zaino-state/src/local_cache/finalised_state.rs
+++ b/zaino-state/src/local_cache/finalised_state.rs
@@ -363,9 +363,11 @@ impl FinalisedState {
         Ok(())
     }
 
-    /// Syncs database with the server,
-    /// waits for server to sync with P2P network,
-    /// Checks for reorg before syncing.
+    /// Syncs database with the server, and waits for server to sync with P2P network.
+    ///
+    /// Checks for reorg before syncing:
+    /// - Searches from ZainoDB tip backwards looking for the last valid block in the database and sets `reorg_height` to the last VALID block.
+    /// - Re-populated the database from the NEXT block in the chain (`reorg_height + 1`).
     async fn sync_db_from_reorg(&self) -> Result<(), FinalisedStateError> {
         let mut reorg_height = self.get_db_height().unwrap_or(Height(0));
 

--- a/zaino-state/src/local_cache/finalised_state.rs
+++ b/zaino-state/src/local_cache/finalised_state.rs
@@ -391,7 +391,7 @@ impl FinalisedState {
             };
         }
 
-        // Refill from reorg_height[+1] to current server (finalised state) height.
+        // Refill from max(reorg_height[+1], sapling_activation_height) to current server (finalised state) height.
         let mut sync_height = self
             .fetcher
             .get_blockchain_info()
@@ -399,7 +399,10 @@ impl FinalisedState {
             .blocks
             .0
             .saturating_sub(99);
-        for block_height in (reorg_height.0 + 1)..=sync_height {
+        for block_height in ((reorg_height.0 + 1)
+            .max(self.config.network.sapling_activation_height().0))
+            ..=sync_height
+        {
             if self.get_hash(block_height).is_ok() {
                 self.delete_block(Height(block_height))?;
             }
@@ -412,6 +415,10 @@ impl FinalisedState {
                 {
                     Ok((hash, block)) => {
                         self.insert_block((Height(block_height), hash, block))?;
+                        println!(
+                            "Block at height {} successfully inserted in finalised state.",
+                            block_height
+                        );
                         break;
                     }
                     Err(e) => {
@@ -442,6 +449,10 @@ impl FinalisedState {
                         {
                             Ok((hash, block)) => {
                                 self.insert_block((Height(block_height), hash, block))?;
+                                println!(
+                                    "Block at height {} successfully inserted in finalised state.",
+                                    block_height
+                                );
                                 break;
                             }
                             Err(e) => {

--- a/zaino-state/src/local_cache/non_finalised_state.rs
+++ b/zaino-state/src/local_cache/non_finalised_state.rs
@@ -79,7 +79,8 @@ impl NonFinalisedState {
         }
 
         let chain_height = fetcher.get_blockchain_info().await?.blocks.0;
-        for height in chain_height.saturating_sub(99)..=chain_height {
+        // We do not fetch the genesis block.
+        for height in chain_height.saturating_sub(99).max(1)..=chain_height {
             loop {
                 match fetch_block_from_node(
                     &non_finalised_state.fetcher,
@@ -238,29 +239,9 @@ impl NonFinalisedState {
                 Ok(height) => reorg_height = height,
                 // Underflow error meaning reorg_height = start of chain.
                 // This means the whole non-finalised state is old.
-                // We fetch the first block in the chain here as the later refill logic always starts from [reorg_height + 1].
                 Err(_) => {
                     self.heights_to_hashes.clear();
                     self.hashes_to_blocks.clear();
-                    loop {
-                        match fetch_block_from_node(
-                            &self.fetcher,
-                            HashOrHeight::Height(reorg_height),
-                        )
-                        .await
-                        {
-                            Ok((hash, block)) => {
-                                self.heights_to_hashes.insert(reorg_height, hash, None);
-                                self.hashes_to_blocks.insert(hash, block, None);
-                                break;
-                            }
-                            Err(e) => {
-                                self.update_status_and_notify(StatusType::RecoverableError);
-                                eprintln!("{e}");
-                                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                            }
-                        }
-                    }
                     break;
                 }
             };
@@ -287,8 +268,8 @@ impl NonFinalisedState {
         }
 
         // Refill from reorg_height[+1].
-        for block_height in (reorg_height.0 + 1)..self.fetcher.get_blockchain_info().await?.blocks.0
-        {
+        let validator_height = self.fetcher.get_blockchain_info().await?.blocks.0;
+        for block_height in (reorg_height.0 + 1)..=validator_height {
             // Either pop the reorged block or pop the oldest block in non-finalised state.
             // If we pop the oldest (valid) block we send it to the finalised state to be saved to disk.
             if self.heights_to_hashes.contains_key(&Height(block_height)) {
@@ -309,22 +290,29 @@ impl NonFinalisedState {
                         )
                     })?
                     .key();
-                if let Some(hash) = self.heights_to_hashes.get(&pop_height) {
-                    if let Some(block) = self.hashes_to_blocks.get(&hash) {
-                        if self
-                            .block_sender
-                            .send((pop_height, *hash, block.as_ref().clone()))
-                            .await
-                            .is_err()
-                        {
-                            self.status.store(StatusType::CriticalError.into());
-                            return Err(NonFinalisedStateError::Critical(
-                                "Critical error in database. Closing NonFinalisedState".to_string(),
-                            ));
+                // Only pop block if it is outside of the non-finalised state block range.
+                if pop_height.0 < (validator_height.saturating_sub(100)) {
+                    if let Some(hash) = self.heights_to_hashes.get(&pop_height) {
+                        // Send to FinalisedState if db is active.
+                        if !self.config.no_db {
+                            if let Some(block) = self.hashes_to_blocks.get(&hash) {
+                                if self
+                                    .block_sender
+                                    .send((pop_height, *hash, block.as_ref().clone()))
+                                    .await
+                                    .is_err()
+                                {
+                                    self.status.store(StatusType::CriticalError.into());
+                                    return Err(NonFinalisedStateError::Critical(
+                                        "Critical error in database. Closing NonFinalisedState"
+                                            .to_string(),
+                                    ));
+                                }
+                            }
                         }
+                        self.hashes_to_blocks.remove(&hash, None);
+                        self.heights_to_hashes.remove(&pop_height, None);
                     }
-                    self.hashes_to_blocks.remove(&hash, None);
-                    self.heights_to_hashes.remove(&pop_height, None);
                 }
             }
             loop {
@@ -338,6 +326,10 @@ impl NonFinalisedState {
                         self.heights_to_hashes
                             .insert(Height(block_height), hash, None);
                         self.hashes_to_blocks.insert(hash, block, None);
+                        println!(
+                            "Block at height {} successfully inserted in non-finalised state.",
+                            block_height
+                        );
                         break;
                     }
                     Err(e) => {


### PR DESCRIPTION
Final integration of the Compact Block Cache.

- Adds BlockCache to FetchService and uses BlockCache block fetch methods.
- Updates DB to use big-endian bytes for height instead of `Height(u32)` (zebra-chain). This is required to search LMDB height keys by order.
- Moves startup sync from FetchService::Spawn to BlockCache::Spawn.

