### PR TITLE
use streamlined test infrastructure refactored from ZLN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3446,6 +3446,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower 0.5.2",
  "tower-service",
  "url",
@@ -5410,10 +5411,10 @@ dependencies = [
  "zaino-fetch",
  "zaino-proto",
  "zaino-testutils",
- "zcash_local_net",
  "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
  "zebra-rpc 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
  "zebra-state 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zingo-infra-services",
  "zingolib",
 ]
 
@@ -5433,6 +5434,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_protocol 0.4.0",
  "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zingo-infra-testutils",
  "zingolib",
 ]
 
@@ -5580,33 +5582,6 @@ dependencies = [
  "zcash_primitives 0.19.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
  "zcash_protocol 0.4.0",
  "zip32",
-]
-
-[[package]]
-name = "zcash_local_net"
-version = "0.1.0"
-source = "git+https://github.com/zingolabs/zcash-local-net.git?rev=d64b76cab748455c5b9e1e4412f1689fb66f7d41#d64b76cab748455c5b9e1e4412f1689fb66f7d41"
-dependencies = [
- "getset",
- "hex",
- "http",
- "json",
- "portpicker",
- "serde_json",
- "tempfile",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tonic",
- "tracing",
- "zcash_client_backend",
- "zcash_primitives 0.19.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
- "zcash_protocol 0.4.0",
- "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
- "zebra-node-services 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
- "zebra-rpc 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
- "zingo-netutils",
- "zingolib",
 ]
 
 [[package]]
@@ -6301,6 +6276,50 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "zingo-infra-services"
+version = "0.1.0"
+source = "git+https://github.com/zancas/infrastructure.git?branch=add_reexports#177e27eab93e219a8128e9136db7f42178c4bb37"
+dependencies = [
+ "getset",
+ "hex",
+ "http",
+ "json",
+ "portpicker",
+ "reqwest",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "zcash_primitives 0.19.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
+ "zcash_protocol 0.4.0",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
+ "zebra-node-services 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
+ "zebra-rpc 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
+]
+
+[[package]]
+name = "zingo-infra-testutils"
+version = "0.1.0"
+source = "git+https://github.com/zancas/infrastructure.git?branch=add_reexports#177e27eab93e219a8128e9136db7f42178c4bb37"
+dependencies = [
+ "http",
+ "portpicker",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing-subscriber",
+ "zcash_client_backend",
+ "zcash_primitives 0.19.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
+ "zcash_protocol 0.4.0",
+ "zingo-infra-services",
+ "zingo-netutils",
+ "zingolib",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,19 +121,20 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "append-only-vec"
@@ -177,18 +178,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -205,9 +206,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47bb8cc16b669d267eeccf585aea077d0882f4777b1c1f740217885d6e6e5a3"
+checksum = "4c2b7ddaa2c56a367ad27a094ad8ef4faacf8a617c2575acb2ba88949df999ca"
 dependencies = [
  "aws-lc-sys",
  "paste",
@@ -216,16 +217,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.23.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2101df3813227bbaaaa0b04cd61c534c7954b22bd68d399b440be937dc63ff7"
+checksum = "71b2ddd3ada61a305e1d8bb6c005d1eaa7d14d903681edfc400406d523a9b491"
 dependencies = [
  "bindgen 0.69.5",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "libc",
  "paste",
 ]
 
@@ -250,8 +250,8 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper 1.0.2",
- "tower 0.5.1",
+ "sync_wrapper",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -271,7 +271,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -363,7 +363,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -376,17 +376,17 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.90",
+ "syn 2.0.96",
  "which",
 ]
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -395,9 +395,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.0",
  "shlex",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -416,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "bip32"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa13fae8b6255872fd86f7faf4b41168661d7d78609f7bfe6771b85c6739a15b"
+checksum = "db40d3dfbeab4e031d78c844642fa0caa0b0db11ce1607ac9d2986dff1405c69"
 dependencies = [
  "bs58",
  "hmac",
@@ -432,18 +432,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -453,9 +453,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitflags-serde-legacy"
@@ -463,7 +463,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b64e60c28b6d25ad92e8b367801ff9aa12b41d05fc8798055d296bace4a60cc"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "serde",
 ]
 
@@ -549,9 +549,9 @@ source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_004#f9f3e5
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byte-slice-cast"
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.2"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -686,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.22"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69371e34337c4c984bbe322360c2547210bf632eb2814bbe78a6e87a2935bd2b"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.22"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24c1b4099818523236a8ca881d2b45db98dadfb4625cf6608c12069fcbbde1"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -708,27 +708,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+checksum = "e24a03c8b52922d68a1589ad61032f2c1aa5a8158d2aa0d93c6e9534944bbad6"
 dependencies = [
  "cc",
 ]
@@ -773,6 +773,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,28 +825,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.16"
+name = "core2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -843,15 +872,15 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -898,7 +927,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -922,7 +951,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -933,7 +962,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1027,7 +1056,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1096,7 +1125,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1157,25 +1186,25 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a83e8d7fd0c526af4aad893b7c9fe41e2699ed8a776a6c74aecdeafe05afc75"
-dependencies = [
- "blake2b_simd",
-]
-
-[[package]]
-name = "f4jumble"
-version = "0.1.0"
 source = "git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2#db6efd6a2fdac955c7eb6929a043d19d9e451429"
 dependencies = [
  "blake2b_simd",
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.2.0"
+name = "f4jumble"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+dependencies = [
+ "blake2b_simd",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -1330,7 +1359,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1398,15 +1427,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.3"
+name = "getrandom"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f636605b743120a8d32ed92fc27b6cde1a769f8f936c065151eb66f88ded513c"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded738faa0e88d3abc9d1a13cb11adc2073c400969eeb8793cf7132589959fc"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1417,9 +1458,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "group"
@@ -1445,7 +1486,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1454,18 +1495,20 @@ dependencies = [
 
 [[package]]
 name = "halo2_gadgets"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126a150072b0c38c7b573fe3eaf0af944a7fed09e154071bf2436d3f016f7230"
+checksum = "73a5e510d58a07d8ed238a5a8a436fe6c2c79e1bb2611f62688bc65007b4e6e7"
 dependencies = [
  "arrayvec",
  "bitvec",
  "ff",
  "group",
+ "halo2_poseidon",
  "halo2_proofs",
  "lazy_static",
  "pasta_curves",
  "rand 0.8.5",
+ "sinsemilla",
  "subtle",
  "uint 0.9.5",
 ]
@@ -1475,6 +1518,18 @@ name = "halo2_legacy_pdqsort"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47716fe1ae67969c5e0b2ef826f32db8c3be72be325e1aa3c1951d06b5575ec5"
+
+[[package]]
+name = "halo2_poseidon"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa3da60b81f02f9b33ebc6252d766f843291fb4d2247a07ae73d20b791fc56f"
+dependencies = [
+ "bitvec",
+ "ff",
+ "group",
+ "pasta_curves",
+]
 
 [[package]]
 name = "halo2_proofs"
@@ -1552,11 +1607,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1595,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "httpdate"
@@ -1629,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1650,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http",
@@ -1854,7 +1909,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1901,14 +1956,14 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "incrementalmerkletree"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45063fbc4b0a37837f6bfe0445f269d13d730ad0aa3b5a7f74aa7bf27a0f4df"
+checksum = "216c71634ac6f6ed13c2102d64354c0a04dcbdc30e31692c5972d3974d8b6d97"
 dependencies = [
  "either",
  "proptest",
@@ -1935,9 +1990,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1974,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2019,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2050,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.7"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c71d8c1a731cc4227c2f698d377e7848ca12c8a48866fc5e6951c43a4db843"
+checksum = "834af00800e962dee8f7bfc0f60601de215e73e78e5497d733a2919da837d3c8"
 dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-server",
@@ -2062,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.7"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2882f6f8acb9fdaec7cefc4fd607119a9bd709831df7d7672a1d3b644628280"
+checksum = "76637f6294b04e747d68e69336ef839a3493ca62b35bf488ead525f7da75c5bb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2085,22 +2140,22 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.24.7"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06c01ae0007548e73412c08e2285ffe5d723195bf268bce67b1b77c3bb2a14d"
+checksum = "6fcae0c6c159e11541080f1f829873d8f374f81eda0abc67695a13fc8dc1a580"
 dependencies = [
  "heck",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.24.7"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ad8ddc14be1d4290cd68046e7d1d37acd408efed6d3ca08aefcc3ad6da069c"
+checksum = "66b7a3df90a1a60c3ed68e7ca63916b53e9afa928e33531e87f61a9c8e9ae87b"
 dependencies = [
  "futures-util",
  "http",
@@ -2125,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.24.7"
+version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a178c60086f24cc35bb82f57c651d0d25d99c4742b4d335de04e97fa1f08a8a1"
+checksum = "ddb81adb1a5ae9182df379e374a79e24e992334e7346af4d065ae5b2acb8d4c6"
 dependencies = [
  "http",
  "serde",
@@ -2160,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex"
-version = "3.3.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d8e41c97e6bc7ecb552016274b99fbb5d035e8de288c582d9b933af6677bfda"
+checksum = "60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126"
 dependencies = [
  "lazy-regex-proc_macros",
  "once_cell",
@@ -2171,14 +2226,14 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex-proc_macros"
-version = "3.3.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e1d8b05d672c53cb9c7b920bbba8783845ae4f0b076e02a3db1d02c81b4163"
+checksum = "4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2198,9 +2253,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libloading"
@@ -2224,7 +2279,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "libc",
 ]
 
@@ -2245,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.20"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2256,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
@@ -2306,9 +2361,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 dependencies = [
  "serde",
 ]
@@ -2381,12 +2436,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memuse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2145869435ace5ea6ea3d35f59be559317ec9a0d04e1812d5f185a87b6d36f1a"
-dependencies = [
- "nonempty",
-]
+checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
 
 [[package]]
 name = "metrics"
@@ -2444,9 +2496,9 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
 dependencies = [
  "libc",
  "log",
@@ -2465,7 +2517,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2529,7 +2581,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2565,11 +2616,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2586,14 +2637,14 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
@@ -2615,17 +2666,20 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f18e997fa121de5c73e95cdc7e8512ae43b7de38904aeea5e5713cc48f3c0ba"
+checksum = "02f7152474406422f572de163e0bc63b2126cdbfe17bc849efbbde36fcfe647e"
 dependencies = [
  "aes",
  "bitvec",
  "blake2b_simd",
+ "core2",
  "ff",
  "fpe",
+ "getset",
  "group",
  "halo2_gadgets",
+ "halo2_poseidon",
  "halo2_proofs",
  "hex",
  "incrementalmerkletree",
@@ -2636,6 +2690,7 @@ dependencies = [
  "rand 0.8.5",
  "reddsa",
  "serde",
+ "sinsemilla",
  "subtle",
  "tracing",
  "visibility",
@@ -2686,28 +2741,30 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.12"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+checksum = "b91c2d9a6a6004e205b7e881856fb1a0f5022d382acc2c01b52185f7b6f65997"
 dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
+ "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "rustversion",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.12"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
+checksum = "77555fd9d578b6470470463fded832619a5fec5ad6cbc551fe4d7507ce50cd3a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2788,34 +2845,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -2882,12 +2939,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.25"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2929,27 +2986,27 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -2963,9 +3020,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2973,11 +3030,10 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
+checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "bytes",
  "heck",
  "itertools 0.13.0",
  "log",
@@ -2988,28 +3044,28 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.90",
+ "syn 2.0.96",
  "tempfile",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
+checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
 dependencies = [
  "prost",
 ]
@@ -3056,7 +3112,7 @@ dependencies = [
  "rustc-hash 2.1.0",
  "rustls",
  "socket2",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
 ]
@@ -3075,7 +3131,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3097,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -3280,11 +3336,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -3338,9 +3394,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3370,11 +3426,12 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3453,7 +3510,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.90",
+ "syn 2.0.96",
  "walkdir",
 ]
 
@@ -3502,22 +3559,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.19"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3538,7 +3595,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.0.1",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -3552,9 +3609,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 dependencies = [
  "web-time",
 ]
@@ -3573,9 +3630,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "rusty-fork"
@@ -3591,9 +3648,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "same-file"
@@ -3685,7 +3742,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3694,11 +3751,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.0.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -3707,9 +3764,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3717,15 +3774,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -3751,22 +3808,22 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "itoa",
  "memchr",
  "ryu",
@@ -3787,15 +3844,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3805,14 +3862,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3821,7 +3878,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "itoa",
  "ryu",
  "serde",
@@ -3865,7 +3922,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5f2390975ebfe8838f9e861f7a588123d49a7a7a0a08568ea831d8ad53fc9b4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "either",
  "incrementalmerkletree",
  "tracing",
@@ -3893,6 +3950,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "sinsemilla"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d268ae0ea06faafe1662e9967cd4f9022014f5eeb798e0c302c876df8b7af9c"
+dependencies = [
+ "group",
+ "pasta_curves",
+ "subtle",
 ]
 
 [[package]]
@@ -3972,9 +4040,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -3989,20 +4057,14 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -4021,7 +4083,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4030,7 +4092,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4063,12 +4125,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -4092,7 +4155,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4103,7 +4166,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "test-case-core",
 ]
 
@@ -4118,11 +4181,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -4133,18 +4196,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4210,9 +4273,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4225,9 +4288,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4244,13 +4307,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4265,12 +4328,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls",
- "rustls-pki-types",
  "tokio",
 ]
 
@@ -4321,7 +4383,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "toml_datetime",
  "winnow",
 ]
@@ -4371,7 +4433,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4396,22 +4458,23 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "tower-batch-control"
-version = "0.2.41-beta.19"
-source = "git+https://github.com/ZcashFoundation/zebra.git#0fe47bbbbbb9e7139bdf79c4fecac0a6d421339c"
+version = "0.2.41-beta.20"
+source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
  "futures",
  "futures-core",
@@ -4427,7 +4490,7 @@ dependencies = [
 [[package]]
 name = "tower-batch-control"
 version = "0.2.41-beta.20"
-source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#c7d8d712698c182b3ba46e1b82ff19c2b51a45c4"
+source = "git+https://github.com/ZcashFoundation/zebra.git#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
  "futures",
  "futures-core",
@@ -4442,8 +4505,8 @@ dependencies = [
 
 [[package]]
 name = "tower-fallback"
-version = "0.2.41-beta.19"
-source = "git+https://github.com/ZcashFoundation/zebra.git#0fe47bbbbbb9e7139bdf79c4fecac0a6d421339c"
+version = "0.2.41-beta.20"
+source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -4454,7 +4517,7 @@ dependencies = [
 [[package]]
 name = "tower-fallback"
 version = "0.2.41-beta.20"
-source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#c7d8d712698c182b3ba46e1b82ff19c2b51a45c4"
+source = "git+https://github.com/ZcashFoundation/zebra.git#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -4494,7 +4557,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4605,9 +4668,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-normalization"
@@ -4617,6 +4680,12 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -4680,9 +4749,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -4704,7 +4773,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4798,6 +4867,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4805,35 +4883,35 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.47"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4844,9 +4922,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4854,28 +4932,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.74"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5149,11 +5230,20 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -5215,7 +5305,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -5227,7 +5317,7 @@ dependencies = [
  "byteorder",
  "hex",
  "http",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "jsonrpsee-types",
  "prost",
  "reqwest",
@@ -5240,9 +5330,9 @@ dependencies = [
  "url",
  "zaino-proto",
  "zcash_protocol 0.4.0",
- "zebra-chain 1.0.0-beta.44",
- "zebra-rpc 1.0.0-beta.44",
- "zebra-state 1.0.0-beta.44",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zebra-rpc 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zebra-state 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
 ]
 
 [[package]]
@@ -5273,9 +5363,9 @@ dependencies = [
  "zaino-fetch",
  "zaino-proto",
  "zaino-state",
- "zebra-chain 1.0.0-beta.44",
- "zebra-rpc 1.0.0-beta.44",
- "zebra-state 1.0.0-beta.44",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zebra-rpc 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zebra-state 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
 ]
 
 [[package]]
@@ -5288,7 +5378,7 @@ dependencies = [
  "futures",
  "hex",
  "http",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "jsonrpc-core",
  "lazy-regex",
  "lmdb",
@@ -5306,9 +5396,9 @@ dependencies = [
  "zaino-proto",
  "zaino-testutils",
  "zcash_local_net",
- "zebra-chain 1.0.0-beta.44",
- "zebra-rpc 1.0.0-beta.44",
- "zebra-state 1.0.0-beta.44",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zebra-rpc 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zebra-state 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
  "zingolib",
 ]
 
@@ -5328,7 +5418,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_local_net",
  "zcash_protocol 0.4.0",
- "zebra-chain 1.0.0-beta.44",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
  "zingolib",
 ]
 
@@ -5346,20 +5436,7 @@ dependencies = [
  "zaino-fetch",
  "zaino-serve",
  "zaino-state",
- "zebra-chain 1.0.0-beta.44",
-]
-
-[[package]]
-name = "zcash_address"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff95eac82f71286a79c750e674550d64fb2b7aadaef7b89286b2917f645457d"
-dependencies = [
- "bech32 0.9.1",
- "bs58",
- "f4jumble 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.4.1",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
 ]
 
 [[package]]
@@ -5369,9 +5446,23 @@ source = "git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sql
 dependencies = [
  "bech32 0.9.1",
  "bs58",
- "f4jumble 0.1.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
- "zcash_encoding 0.2.1 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
+ "f4jumble 0.1.0",
+ "zcash_encoding 0.2.1",
  "zcash_protocol 0.4.0",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b955fe87f2d9052e3729bdbeb0e94975355f4fe39f7d26aea9457bec6a0bb55"
+dependencies = [
+ "bech32 0.11.0",
+ "bs58",
+ "core2",
+ "f4jumble 0.1.1",
+ "zcash_encoding 0.2.2",
+ "zcash_protocol 0.4.3",
 ]
 
 [[package]]
@@ -5409,8 +5500,8 @@ dependencies = [
  "tonic-build",
  "tracing",
  "which",
- "zcash_address 0.6.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
- "zcash_encoding 0.2.1 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
+ "zcash_address 0.6.0",
+ "zcash_encoding 0.2.1",
  "zcash_keys",
  "zcash_note_encryption",
  "zcash_primitives 0.19.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
@@ -5422,8 +5513,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052d8230202f0a018cd9b5d1b56b94cd25e18eccc2d8665073bcea8261ab87fc"
+source = "git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2#db6efd6a2fdac955c7eb6929a043d19d9e451429"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -5431,10 +5521,11 @@ dependencies = [
 
 [[package]]
 name = "zcash_encoding"
-version = "0.2.1"
-source = "git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2#db6efd6a2fdac955c7eb6929a043d19d9e451429"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3654116ae23ab67dd1f849b01f8821a8a156f884807ff665eac109bf28306c4d"
 dependencies = [
- "byteorder",
+ "core2",
  "nonempty",
 ]
 
@@ -5470,8 +5561,8 @@ dependencies = [
  "secrecy",
  "subtle",
  "tracing",
- "zcash_address 0.6.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
- "zcash_encoding 0.2.1 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
+ "zcash_address 0.6.0",
+ "zcash_encoding 0.2.1",
  "zcash_primitives 0.19.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
  "zcash_protocol 0.4.0",
  "zip32",
@@ -5497,18 +5588,18 @@ dependencies = [
  "zcash_client_backend",
  "zcash_primitives 0.19.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
  "zcash_protocol 0.4.0",
- "zebra-chain 1.0.0-beta.43",
- "zebra-node-services 1.0.0-beta.43",
- "zebra-rpc 1.0.0-beta.43",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
+ "zebra-node-services 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
+ "zebra-rpc 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
  "zingo-netutils",
  "zingolib",
 ]
 
 [[package]]
 name = "zcash_note_encryption"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4580cd6cee12e44421dac43169be8d23791650816bdb34e6ddfa70ac89c1c5"
+checksum = "77efec759c3798b6e4d829fcc762070d9b229b0f13338c40bf993b7b609c2272"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -5548,10 +5639,10 @@ dependencies = [
  "sha2",
  "subtle",
  "tracing",
- "zcash_address 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.6.2",
+ "zcash_encoding 0.2.2",
  "zcash_note_encryption",
- "zcash_protocol 0.4.1",
+ "zcash_protocol 0.4.3",
  "zcash_spec",
  "zip32",
 ]
@@ -5586,8 +5677,8 @@ dependencies = [
  "sha2",
  "subtle",
  "tracing",
- "zcash_address 0.6.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
- "zcash_encoding 0.2.1 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
+ "zcash_address 0.6.0",
+ "zcash_encoding 0.2.1",
  "zcash_note_encryption",
  "zcash_protocol 0.4.0",
  "zcash_spec",
@@ -5650,11 +5741,13 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4bbb28b59321f47454e69c2d95c11c227bb1a21bfa3381bd43c4ac98f5caee1"
+checksum = "82cb36b15b5a1be70b30c32ce40372dead6561df8a467e297f96b892873a63a2"
 dependencies = [
+ "core2",
  "document-features",
+ "hex",
  "memuse",
 ]
 
@@ -5664,7 +5757,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2122a042c77d529d3c60b899e74705eda39ae96a8a992460caeb06afa76990a2"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen 0.71.1",
  "cc",
 ]
 
@@ -5679,10 +5772,10 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "1.0.0-beta.43"
-source = "git+https://github.com/ZcashFoundation/zebra.git#0fe47bbbbbb9e7139bdf79c4fecac0a6d421339c"
+version = "1.0.0-beta.44"
+source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "bitflags-serde-legacy",
  "bitvec",
  "blake2b_simd",
@@ -5720,25 +5813,25 @@ dependencies = [
  "sha2",
  "static_assertions",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
- "zcash_address 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.6.2",
+ "zcash_encoding 0.2.2",
  "zcash_history",
  "zcash_note_encryption",
  "zcash_primitives 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.4.1",
+ "zcash_protocol 0.4.3",
 ]
 
 [[package]]
 name = "zebra-chain"
 version = "1.0.0-beta.44"
-source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#c7d8d712698c182b3ba46e1b82ff19c2b51a45c4"
+source = "git+https://github.com/ZcashFoundation/zebra.git#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "bitflags-serde-legacy",
  "bitvec",
  "blake2b_simd",
@@ -5776,23 +5869,23 @@ dependencies = [
  "sha2",
  "static_assertions",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
- "zcash_address 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address 0.6.2",
+ "zcash_encoding 0.2.2",
  "zcash_history",
  "zcash_note_encryption",
  "zcash_primitives 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.4.1",
+ "zcash_protocol 0.4.3",
 ]
 
 [[package]]
 name = "zebra-consensus"
-version = "1.0.0-beta.43"
-source = "git+https://github.com/ZcashFoundation/zebra.git#0fe47bbbbbb9e7139bdf79c4fecac0a6d421339c"
+version = "1.0.0-beta.44"
+source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5810,25 +5903,25 @@ dependencies = [
  "rayon",
  "sapling-crypto",
  "serde",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
  "tower 0.4.13",
- "tower-batch-control 0.2.41-beta.19",
- "tower-fallback 0.2.41-beta.19",
+ "tower-batch-control 0.2.41-beta.20 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "tower-fallback 0.2.41-beta.20 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
  "tracing",
  "tracing-futures",
  "wagyu-zcash-parameters",
  "zcash_proofs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zebra-chain 1.0.0-beta.43",
- "zebra-node-services 1.0.0-beta.43",
- "zebra-script 1.0.0-beta.43",
- "zebra-state 1.0.0-beta.43",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zebra-node-services 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zebra-script 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zebra-state 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
 ]
 
 [[package]]
 name = "zebra-consensus"
 version = "1.0.0-beta.44"
-source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#c7d8d712698c182b3ba46e1b82ff19c2b51a45c4"
+source = "git+https://github.com/ZcashFoundation/zebra.git#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5846,27 +5939,27 @@ dependencies = [
  "rayon",
  "sapling-crypto",
  "serde",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
  "tower 0.4.13",
- "tower-batch-control 0.2.41-beta.20",
- "tower-fallback 0.2.41-beta.20",
+ "tower-batch-control 0.2.41-beta.20 (git+https://github.com/ZcashFoundation/zebra.git)",
+ "tower-fallback 0.2.41-beta.20 (git+https://github.com/ZcashFoundation/zebra.git)",
  "tracing",
  "tracing-futures",
  "wagyu-zcash-parameters",
  "zcash_proofs 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zebra-chain 1.0.0-beta.44",
- "zebra-node-services 1.0.0-beta.44",
- "zebra-script 1.0.0-beta.44",
- "zebra-state 1.0.0-beta.44",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
+ "zebra-node-services 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
+ "zebra-script 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
+ "zebra-state 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
 ]
 
 [[package]]
 name = "zebra-network"
-version = "1.0.0-beta.43"
-source = "git+https://github.com/ZcashFoundation/zebra.git#0fe47bbbbbb9e7139bdf79c4fecac0a6d421339c"
+version = "1.0.0-beta.44"
+source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -5874,7 +5967,7 @@ dependencies = [
  "futures",
  "hex",
  "humantime-serde",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "itertools 0.13.0",
  "lazy_static",
  "metrics",
@@ -5886,7 +5979,7 @@ dependencies = [
  "regex",
  "serde",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5894,15 +5987,15 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-futures",
- "zebra-chain 1.0.0-beta.43",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
 ]
 
 [[package]]
 name = "zebra-network"
 version = "1.0.0-beta.44"
-source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#c7d8d712698c182b3ba46e1b82ff19c2b51a45c4"
+source = "git+https://github.com/ZcashFoundation/zebra.git#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -5910,7 +6003,7 @@ dependencies = [
  "futures",
  "hex",
  "humantime-serde",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "itertools 0.13.0",
  "lazy_static",
  "metrics",
@@ -5922,7 +6015,7 @@ dependencies = [
  "regex",
  "serde",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5930,74 +6023,41 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-futures",
- "zebra-chain 1.0.0-beta.44",
-]
-
-[[package]]
-name = "zebra-node-services"
-version = "1.0.0-beta.43"
-source = "git+https://github.com/ZcashFoundation/zebra.git#0fe47bbbbbb9e7139bdf79c4fecac0a6d421339c"
-dependencies = [
- "color-eyre",
- "jsonrpc-core",
- "reqwest",
- "serde",
- "serde_json",
- "tokio",
- "zebra-chain 1.0.0-beta.43",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
 ]
 
 [[package]]
 name = "zebra-node-services"
 version = "1.0.0-beta.44"
-source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#c7d8d712698c182b3ba46e1b82ff19c2b51a45c4"
+source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
  "color-eyre",
- "jsonrpc-core",
- "reqwest",
- "serde",
- "serde_json",
- "tokio",
- "zebra-chain 1.0.0-beta.44",
-]
-
-[[package]]
-name = "zebra-rpc"
-version = "1.0.0-beta.43"
-source = "git+https://github.com/ZcashFoundation/zebra.git#0fe47bbbbbb9e7139bdf79c4fecac0a6d421339c"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "color-eyre",
- "futures",
- "hex",
- "http-body-util",
- "hyper",
- "indexmap 2.7.0",
- "jsonrpsee",
- "jsonrpsee-proc-macros",
  "jsonrpsee-types",
- "nix",
- "rand 0.8.5",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
- "tower 0.4.13",
- "tracing",
- "zcash_address 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_primitives 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zebra-chain 1.0.0-beta.43",
- "zebra-consensus 1.0.0-beta.43",
- "zebra-network 1.0.0-beta.43",
- "zebra-node-services 1.0.0-beta.43",
- "zebra-script 1.0.0-beta.43",
- "zebra-state 1.0.0-beta.43",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+]
+
+[[package]]
+name = "zebra-node-services"
+version = "1.0.0-beta.44"
+source = "git+https://github.com/ZcashFoundation/zebra.git#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
+dependencies = [
+ "color-eyre",
+ "jsonrpsee-types",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
 ]
 
 [[package]]
 name = "zebra-rpc"
 version = "1.0.0-beta.44"
-source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#c7d8d712698c182b3ba46e1b82ff19c2b51a45c4"
+source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -6006,7 +6066,7 @@ dependencies = [
  "hex",
  "http-body-util",
  "hyper",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "jsonrpsee",
  "jsonrpsee-proc-macros",
  "jsonrpsee-types",
@@ -6018,48 +6078,82 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "zcash_primitives 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zebra-chain 1.0.0-beta.44",
- "zebra-consensus 1.0.0-beta.44",
- "zebra-network 1.0.0-beta.44",
- "zebra-node-services 1.0.0-beta.44",
- "zebra-script 1.0.0-beta.44",
- "zebra-state 1.0.0-beta.44",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zebra-consensus 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zebra-network 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zebra-node-services 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zebra-script 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+ "zebra-state 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
 ]
 
 [[package]]
-name = "zebra-script"
-version = "1.0.0-beta.43"
-source = "git+https://github.com/ZcashFoundation/zebra.git#0fe47bbbbbb9e7139bdf79c4fecac0a6d421339c"
+name = "zebra-rpc"
+version = "1.0.0-beta.44"
+source = "git+https://github.com/ZcashFoundation/zebra.git#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
- "thiserror 2.0.9",
- "zcash_script",
- "zebra-chain 1.0.0-beta.43",
+ "base64 0.22.1",
+ "chrono",
+ "color-eyre",
+ "futures",
+ "hex",
+ "http-body-util",
+ "hyper",
+ "indexmap 2.7.1",
+ "jsonrpsee",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-types",
+ "nix",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower 0.4.13",
+ "tracing",
+ "zcash_address 0.6.2",
+ "zcash_primitives 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
+ "zebra-consensus 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
+ "zebra-network 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
+ "zebra-node-services 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
+ "zebra-script 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
+ "zebra-state 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
 ]
 
 [[package]]
 name = "zebra-script"
 version = "1.0.0-beta.44"
-source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#c7d8d712698c182b3ba46e1b82ff19c2b51a45c4"
+source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "zcash_script",
- "zebra-chain 1.0.0-beta.44",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
+]
+
+[[package]]
+name = "zebra-script"
+version = "1.0.0-beta.44"
+source = "git+https://github.com/ZcashFoundation/zebra.git#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
+dependencies = [
+ "thiserror 2.0.11",
+ "zcash_script",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
 ]
 
 [[package]]
 name = "zebra-state"
-version = "1.0.0-beta.43"
-source = "git+https://github.com/ZcashFoundation/zebra.git#0fe47bbbbbb9e7139bdf79c4fecac0a6d421339c"
+version = "1.0.0-beta.44"
+source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
  "bincode",
  "chrono",
+ "crossbeam-channel",
  "dirs",
  "futures",
  "hex",
  "hex-literal",
  "human_bytes",
  "humantime-serde",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "itertools 0.13.0",
  "lazy_static",
  "metrics",
@@ -6071,27 +6165,28 @@ dependencies = [
  "semver",
  "serde",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
  "tower 0.4.13",
  "tracing",
- "zebra-chain 1.0.0-beta.43",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
 ]
 
 [[package]]
 name = "zebra-state"
 version = "1.0.0-beta.44"
-source = "git+https://github.com/ZcashFoundation/zebra.git?branch=main#c7d8d712698c182b3ba46e1b82ff19c2b51a45c4"
+source = "git+https://github.com/ZcashFoundation/zebra.git#0dcc4205ee1758daf2475ffc5609a94e4f5acc05"
 dependencies = [
  "bincode",
  "chrono",
+ "crossbeam-channel",
  "dirs",
  "futures",
  "hex",
  "hex-literal",
  "human_bytes",
  "humantime-serde",
- "indexmap 2.7.0",
+ "indexmap 2.7.1",
  "itertools 0.13.0",
  "lazy_static",
  "metrics",
@@ -6103,11 +6198,11 @@ dependencies = [
  "semver",
  "serde",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
  "tower 0.4.13",
  "tracing",
- "zebra-chain 1.0.0-beta.44",
+ "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git)",
 ]
 
 [[package]]
@@ -6128,7 +6223,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6148,7 +6243,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -6169,7 +6264,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6191,7 +6286,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6199,9 +6294,9 @@ name = "zingo-memo"
 version = "0.1.0"
 source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_004#f9f3e5f6da261ec6b7bd1282905534fdc328cb41"
 dependencies = [
- "zcash_address 0.6.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
+ "zcash_address 0.6.0",
  "zcash_client_backend",
- "zcash_encoding 0.2.1 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
+ "zcash_encoding 0.2.1",
  "zcash_keys",
  "zcash_primitives 0.19.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
 ]
@@ -6221,7 +6316,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio-rustls",
  "tonic",
- "tower 0.5.1",
+ "tower 0.5.2",
  "webpki-roots 0.25.4",
  "zcash_client_backend",
 ]
@@ -6254,7 +6349,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
- "zcash_address 0.6.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
+ "zcash_address 0.6.0",
  "zcash_client_backend",
  "zcash_keys",
  "zcash_note_encryption",
@@ -6321,9 +6416,9 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing-subscriber",
- "zcash_address 0.6.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
+ "zcash_address 0.6.0",
  "zcash_client_backend",
- "zcash_encoding 0.2.1 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
+ "zcash_encoding 0.2.1",
  "zcash_keys",
  "zcash_note_encryption",
  "zcash_primitives 0.19.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
@@ -6337,9 +6432,9 @@ dependencies = [
 
 [[package]]
 name = "zip32"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92022ac1e47c7b78f9cee29efac8a1a546e189506f3bb5ad46d525be7c519bf6"
+checksum = "2e9943793abf9060b68e1889012dafbd5523ab5b125c0fcc24802d69182f2ac9"
 dependencies = [
  "blake2b_simd",
  "memuse",
@@ -6355,6 +6450,6 @@ dependencies = [
  "base64 0.22.1",
  "nom",
  "percent-encoding",
- "zcash_address 0.6.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
+ "zcash_address 0.6.0",
  "zcash_protocol 0.4.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6281,7 +6281,7 @@ dependencies = [
 [[package]]
 name = "zingo-infra-services"
 version = "0.1.0"
-source = "git+https://github.com/zancas/infrastructure.git?branch=add_reexports#94f90b6ce8002b6d394dc230e18c93e123b681d5"
+source = "git+https://github.com/zingolabs/infrastructure.git#18cce79116589ce88b24310a18ad88e3e3023d7c"
 dependencies = [
  "getset",
  "hex",
@@ -6305,7 +6305,7 @@ dependencies = [
 [[package]]
 name = "zingo-infra-testutils"
 version = "0.1.0"
-source = "git+https://github.com/zancas/infrastructure.git?branch=add_reexports#94f90b6ce8002b6d394dc230e18c93e123b681d5"
+source = "git+https://github.com/zingolabs/infrastructure.git#18cce79116589ce88b24310a18ad88e3e3023d7c"
 dependencies = [
  "http",
  "portpicker",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-compression"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+dependencies = [
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,7 +2037,7 @@ dependencies = [
  "url",
  "zaino-fetch",
  "zaino-testutils",
- "zcash_local_net",
+ "zingo-infra-testutils",
  "zingolib",
 ]
 
@@ -3398,6 +3412,7 @@ version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
@@ -5416,7 +5431,6 @@ dependencies = [
  "zaino-fetch",
  "zainod",
  "zcash_client_backend",
- "zcash_local_net",
  "zcash_protocol 0.4.0",
  "zebra-chain 1.0.0-beta.44 (git+https://github.com/ZcashFoundation/zebra.git?branch=main)",
  "zingolib",
@@ -6452,4 +6466,32 @@ dependencies = [
  "percent-encoding",
  "zcash_address 0.6.0",
  "zcash_protocol 0.4.0",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6281,7 +6281,7 @@ dependencies = [
 [[package]]
 name = "zingo-infra-services"
 version = "0.1.0"
-source = "git+https://github.com/zancas/infrastructure.git?branch=add_reexports#177e27eab93e219a8128e9136db7f42178c4bb37"
+source = "git+https://github.com/zancas/infrastructure.git?branch=add_reexports#94f90b6ce8002b6d394dc230e18c93e123b681d5"
 dependencies = [
  "getset",
  "hex",
@@ -6305,7 +6305,7 @@ dependencies = [
 [[package]]
 name = "zingo-infra-testutils"
 version = "0.1.0"
-source = "git+https://github.com/zancas/infrastructure.git?branch=add_reexports#177e27eab93e219a8128e9136db7f42178c4bb37"
+source = "git+https://github.com/zancas/infrastructure.git?branch=add_reexports#94f90b6ce8002b6d394dc230e18c93e123b681d5"
 dependencies = [
  "http",
  "portpicker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ zebra-rpc = { git = "https://github.com/ZcashFoundation/zebra.git", branch = "ma
 
 
 # Zingo-infra-testutils
-zingo-infra-testutils = { git = "https://github.com/zancas/infrastructure.git", branch = "add_reexports" }
-zingo-infra-services = { git = "https://github.com/zancas/infrastructure.git", branch = "add_reexports" }
+zingo-infra-testutils = { git = "https://github.com/zingolabs/infrastructure.git" }
+zingo-infra-services = { git = "https://github.com/zingolabs/infrastructure.git" }
 
 # Miscellaneous
 tokio = { version = "1.38", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ zebra-rpc = { git = "https://github.com/ZcashFoundation/zebra.git", branch = "ma
 
 
 # Zingo-infra-testutils
-zingo-infra-testutils = { git = "https://github.com/zingolabs/infrastructure.git" }
+zingo-infra-testutils = { git = "https://github.com/zancas/infrastructure.git", branch = "turn_off_fetch" }
 
 # Miscellaneous
 tokio = { version = "1.38", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ zebra-rpc = { git = "https://github.com/ZcashFoundation/zebra.git", branch = "ma
 
 # Zingo-infra-testutils
 zingo-infra-testutils = { git = "https://github.com/zancas/infrastructure.git", branch = "add_reexports" }
+zingo-infra-services = { git = "https://github.com/zancas/infrastructure.git", branch = "add_reexports" }
 
 # Miscellaneous
 tokio = { version = "1.38", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ zebra-rpc = { git = "https://github.com/ZcashFoundation/zebra.git", branch = "ma
 
 
 # Zingo-infra-testutils
-zingo-infra-testutils = { git = "https://github.com/zancas/infrastructure.git", branch = "turn_off_fetch" }
+zingo-infra-testutils = { git = "https://github.com/zancas/infrastructure.git", branch = "add_reexports" }
 
 # Miscellaneous
 tokio = { version = "1.38", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ zebra-state = { git = "https://github.com/ZcashFoundation/zebra.git", branch = "
 zebra-rpc = { git = "https://github.com/ZcashFoundation/zebra.git", branch = "main" }
 
 
-# Zcash-Local-Net
-zingo_infra_testutils = { git = "https://github.com/zingolabs/infrastructure/testutils.git" }
+# Zingo-infra-testutils
+zingo-infra-testutils = { git = "https://github.com/zingolabs/infrastructure.git" }
 
 # Miscellaneous
 tokio = { version = "1.38", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ zebra-rpc = { git = "https://github.com/ZcashFoundation/zebra.git", branch = "ma
 
 
 # Zcash-Local-Net
-zcash_local_net = { git = "https://github.com/zingolabs/zcash-local-net.git", rev = "d64b76cab748455c5b9e1e4412f1689fb66f7d41", features = [ "test_fixtures" ] }
+zingo_infra_testutils = { git = "https://github.com/zingolabs/infrastructure/testutils" }
 
 # Miscellaneous
 tokio = { version = "1.38", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ zebra-rpc = { git = "https://github.com/ZcashFoundation/zebra.git", branch = "ma
 
 
 # Zcash-Local-Net
-zingo_infra_testutils = { git = "https://github.com/zingolabs/infrastructure/testutils" }
+zingo_infra_testutils = { git = "https://github.com/zingolabs/infrastructure/testutils.git" }
 
 # Miscellaneous
 tokio = { version = "1.38", features = ["full"] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -14,7 +14,7 @@ zaino-testutils = { path = "../zaino-testutils" }
 zaino-fetch = { path = "../zaino-fetch" }
 
 # Test fixtures
-zingo-infra-testutils = { workspace = true, features = [ "services" ] }
+zingo-infra-testutils = { workspace = true }
 
 # Lightclient
 zingolib = { workspace = true }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -14,7 +14,7 @@ zaino-testutils = { path = "../zaino-testutils" }
 zaino-fetch = { path = "../zaino-fetch" }
 
 # Test fixtures
-zingo-infra-testutils = { workspace = true }
+zingo-infra-testutils = { workspace = true, features = [ "services" ] }
 
 # Lightclient
 zingolib = { workspace = true }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -14,7 +14,7 @@ zaino-testutils = { path = "../zaino-testutils" }
 zaino-fetch = { path = "../zaino-fetch" }
 
 # Test fixtures
-zcash_local_net = { workspace = true, features = ["test_fixtures"] }
+zingo-infra-testutils = { workspace = true }
 
 # Lightclient
 zingolib = { workspace = true }

--- a/integration-tests/tests/client_rpcs.rs
+++ b/integration-tests/tests/client_rpcs.rs
@@ -5,7 +5,7 @@
 //! See `Testing` section of README.md for more details.
 
 use zaino_testutils::{LIGHTWALLETD_BIN, ZAINOD_BIN, ZCASHD_BIN, ZCASH_CLI_BIN, ZEBRAD_BIN};
-use zingo_infra_testutils::network::Network;
+use zingo_infra_testutils::services::network::Network;
 
 pub mod client_rpcs {
     use super::*;

--- a/integration-tests/tests/client_rpcs.rs
+++ b/integration-tests/tests/client_rpcs.rs
@@ -5,7 +5,7 @@
 //! See `Testing` section of README.md for more details.
 
 use zaino_testutils::{LIGHTWALLETD_BIN, ZAINOD_BIN, ZCASHD_BIN, ZCASH_CLI_BIN, ZEBRAD_BIN};
-use zcash_local_net::network::Network;
+use zingo_infra_testutils::network::Network;
 
 pub mod client_rpcs {
     use super::*;
@@ -15,7 +15,7 @@ pub mod client_rpcs {
     async fn generate_zcashd_chain_cache() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::generate_zcashd_chain_cache(
+        zingo_infra_testutils::test_fixtures::generate_zcashd_chain_cache(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             LIGHTWALLETD_BIN.clone(),
@@ -28,7 +28,7 @@ pub mod client_rpcs {
     async fn generate_zebrad_large_chain_cache() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::generate_zebrad_large_chain_cache(
+        zingo_infra_testutils::test_fixtures::generate_zebrad_large_chain_cache(
             ZEBRAD_BIN.clone(),
             LIGHTWALLETD_BIN.clone(),
         )
@@ -39,7 +39,7 @@ pub mod client_rpcs {
     async fn get_lightd_info() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_lightd_info(
+        zingo_infra_testutils::test_fixtures::get_lightd_info(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -52,7 +52,7 @@ pub mod client_rpcs {
     async fn get_latest_block() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_latest_block(
+        zingo_infra_testutils::test_fixtures::get_latest_block(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -65,7 +65,7 @@ pub mod client_rpcs {
     async fn get_block() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_block(
+        zingo_infra_testutils::test_fixtures::get_block(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -78,7 +78,7 @@ pub mod client_rpcs {
     async fn get_block_out_of_bounds() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_block_out_of_bounds(
+        zingo_infra_testutils::test_fixtures::get_block_out_of_bounds(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -91,7 +91,7 @@ pub mod client_rpcs {
     async fn get_block_nullifiers() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_block_nullifiers(
+        zingo_infra_testutils::test_fixtures::get_block_nullifiers(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -104,7 +104,7 @@ pub mod client_rpcs {
     async fn get_block_range_nullifiers() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_block_range_nullifiers(
+        zingo_infra_testutils::test_fixtures::get_block_range_nullifiers(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -117,7 +117,7 @@ pub mod client_rpcs {
     async fn get_block_range_nullifiers_reverse() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_block_range_nullifiers_reverse(
+        zingo_infra_testutils::test_fixtures::get_block_range_nullifiers_reverse(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -130,7 +130,7 @@ pub mod client_rpcs {
     async fn get_block_range_lower() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_block_range_lower(
+        zingo_infra_testutils::test_fixtures::get_block_range_lower(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -143,7 +143,7 @@ pub mod client_rpcs {
     async fn get_block_range_upper() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_block_range_upper(
+        zingo_infra_testutils::test_fixtures::get_block_range_upper(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -156,7 +156,7 @@ pub mod client_rpcs {
     async fn get_block_range_reverse() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_block_range_reverse(
+        zingo_infra_testutils::test_fixtures::get_block_range_reverse(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -169,7 +169,7 @@ pub mod client_rpcs {
     async fn get_block_range_out_of_bounds() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_block_range_out_of_bounds(
+        zingo_infra_testutils::test_fixtures::get_block_range_out_of_bounds(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -182,7 +182,7 @@ pub mod client_rpcs {
     async fn get_transaction() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_transaction(
+        zingo_infra_testutils::test_fixtures::get_transaction(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -196,7 +196,7 @@ pub mod client_rpcs {
     async fn send_transaction() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::send_transaction(
+        zingo_infra_testutils::test_fixtures::send_transaction(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -209,7 +209,7 @@ pub mod client_rpcs {
     async fn get_taddress_txids_all() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_taddress_txids_all(
+        zingo_infra_testutils::test_fixtures::get_taddress_txids_all(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -222,7 +222,7 @@ pub mod client_rpcs {
     async fn get_taddress_txids_lower() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_taddress_txids_lower(
+        zingo_infra_testutils::test_fixtures::get_taddress_txids_lower(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -235,7 +235,7 @@ pub mod client_rpcs {
     async fn get_taddress_txids_upper() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_taddress_txids_upper(
+        zingo_infra_testutils::test_fixtures::get_taddress_txids_upper(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -248,7 +248,7 @@ pub mod client_rpcs {
     async fn get_taddress_balance() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_taddress_balance(
+        zingo_infra_testutils::test_fixtures::get_taddress_balance(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -261,7 +261,7 @@ pub mod client_rpcs {
     async fn get_taddress_balance_stream() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_taddress_balance_stream(
+        zingo_infra_testutils::test_fixtures::get_taddress_balance_stream(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -274,7 +274,7 @@ pub mod client_rpcs {
     async fn get_mempool_tx() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_mempool_tx(
+        zingo_infra_testutils::test_fixtures::get_mempool_tx(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -287,7 +287,7 @@ pub mod client_rpcs {
     async fn get_mempool_stream_zingolib_mempool_monitor() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_mempool_stream_zingolib_mempool_monitor(
+        zingo_infra_testutils::test_fixtures::get_mempool_stream_zingolib_mempool_monitor(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -300,7 +300,7 @@ pub mod client_rpcs {
     async fn get_mempool_stream() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_mempool_stream(
+        zingo_infra_testutils::test_fixtures::get_mempool_stream(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -313,7 +313,7 @@ pub mod client_rpcs {
     async fn get_tree_state_by_height() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_tree_state_by_height(
+        zingo_infra_testutils::test_fixtures::get_tree_state_by_height(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -326,7 +326,7 @@ pub mod client_rpcs {
     async fn get_tree_state_by_hash() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_tree_state_by_hash(
+        zingo_infra_testutils::test_fixtures::get_tree_state_by_hash(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -339,7 +339,7 @@ pub mod client_rpcs {
     async fn get_tree_state_out_of_bounds() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_tree_state_out_of_bounds(
+        zingo_infra_testutils::test_fixtures::get_tree_state_out_of_bounds(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -352,7 +352,7 @@ pub mod client_rpcs {
     async fn get_latest_tree_state() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_latest_tree_state(
+        zingo_infra_testutils::test_fixtures::get_latest_tree_state(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -369,7 +369,7 @@ pub mod client_rpcs {
     async fn get_subtree_roots_sapling() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_subtree_roots_sapling(
+        zingo_infra_testutils::test_fixtures::get_subtree_roots_sapling(
             ZEBRAD_BIN.clone(),
             ZAINOD_BIN.clone(),
             LIGHTWALLETD_BIN.clone(),
@@ -386,7 +386,7 @@ pub mod client_rpcs {
     async fn get_subtree_roots_orchard() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_subtree_roots_orchard(
+        zingo_infra_testutils::test_fixtures::get_subtree_roots_orchard(
             ZEBRAD_BIN.clone(),
             ZAINOD_BIN.clone(),
             LIGHTWALLETD_BIN.clone(),
@@ -399,7 +399,7 @@ pub mod client_rpcs {
     async fn get_address_utxos_all() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_address_utxos_all(
+        zingo_infra_testutils::test_fixtures::get_address_utxos_all(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -412,7 +412,7 @@ pub mod client_rpcs {
     async fn get_address_utxos_lower() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_address_utxos_lower(
+        zingo_infra_testutils::test_fixtures::get_address_utxos_lower(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -425,7 +425,7 @@ pub mod client_rpcs {
     async fn get_address_utxos_upper() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_address_utxos_upper(
+        zingo_infra_testutils::test_fixtures::get_address_utxos_upper(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -438,7 +438,7 @@ pub mod client_rpcs {
     async fn get_address_utxos_out_of_bounds() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_address_utxos_out_of_bounds(
+        zingo_infra_testutils::test_fixtures::get_address_utxos_out_of_bounds(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -451,7 +451,7 @@ pub mod client_rpcs {
     async fn get_address_utxos_stream_all() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_address_utxos_stream_all(
+        zingo_infra_testutils::test_fixtures::get_address_utxos_stream_all(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -464,7 +464,7 @@ pub mod client_rpcs {
     async fn get_address_utxos_stream_lower() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_address_utxos_stream_lower(
+        zingo_infra_testutils::test_fixtures::get_address_utxos_stream_lower(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -477,7 +477,7 @@ pub mod client_rpcs {
     async fn get_address_utxos_stream_upper() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_address_utxos_stream_upper(
+        zingo_infra_testutils::test_fixtures::get_address_utxos_stream_upper(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),
@@ -490,7 +490,7 @@ pub mod client_rpcs {
     async fn get_address_utxos_stream_out_of_bounds() {
         tracing_subscriber::fmt().init();
 
-        zcash_local_net::test_fixtures::get_address_utxos_stream_out_of_bounds(
+        zingo_infra_testutils::test_fixtures::get_address_utxos_stream_out_of_bounds(
             ZCASHD_BIN.clone(),
             ZCASH_CLI_BIN.clone(),
             ZAINOD_BIN.clone(),

--- a/integration-tests/tests/wallet_to_validator.rs
+++ b/integration-tests/tests/wallet_to_validator.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 use zaino_testutils::TestManager;
-use zcash_local_net::validator::Validator;
+use zingo_infra_testutils::validator::Validator;
 use zingolib::testutils::lightclient::from_inputs;
 
 mod wallet_basic {

--- a/integration-tests/tests/wallet_to_validator.rs
+++ b/integration-tests/tests/wallet_to_validator.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 use zaino_testutils::TestManager;
-use zingo_infra_testutils::validator::Validator;
+use zingo_infra_testutils::services::validator::Validator;
 use zingolib::testutils::lightclient::from_inputs;
 
 mod wallet_basic {

--- a/zaino-state/Cargo.toml
+++ b/zaino-state/Cargo.toml
@@ -42,7 +42,7 @@ prost = { workspace = true }
 zaino-testutils = { path = "../zaino-testutils" }
 
 # Test Utilities
-zcash_local_net = { workspace = true, features = ["test_fixtures"] }
+zingo-infra-testutils = { workspace = true }
 
 # ZingoLib
 zingolib = { workspace = true }

--- a/zaino-state/Cargo.toml
+++ b/zaino-state/Cargo.toml
@@ -40,9 +40,7 @@ prost = { workspace = true }
 
 [dev-dependencies]
 zaino-testutils = { path = "../zaino-testutils" }
-
-# Test Utilities
-zingo-infra-testutils = { workspace = true }
+zingo-infra-services = { workspace = true }
 
 # ZingoLib
 zingolib = { workspace = true }

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -1826,8 +1826,8 @@ mod tests {
 
     use super::*;
     use zaino_testutils::{TestManager, ZCASHD_CHAIN_CACHE_BIN, ZEBRAD_CHAIN_CACHE_BIN};
-    use zingo_infra_testutils::validator::Validator;
     use zebra_chain::parameters::Network;
+    use zingo_infra_services::validator::Validator;
 
     #[tokio::test]
     async fn launch_fetch_service_zcashd_regtest_no_cache() {

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -1826,7 +1826,7 @@ mod tests {
 
     use super::*;
     use zaino_testutils::{TestManager, ZCASHD_CHAIN_CACHE_BIN, ZEBRAD_CHAIN_CACHE_BIN};
-    use zcash_local_net::validator::Validator;
+    use zingo_infra_testutils::validator::Validator;
     use zebra_chain::parameters::Network;
 
     #[tokio::test]

--- a/zaino-state/src/state.rs
+++ b/zaino-state/src/state.rs
@@ -1066,7 +1066,7 @@ mod tests {
     use futures::stream::StreamExt;
     use zaino_proto::proto::service::BlockId;
     use zaino_testutils::{TestManager, ZEBRAD_CHAIN_CACHE_BIN, ZEBRAD_TESTNET_CACHE_BIN};
-    use zcash_local_net::validator::Validator;
+    use zingo_infra_testutils::validator::Validator;
     use zebra_chain::parameters::Network;
 
     #[tokio::test]
@@ -1689,7 +1689,7 @@ mod tests {
     async fn state_service_testnet_get_block_range_large() {
         let mut test_manager = TestManager::launch(
             "zebrad",
-            Some(zcash_local_net::network::Network::Testnet),
+            Some(zingo_infra_testutils::network::Network::Testnet),
             ZEBRAD_TESTNET_CACHE_BIN.clone(),
             false,
             true,

--- a/zaino-state/src/state.rs
+++ b/zaino-state/src/state.rs
@@ -1066,8 +1066,8 @@ mod tests {
     use futures::stream::StreamExt;
     use zaino_proto::proto::service::BlockId;
     use zaino_testutils::{TestManager, ZEBRAD_CHAIN_CACHE_BIN, ZEBRAD_TESTNET_CACHE_BIN};
-    use zingo_infra_testutils::validator::Validator;
     use zebra_chain::parameters::Network;
+    use zingo_infra_services::validator::Validator;
 
     #[tokio::test]
     async fn launch_state_regtest_service_no_cache() {
@@ -1689,7 +1689,7 @@ mod tests {
     async fn state_service_testnet_get_block_range_large() {
         let mut test_manager = TestManager::launch(
             "zebrad",
-            Some(zingo_infra_testutils::network::Network::Testnet),
+            Some(zingo_infra_services::network::Network::Testnet),
             ZEBRAD_TESTNET_CACHE_BIN.clone(),
             false,
             true,

--- a/zaino-testutils/Cargo.toml
+++ b/zaino-testutils/Cargo.toml
@@ -27,7 +27,7 @@ zebra-chain = { workspace = true }
 zingolib = { workspace = true }
 
 # Test Utilities
-zingo-infra-testutils = { workspace = true, features = [ "services" ] }
+zingo-infra-testutils = { workspace = true }
 
 # Miscellaneous
 tokio = { workspace = true }

--- a/zaino-testutils/Cargo.toml
+++ b/zaino-testutils/Cargo.toml
@@ -27,7 +27,7 @@ zebra-chain = { workspace = true }
 zingolib = { workspace = true }
 
 # Test Utilities
-zingo-infra-testutils = { workspace = true }
+zingo-infra-testutils = { workspace = true, features = [ "services" ] }
 
 # Miscellaneous
 tokio = { workspace = true }

--- a/zaino-testutils/Cargo.toml
+++ b/zaino-testutils/Cargo.toml
@@ -27,7 +27,7 @@ zebra-chain = { workspace = true }
 zingolib = { workspace = true }
 
 # Test Utilities
-zcash_local_net = { workspace = true, features = ["test_fixtures"] }
+zingo-infra-testutils = { workspace = true }
 
 # Miscellaneous
 tokio = { workspace = true }


### PR DESCRIPTION
This PR proposes to have `zaino` depend on the refactored/rebranded version of `zcash-local-net` which is exposed as the crate [zingo_infra_testutils](https://github.com/zingolabs/infrastructure/tree/main/testutils) in the [infrastructure repo](https://github.com/zingolabs/infrastructure/tree/main).

Before committing to `zaino` I ran the "client_rpcs" tests in `zaino`, as described here:

https://github.com/zingolabs/zaino/blob/dev/docs/testing.md#client-rpc-tests

I ran them against commit:

```
git show
commit ab3183d812adcae35821fc6b0bf1d1c441759f44 (HEAD -> port_to_new_test_infrastructure, zingolabs/dev, zingolabs/HEAD, zancos/port_to_new_test_infrastructure)
Merge: 668205e 5afc472
Author: Za Wilcox <zancas@zingolabs.org>
Date:   Tue Jan 28 13:36:49 2025 -0700

    Merge pull request #171 from idky137/add_version_command

    Add --version command
```
which was then "dev".

Here are the results:
```
cargo nextest run --test client_rpcs --failure-output never
    Finished `test` profile [optimized + debuginfo] target(s) in 0.17s
------------
 Nextest run ID 246394fb-e261-415e-aeb6-204cca062c87 with nextest profile: default
    Starting 34 tests across 1 binary (3 tests skipped)
        PASS [  16.825s] integration-tests::client_rpcs client_rpcs::get_latest_block
        PASS [  16.829s] integration-tests::client_rpcs client_rpcs::get_address_utxos_stream_upper
        PASS [  16.829s] integration-tests::client_rpcs client_rpcs::get_address_utxos_upper
        PASS [  16.829s] integration-tests::client_rpcs client_rpcs::get_address_utxos_stream_lower
        PASS [  16.833s] integration-tests::client_rpcs client_rpcs::get_address_utxos_out_of_bounds
        PASS [  16.833s] integration-tests::client_rpcs client_rpcs::get_lightd_info
        FAIL [   0.009s] integration-tests::client_rpcs client_rpcs::get_subtree_roots_orchard
        FAIL [   0.010s] integration-tests::client_rpcs client_rpcs::get_subtree_roots_sapling
        FAIL [  17.833s] integration-tests::client_rpcs client_rpcs::get_block_range_nullifiers_reverse
        FAIL [  17.833s] integration-tests::client_rpcs client_rpcs::get_block_range_nullifiers
        PASS [  17.839s] integration-tests::client_rpcs client_rpcs::get_address_utxos_lower
        PASS [  17.857s] integration-tests::client_rpcs client_rpcs::get_address_utxos_all
        FAIL [  17.856s] integration-tests::client_rpcs client_rpcs::get_block_range_reverse
        FAIL [  17.861s] integration-tests::client_rpcs client_rpcs::get_block
        FAIL [  17.865s] integration-tests::client_rpcs client_rpcs::get_block_nullifiers
        PASS [  17.867s] integration-tests::client_rpcs client_rpcs::get_address_utxos_stream_all
        FAIL [  17.877s] integration-tests::client_rpcs client_rpcs::get_block_range_lower
        PASS [  17.879s] integration-tests::client_rpcs client_rpcs::get_address_utxos_stream_out_of_bounds
        PASS [  17.879s] integration-tests::client_rpcs client_rpcs::get_latest_tree_state
        FAIL [  17.892s] integration-tests::client_rpcs client_rpcs::get_block_range_out_of_bounds
        FAIL [  18.837s] integration-tests::client_rpcs client_rpcs::get_block_out_of_bounds
        FAIL [  18.907s] integration-tests::client_rpcs client_rpcs::get_block_range_upper
        PASS [  11.984s] integration-tests::client_rpcs client_rpcs::get_taddress_balance
        PASS [  10.986s] integration-tests::client_rpcs client_rpcs::get_taddress_txids_lower
        FAIL [  10.959s] integration-tests::client_rpcs client_rpcs::get_tree_state_out_of_bounds
        PASS [  11.982s] integration-tests::client_rpcs client_rpcs::get_taddress_balance_stream
        PASS [  11.980s] integration-tests::client_rpcs client_rpcs::get_taddress_txids_all
        PASS [  10.964s] integration-tests::client_rpcs client_rpcs::get_tree_state_by_height
        PASS [  11.980s] integration-tests::client_rpcs client_rpcs::get_taddress_txids_upper
        PASS [  11.961s] integration-tests::client_rpcs client_rpcs::get_tree_state_by_hash
        PASS [  20.981s] integration-tests::client_rpcs client_rpcs::get_transaction
        FAIL [  42.990s] integration-tests::client_rpcs client_rpcs::get_mempool_tx
        PASS [  46.002s] integration-tests::client_rpcs client_rpcs::get_mempool_stream
        PASS [  54.007s] integration-tests::client_rpcs client_rpcs::get_mempool_stream_zingolib_mempool_monitor
------------
     Summary [  70.838s] 34 tests run: 21 passed, 13 failed, 3 skipped
        FAIL [  17.861s] integration-tests::client_rpcs client_rpcs::get_block
        FAIL [  17.865s] integration-tests::client_rpcs client_rpcs::get_block_nullifiers
        FAIL [  18.837s] integration-tests::client_rpcs client_rpcs::get_block_out_of_bounds
        FAIL [  17.877s] integration-tests::client_rpcs client_rpcs::get_block_range_lower
        FAIL [  17.833s] integration-tests::client_rpcs client_rpcs::get_block_range_nullifiers
        FAIL [  17.833s] integration-tests::client_rpcs client_rpcs::get_block_range_nullifiers_reverse
        FAIL [  17.892s] integration-tests::client_rpcs client_rpcs::get_block_range_out_of_bounds
        FAIL [  17.856s] integration-tests::client_rpcs client_rpcs::get_block_range_reverse
        FAIL [  18.907s] integration-tests::client_rpcs client_rpcs::get_block_range_upper
        FAIL [  42.990s] integration-tests::client_rpcs client_rpcs::get_mempool_tx
        FAIL [   0.009s] integration-tests::client_rpcs client_rpcs::get_subtree_roots_orchard
        FAIL [   0.010s] integration-tests::client_rpcs client_rpcs::get_subtree_roots_sapling
        FAIL [  10.959s] integration-tests::client_rpcs client_rpcs::get_tree_state_out_of_bounds
error: test run failed
```

I will use this as baseline to argue that the change of name here, doesn't cause new errors.