### PR TITLE
Handle critical errors

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,3 @@
 [profile.default]
+test-threads = 4
 fail-fast = false

--- a/integration-tests/tests/wallet_to_validator.rs
+++ b/integration-tests/tests/wallet_to_validator.rs
@@ -60,9 +60,11 @@ mod wallet_basic {
 
         if validator == "zebrad" {
             test_manager.local_net.generate_blocks(100).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             clients.faucet.do_sync(true).await.unwrap();
             clients.faucet.quick_shield().await.unwrap();
             test_manager.local_net.generate_blocks(1).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             clients.faucet.do_sync(true).await.unwrap();
         };
 
@@ -77,6 +79,7 @@ mod wallet_basic {
         .await
         .unwrap();
         test_manager.local_net.generate_blocks(1).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         clients.recipient.do_sync(true).await.unwrap();
 
         assert_eq!(
@@ -115,9 +118,11 @@ mod wallet_basic {
 
         if validator == "zebrad" {
             test_manager.local_net.generate_blocks(100).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             clients.faucet.do_sync(true).await.unwrap();
             clients.faucet.quick_shield().await.unwrap();
             test_manager.local_net.generate_blocks(1).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             clients.faucet.do_sync(true).await.unwrap();
         };
 
@@ -132,6 +137,7 @@ mod wallet_basic {
         .await
         .unwrap();
         test_manager.local_net.generate_blocks(1).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         clients.recipient.do_sync(true).await.unwrap();
 
         assert_eq!(
@@ -171,9 +177,11 @@ mod wallet_basic {
 
         if validator == "zebrad" {
             test_manager.local_net.generate_blocks(100).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             clients.faucet.do_sync(true).await.unwrap();
             clients.faucet.quick_shield().await.unwrap();
             test_manager.local_net.generate_blocks(1).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             clients.faucet.do_sync(true).await.unwrap();
         };
 
@@ -189,6 +197,7 @@ mod wallet_basic {
         .unwrap();
 
         test_manager.local_net.generate_blocks(1).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
         let fetch_service = zaino_fetch::jsonrpc::connector::JsonRpcConnector::new_with_basic_auth(
             test_node_and_return_url(
@@ -222,7 +231,17 @@ mod wallet_basic {
 
         dbg!(unfinalised_transactions.clone());
 
-        test_manager.local_net.generate_blocks(99).await.unwrap();
+        // Generate blocks
+        //
+        // NOTE: Generating blocks with zcashd blocks the tokio main thread???, stopping background processes from running,
+        //       for this reason we generate blocks 1 at a time and sleep to let other tasks run.
+        for height in 1..=99 {
+            dbg!("Generating block at height: {}", height);
+            test_manager.local_net.generate_blocks(1).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
         println!("\n\nFetching Tx From Finalized Chain!\n");
 
@@ -275,20 +294,25 @@ mod wallet_basic {
             .expect("Clients are not initialized");
 
         test_manager.local_net.generate_blocks(2).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         clients.faucet.do_sync(true).await.unwrap();
 
         // "Create" 3 orchard notes in faucet.
         if validator == "zebrad" {
             test_manager.local_net.generate_blocks(100).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             clients.faucet.do_sync(true).await.unwrap();
             clients.faucet.quick_shield().await.unwrap();
             test_manager.local_net.generate_blocks(100).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             clients.faucet.do_sync(true).await.unwrap();
             clients.faucet.quick_shield().await.unwrap();
             test_manager.local_net.generate_blocks(100).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             clients.faucet.do_sync(true).await.unwrap();
             clients.faucet.quick_shield().await.unwrap();
             test_manager.local_net.generate_blocks(1).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             clients.faucet.do_sync(true).await.unwrap();
         };
 
@@ -323,7 +347,17 @@ mod wallet_basic {
         .await
         .unwrap();
 
-        test_manager.local_net.generate_blocks(100).await.unwrap();
+        // Generate blocks
+        //
+        // NOTE: Generating blocks with zcashd blocks the tokio main thread???, stopping background processes from running,
+        //       for this reason we generate blocks 1 at a time and sleep to let other tasks run.
+        for height in 1..=100 {
+            dbg!("Generating block at height: {}", height);
+            test_manager.local_net.generate_blocks(1).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         clients.recipient.do_sync(true).await.unwrap();
 
         assert_eq!(
@@ -380,9 +414,11 @@ mod wallet_basic {
 
         if validator == "zebrad" {
             test_manager.local_net.generate_blocks(100).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             clients.faucet.do_sync(true).await.unwrap();
             clients.faucet.quick_shield().await.unwrap();
             test_manager.local_net.generate_blocks(1).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             clients.faucet.do_sync(true).await.unwrap();
         };
 
@@ -397,7 +433,17 @@ mod wallet_basic {
         .await
         .unwrap();
 
-        test_manager.local_net.generate_blocks(100).await.unwrap();
+        // Generate blocks
+        //
+        // NOTE: Generating blocks with zcashd blocks the tokio main thread???, stopping background processes from running,
+        //       for this reason we generate blocks 1 at a time and sleep to let other tasks run.
+        for height in 1..=100 {
+            dbg!("Generating block at height: {}", height);
+            test_manager.local_net.generate_blocks(1).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         clients.recipient.do_sync(true).await.unwrap();
 
         assert_eq!(
@@ -412,6 +458,7 @@ mod wallet_basic {
 
         clients.recipient.quick_shield().await.unwrap();
         test_manager.local_net.generate_blocks(1).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         clients.recipient.do_sync(true).await.unwrap();
 
         assert_eq!(
@@ -449,16 +496,20 @@ mod wallet_basic {
         let recipient_client = Arc::new(clients.recipient);
 
         test_manager.local_net.generate_blocks(1).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         clients.faucet.do_sync(true).await.unwrap();
 
         if validator == "zebrad" {
             test_manager.local_net.generate_blocks(100).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             clients.faucet.do_sync(true).await.unwrap();
             clients.faucet.quick_shield().await.unwrap();
             test_manager.local_net.generate_blocks(100).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             clients.faucet.do_sync(true).await.unwrap();
             clients.faucet.quick_shield().await.unwrap();
             test_manager.local_net.generate_blocks(1).await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
             clients.faucet.do_sync(true).await.unwrap();
         };
 
@@ -528,22 +579,6 @@ mod wallet_basic {
                 .await
         );
 
-        test_manager.local_net.generate_blocks(1).await.unwrap();
-
-        println!("\n\nFetching Mined Tx 1!\n");
-        let _transaction_1 = dbg!(
-            fetch_service
-                .get_raw_transaction(mempool_txids.transactions[0].clone(), Some(1))
-                .await
-        );
-
-        println!("\n\nFetching Mined Tx 2!\n");
-        let _transaction_2 = dbg!(
-            fetch_service
-                .get_raw_transaction(mempool_txids.transactions[1].clone(), Some(1))
-                .await
-        );
-
         assert_eq!(
             recipient_client
                 .do_balance()
@@ -562,7 +597,21 @@ mod wallet_basic {
         );
 
         test_manager.local_net.generate_blocks(1).await.unwrap();
-        recipient_client.do_rescan().await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        println!("\n\nFetching Mined Tx 1!\n");
+        let _transaction_1 = dbg!(
+            fetch_service
+                .get_raw_transaction(mempool_txids.transactions[0].clone(), Some(1))
+                .await
+        );
+
+        println!("\n\nFetching Mined Tx 2!\n");
+        let _transaction_2 = dbg!(
+            fetch_service
+                .get_raw_transaction(mempool_txids.transactions[1].clone(), Some(1))
+                .await
+        );
 
         assert_eq!(
             recipient_client

--- a/zaino-serve/src/server/grpc.rs
+++ b/zaino-serve/src/server/grpc.rs
@@ -34,9 +34,8 @@ impl TonicServer {
     pub async fn spawn(
         service_subscriber: IndexerSubscriber<FetchServiceSubscriber>,
         server_config: GrpcConfig,
-        status: AtomicStatus,
     ) -> Result<Self, ServerError> {
-        status.store(StatusType::Spawning as usize);
+        let status = AtomicStatus::new(StatusType::Spawning.into());
 
         let svc = CompactTxStreamerServer::new(GrpcClient {
             service_subscriber: service_subscriber.clone(),
@@ -78,7 +77,7 @@ impl TonicServer {
     }
 
     /// Sets the servers to close gracefully.
-    pub async fn shutdown(&mut self) {
+    pub async fn close(&mut self) {
         self.status.store(StatusType::Closing as usize);
 
         if let Some(handle) = self.server_handle.take() {

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -99,7 +99,8 @@ impl ZcashService for FetchService {
             zebra_build_data.subversion,
         );
 
-        let block_cache = BlockCache::spawn(&fetcher, config.clone().into()).await?;
+        let block_cache =
+            BlockCache::spawn(&fetcher, config.clone().into(), status.clone()).await?;
 
         let mempool = Mempool::spawn(&fetcher, None).await?;
 

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -133,6 +133,10 @@ impl ZcashService for FetchService {
             | (_, StatusType::Offline)
             | (StatusType::CriticalError, _)
             | (_, StatusType::CriticalError) => StatusType::CriticalError,
+            // If either is RecoverableError, return RecoverableError.
+            (StatusType::RecoverableError, _) | (_, StatusType::RecoverableError) => {
+                StatusType::RecoverableError
+            }
             // If either is Spawning, return Spawning.
             (StatusType::Spawning, _) | (_, StatusType::Spawning) => StatusType::Spawning,
             // If either is Syncing, return Syncing.
@@ -186,6 +190,10 @@ impl FetchServiceSubscriber {
             | (_, StatusType::Offline)
             | (StatusType::CriticalError, _)
             | (_, StatusType::CriticalError) => StatusType::CriticalError,
+            // If either is RecoverableError, return RecoverableError.
+            (StatusType::RecoverableError, _) | (_, StatusType::RecoverableError) => {
+                StatusType::RecoverableError
+            }
             // If either is Spawning, return Spawning.
             (StatusType::Spawning, _) | (_, StatusType::Spawning) => StatusType::Spawning,
             // If either is Syncing, return Syncing.

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -94,13 +94,19 @@ impl ZcashService for FetchService {
 
         let mempool = Mempool::spawn(&fetcher, None).await?;
 
-        Ok(Self {
+        let fetch_service = Self {
             fetcher,
             block_cache,
             mempool,
             data,
             config,
-        })
+        };
+
+        while fetch_service.status() != StatusType::Ready {
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+
+        Ok(fetch_service)
     }
 
     /// Returns a [`FetchServiceSubscriber`].

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -125,25 +125,7 @@ impl ZcashService for FetchService {
         let mempool_status = self.mempool.status();
         let block_cache_status = self.block_cache.status();
 
-        match (mempool_status, block_cache_status) {
-            // If either is Closing, return Closing.
-            (StatusType::Closing, _) | (_, StatusType::Closing) => StatusType::Closing,
-            // If either is Offline or CriticalError, return CriticalError.
-            (StatusType::Offline, _)
-            | (_, StatusType::Offline)
-            | (StatusType::CriticalError, _)
-            | (_, StatusType::CriticalError) => StatusType::CriticalError,
-            // If either is RecoverableError, return RecoverableError.
-            (StatusType::RecoverableError, _) | (_, StatusType::RecoverableError) => {
-                StatusType::RecoverableError
-            }
-            // If either is Spawning, return Spawning.
-            (StatusType::Spawning, _) | (_, StatusType::Spawning) => StatusType::Spawning,
-            // If either is Syncing, return Syncing.
-            (StatusType::Syncing, _) | (_, StatusType::Syncing) => StatusType::Syncing,
-            // Otherwise, return Ready.
-            _ => StatusType::Ready,
-        }
+        mempool_status.combine(block_cache_status)
     }
 
     /// Shuts down the StateService.
@@ -182,25 +164,7 @@ impl FetchServiceSubscriber {
         let mempool_status = self.mempool.status();
         let block_cache_status = self.block_cache.status();
 
-        match (mempool_status, block_cache_status) {
-            // If either is Closing, return Closing.
-            (StatusType::Closing, _) | (_, StatusType::Closing) => StatusType::Closing,
-            // If either is Offline or CriticalError, return CriticalError.
-            (StatusType::Offline, _)
-            | (_, StatusType::Offline)
-            | (StatusType::CriticalError, _)
-            | (_, StatusType::CriticalError) => StatusType::CriticalError,
-            // If either is RecoverableError, return RecoverableError.
-            (StatusType::RecoverableError, _) | (_, StatusType::RecoverableError) => {
-                StatusType::RecoverableError
-            }
-            // If either is Spawning, return Spawning.
-            (StatusType::Spawning, _) | (_, StatusType::Spawning) => StatusType::Spawning,
-            // If either is Syncing, return Syncing.
-            (StatusType::Syncing, _) | (_, StatusType::Syncing) => StatusType::Syncing,
-            // Otherwise, return Ready.
-            _ => StatusType::Ready,
-        }
+        mempool_status.combine(block_cache_status)
     }
 }
 

--- a/zaino-state/src/indexer.rs
+++ b/zaino-state/src/indexer.rs
@@ -18,7 +18,7 @@ use zebra_rpc::methods::{
 };
 
 use crate::{
-    status::{AtomicStatus, StatusType},
+    status::StatusType,
     stream::{
         AddressStream, CompactBlockStream, CompactTransactionStream, RawTransactionStream,
         SubtreeRootReplyStream, UtxoReplyStream,
@@ -41,12 +41,9 @@ where
     Service: ZcashService,
 {
     /// Creates a new `IndexerService` using the provided `config`.
-    pub async fn spawn(
-        config: Service::Config,
-        status: AtomicStatus,
-    ) -> Result<Self, Service::Error> {
+    pub async fn spawn(config: Service::Config) -> Result<Self, Service::Error> {
         Ok(IndexerService {
-            service: Service::spawn(config, status).await?,
+            service: Service::spawn(config).await?,
         })
     }
 
@@ -74,7 +71,7 @@ pub trait ZcashService: Sized {
     type Config: Clone;
 
     /// Spawns a [`Service`].
-    async fn spawn(config: Self::Config, status: AtomicStatus) -> Result<Self, Self::Error>;
+    async fn spawn(config: Self::Config) -> Result<Self, Self::Error>;
 
     /// Returns a [`ServiceSubscriber`].
     fn get_subscriber(&self) -> IndexerSubscriber<Self::Subscriber>;

--- a/zaino-state/src/local_cache.rs
+++ b/zaino-state/src/local_cache.rs
@@ -80,25 +80,7 @@ impl BlockCache {
             },
         };
 
-        match (non_finalised_state_status, finalised_state_status) {
-            // If either is Closing, return Closing.
-            (StatusType::Closing, _) | (_, StatusType::Closing) => StatusType::Closing,
-            // If either is Offline or CriticalError, return CriticalError.
-            (StatusType::Offline, _)
-            | (_, StatusType::Offline)
-            | (StatusType::CriticalError, _)
-            | (_, StatusType::CriticalError) => StatusType::CriticalError,
-            // If either is RecoverableError, return RecoverableError.
-            (StatusType::RecoverableError, _) | (_, StatusType::RecoverableError) => {
-                StatusType::RecoverableError
-            }
-            // If either is Spawning, return Spawning.
-            (StatusType::Spawning, _) | (_, StatusType::Spawning) => StatusType::Spawning,
-            // If either is Syncing, return Syncing.
-            (StatusType::Syncing, _) | (_, StatusType::Syncing) => StatusType::Syncing,
-            // Otherwise, return Ready.
-            _ => StatusType::Ready,
-        }
+        non_finalised_state_status.combine(finalised_state_status)
     }
 
     /// Sets the block cache to close gracefully.
@@ -220,25 +202,7 @@ impl BlockCacheSubscriber {
             },
         };
 
-        match (non_finalised_state_status, finalised_state_status) {
-            // If either is Closing, return Closing.
-            (StatusType::Closing, _) | (_, StatusType::Closing) => StatusType::Closing,
-            // If either is Offline or CriticalError, return CriticalError.
-            (StatusType::Offline, _)
-            | (_, StatusType::Offline)
-            | (StatusType::CriticalError, _)
-            | (_, StatusType::CriticalError) => StatusType::CriticalError,
-            // If either is RecoverableError, return RecoverableError.
-            (StatusType::RecoverableError, _) | (_, StatusType::RecoverableError) => {
-                StatusType::RecoverableError
-            }
-            // If either is Spawning, return Spawning.
-            (StatusType::Spawning, _) | (_, StatusType::Spawning) => StatusType::Spawning,
-            // If either is Syncing, return Syncing.
-            (StatusType::Syncing, _) | (_, StatusType::Syncing) => StatusType::Syncing,
-            // Otherwise, return Ready.
-            _ => StatusType::Ready,
-        }
+        non_finalised_state_status.combine(finalised_state_status)
     }
 }
 

--- a/zaino-state/src/local_cache.rs
+++ b/zaino-state/src/local_cache.rs
@@ -88,6 +88,10 @@ impl BlockCache {
             | (_, StatusType::Offline)
             | (StatusType::CriticalError, _)
             | (_, StatusType::CriticalError) => StatusType::CriticalError,
+            // If either is RecoverableError, return RecoverableError.
+            (StatusType::RecoverableError, _) | (_, StatusType::RecoverableError) => {
+                StatusType::RecoverableError
+            }
             // If either is Spawning, return Spawning.
             (StatusType::Spawning, _) | (_, StatusType::Spawning) => StatusType::Spawning,
             // If either is Syncing, return Syncing.
@@ -224,6 +228,10 @@ impl BlockCacheSubscriber {
             | (_, StatusType::Offline)
             | (StatusType::CriticalError, _)
             | (_, StatusType::CriticalError) => StatusType::CriticalError,
+            // If either is RecoverableError, return RecoverableError.
+            (StatusType::RecoverableError, _) | (_, StatusType::RecoverableError) => {
+                StatusType::RecoverableError
+            }
             // If either is Spawning, return Spawning.
             (StatusType::Spawning, _) | (_, StatusType::Spawning) => StatusType::Spawning,
             // If either is Syncing, return Syncing.

--- a/zaino-state/src/local_cache/finalised_state.rs
+++ b/zaino-state/src/local_cache/finalised_state.rs
@@ -125,7 +125,7 @@ impl FinalisedState {
     /// - db_path: File path of the db.
     /// - db_size: Max size of the db in gb.
     /// - block_reciever: Channel that recieves new blocks to add to the db.
-    /// - status_signal: Used to send error status signals th outer processes.
+    /// - status_signal: Used to send error status signals to outer processes.
     pub async fn spawn(
         fetcher: &JsonRpcConnector,
         block_receiver: tokio::sync::mpsc::Receiver<(Height, Hash, CompactBlock)>,

--- a/zaino-state/src/status.rs
+++ b/zaino-state/src/status.rs
@@ -127,4 +127,28 @@ impl StatusType {
 
         format!("{}{}{}", color_code, symbol, "\x1b[0m")
     }
+
+    /// Look at two statuses, and return the more
+    /// 'severe' of the two statuses
+    pub fn combine(self, other: StatusType) -> StatusType {
+        match (self, other) {
+            // If either is Closing, return Closing.
+            (StatusType::Closing, _) | (_, StatusType::Closing) => StatusType::Closing,
+            // If either is Offline or CriticalError, return CriticalError.
+            (StatusType::Offline, _)
+            | (_, StatusType::Offline)
+            | (StatusType::CriticalError, _)
+            | (_, StatusType::CriticalError) => StatusType::CriticalError,
+            // If either is RecoverableError, return RecoverableError.
+            (StatusType::RecoverableError, _) | (_, StatusType::RecoverableError) => {
+                StatusType::RecoverableError
+            }
+            // If either is Spawning, return Spawning.
+            (StatusType::Spawning, _) | (_, StatusType::Spawning) => StatusType::Spawning,
+            // If either is Syncing, return Syncing.
+            (StatusType::Syncing, _) | (_, StatusType::Syncing) => StatusType::Syncing,
+            // Otherwise, return Ready.
+            _ => StatusType::Ready,
+        }
+    }
 }

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -682,6 +682,7 @@ mod tests {
             .expect("Clients are not initialized");
 
         test_manager.local_net.generate_blocks(100).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         clients.faucet.do_sync(true).await.unwrap();
         dbg!(clients.faucet.do_balance().await);
 
@@ -705,6 +706,7 @@ mod tests {
         // *Send all transparent funds to own orchard address.
         clients.faucet.quick_shield().await.unwrap();
         test_manager.local_net.generate_blocks(1).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         clients.faucet.do_sync(true).await.unwrap();
         dbg!(clients.faucet.do_balance().await);
 
@@ -727,6 +729,7 @@ mod tests {
         .unwrap();
 
         test_manager.local_net.generate_blocks(1).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         clients.recipient.do_sync(true).await.unwrap();
         dbg!(clients.recipient.do_balance().await);
 
@@ -785,6 +788,7 @@ mod tests {
         .unwrap();
 
         test_manager.local_net.generate_blocks(1).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         clients.recipient.do_sync(true).await.unwrap();
         dbg!(clients.recipient.do_balance().await);
 

--- a/zainod/src/error.rs
+++ b/zainod/src/error.rs
@@ -28,4 +28,7 @@ pub enum IndexerError {
     /// Custom indexor errors.
     #[error("Misc indexer error: {0}")]
     MiscIndexerError(String),
+    /// Zaino restart signal.
+    #[error("Restart Zaino")]
+    Restart,
 }

--- a/zainod/src/indexer.rs
+++ b/zainod/src/indexer.rs
@@ -187,12 +187,16 @@ impl Indexer {
         Ok(serve_task)
     }
 
-    /// Checks indexers status and servers internal status for error signal.
+    /// Checks indexers status and servers internal statuses for either offline of critical error signals.
     fn check_for_critical_errors(&self) -> bool {
         let statuses = &self.statuses();
-        if statuses.indexer_status.load() >= 5
-            || statuses.service_status.load() >= 5
-            || statuses.grpc_server_status.load() >= 5
+        if [
+            statuses.indexer_status.load(),
+            statuses.service_status.load(),
+            statuses.grpc_server_status.load(),
+        ]
+        .iter()
+        .any(|&status| status == 5 || status >= 7)
         {
             true
         } else {

--- a/zainod/src/indexer.rs
+++ b/zainod/src/indexer.rs
@@ -1,6 +1,5 @@
 //! Zingo-Indexer implementation.
 
-use std::process;
 use tokio::time::Instant;
 use tracing::info;
 
@@ -10,62 +9,10 @@ use zaino_state::{
     config::FetchServiceConfig,
     fetch::FetchService,
     indexer::{IndexerService, ZcashService},
-    status::{AtomicStatus, StatusType},
+    status::StatusType,
 };
 
 use crate::{config::IndexerConfig, error::IndexerError};
-
-/// Holds the status of the server and all its components.
-#[derive(Debug, Clone)]
-pub struct IndexerStatus {
-    /// Status of the indexer.
-    pub indexer_status: AtomicStatus,
-    /// Status of the chain state service.
-    pub service_status: AtomicStatus,
-    /// Status of the gRPC server.
-    pub grpc_server_status: AtomicStatus,
-}
-
-impl IndexerStatus {
-    /// Creates a new IndexerStatus.
-    pub fn new() -> Self {
-        IndexerStatus {
-            indexer_status: AtomicStatus::new(StatusType::Offline.into()),
-            service_status: AtomicStatus::new(StatusType::Offline.into()),
-            grpc_server_status: AtomicStatus::new(StatusType::Offline.into()),
-        }
-    }
-
-    /// Returns the IndexerStatus.
-    pub fn load(&self) -> IndexerStatus {
-        self.indexer_status.load();
-        self.service_status.load();
-        self.grpc_server_status.load();
-        self.clone()
-    }
-
-    /// Logs the indexers status.
-    pub fn log(&self) {
-        let statuses = self.load();
-        let indexer_status = StatusType::from(statuses.indexer_status);
-        let service_status = StatusType::from(statuses.service_status);
-        let grpc_server_status = StatusType::from(statuses.grpc_server_status);
-
-        let indexer_status_symbol = indexer_status.get_status_symbol();
-        let service_status_symbol = service_status.get_status_symbol();
-        let grpc_server_status_symbol = grpc_server_status.get_status_symbol();
-
-        info!(
-            "Zaino status check - Indexer:{}{} Service:{}{} gRPC Server:{}{}",
-            indexer_status_symbol,
-            indexer_status,
-            service_status_symbol,
-            service_status,
-            grpc_server_status_symbol,
-            grpc_server_status
-        );
-    }
-}
 
 /// Zingo-Indexer.
 pub struct Indexer {
@@ -73,8 +20,6 @@ pub struct Indexer {
     server: Option<TonicServer>,
     /// Chain fetch service state process handler..
     service: Option<IndexerService<FetchService>>,
-    /// Indexers status.
-    status: IndexerStatus,
 }
 
 impl Indexer {
@@ -84,17 +29,14 @@ impl Indexer {
     pub async fn start(
         config: IndexerConfig,
     ) -> Result<tokio::task::JoinHandle<Result<(), IndexerError>>, IndexerError> {
-        let indexer_status = IndexerStatus::new();
-        set_ctrlc(indexer_status.clone());
         startup_message();
         info!("Starting Zaino..");
-        Indexer::spawn(config, indexer_status).await
+        Indexer::spawn(config).await
     }
 
     /// Spawns a new Indexer server.
     pub async fn spawn(
         config: IndexerConfig,
-        status: IndexerStatus,
     ) -> Result<tokio::task::JoinHandle<Result<(), IndexerError>>, IndexerError> {
         config.check_config()?;
         info!("Checking connection with node..");
@@ -106,32 +48,28 @@ impl Indexer {
             config.validator_password.clone(),
         )
         .await?;
+
         info!(
             " - Connected to node using JsonRPC at address {}.",
             zebrad_uri
         );
 
-        status.indexer_status.store(StatusType::Spawning.into());
-
-        let chain_state_service = IndexerService::<FetchService>::spawn(
-            FetchServiceConfig::new(
-                config.validator_listen_address,
-                config.validator_cookie_auth,
-                config.validator_cookie_path.clone(),
-                config.validator_user.clone(),
-                config.validator_password.clone(),
-                None,
-                None,
-                config.map_capacity,
-                config.map_shard_amount,
-                config.db_path.clone(),
-                config.db_size,
-                config.get_network()?,
-                config.no_sync,
-                config.no_db,
-            ),
-            status.service_status.clone(),
-        )
+        let chain_state_service = IndexerService::<FetchService>::spawn(FetchServiceConfig::new(
+            config.validator_listen_address,
+            config.validator_cookie_auth,
+            config.validator_cookie_path.clone(),
+            config.validator_user.clone(),
+            config.validator_password.clone(),
+            None,
+            None,
+            config.map_capacity,
+            config.map_shard_amount,
+            config.db_path.clone(),
+            config.db_size,
+            config.get_network()?,
+            config.no_sync,
+            config.no_db,
+        ))
         .await?;
 
         let grpc_server = TonicServer::spawn(
@@ -142,7 +80,6 @@ impl Indexer {
                 tls_cert_path: config.tls_cert_path.clone(),
                 tls_key_path: config.tls_key_path.clone(),
             },
-            status.grpc_server_status.clone(),
         )
         .await
         .unwrap();
@@ -150,16 +87,9 @@ impl Indexer {
         let mut indexer = Indexer {
             server: Some(grpc_server),
             service: Some(chain_state_service),
-            status,
         };
 
-        indexer
-            .status
-            .indexer_status
-            .store(StatusType::Ready.into());
-
-        // NOTE: This interval may need to be reduced or removed / moved once scale testing begins.
-        let mut server_interval = tokio::time::interval(tokio::time::Duration::from_millis(50));
+        let mut server_interval = tokio::time::interval(tokio::time::Duration::from_millis(100));
         let mut last_log_time = Instant::now();
         let log_interval = tokio::time::Duration::from_secs(10);
 
@@ -167,20 +97,19 @@ impl Indexer {
             loop {
                 // Log the servers status.
                 if last_log_time.elapsed() >= log_interval {
-                    indexer.statuses();
-                    indexer.status.log();
+                    indexer.log_status();
                     last_log_time = Instant::now();
                 }
 
                 // Check for restart signals.
                 if indexer.check_for_critical_errors() {
-                    indexer.shutdown().await;
+                    indexer.close().await;
                     return Err(IndexerError::Restart);
                 }
 
                 // Check for shutdown signals.
                 if indexer.check_for_shutdown() {
-                    indexer.shutdown().await;
+                    indexer.close().await;
                     return Ok(());
                 }
 
@@ -193,76 +122,89 @@ impl Indexer {
 
     /// Checks indexers status and servers internal statuses for either offline of critical error signals.
     fn check_for_critical_errors(&self) -> bool {
-        let statuses = &self.statuses();
-        if [
-            statuses.indexer_status.load(),
-            statuses.service_status.load(),
-            statuses.grpc_server_status.load(),
-        ]
-        .iter()
-        .any(|&status| status == 5 || status >= 7)
-        {
-            true
-        } else {
-            false
-        }
+        let status = self.status_int();
+        status == 5 || status >= 7
     }
 
     /// Checks indexers status and servers internal status for closure signal.
     fn check_for_shutdown(&self) -> bool {
-        if self.status() == 4 {
+        if self.status_int() == 4 {
             return true;
         }
         false
     }
 
     /// Sets the servers to close gracefully.
-    async fn shutdown(&mut self) {
-        self.status
-            .grpc_server_status
-            .store(StatusType::Closing.into());
-        self.status.service_status.store(StatusType::Closing.into());
-        self.status.indexer_status.store(StatusType::Closing.into());
-
+    async fn close(&mut self) {
         if let Some(mut server) = self.server.take() {
-            server.shutdown().await;
-            self.status
-                .grpc_server_status
-                .store(StatusType::Offline.into());
+            server.close().await;
+            server.status.store(StatusType::Offline.into());
         }
 
         if let Some(service) = self.service.take() {
-            service.inner().close();
-            self.status.service_status.store(StatusType::Offline.into());
+            let mut service = service.inner();
+            service.close();
         }
-
-        self.status.indexer_status.store(StatusType::Offline.into());
     }
 
-    /// Returns the indexers current status usize.
-    pub fn status(&self) -> usize {
-        self.status.indexer_status.load()
+    /// Returns the indexers current status usize, caliculates from internal statuses.
+    fn status_int(&self) -> u16 {
+        let service_status = match &self.service {
+            Some(service) => service.inner_ref().status().into(),
+            None => return 7,
+        };
+        let server_status = match &self.server {
+            Some(server) => server.status().into(),
+            None => return 7,
+        };
+
+        match (service_status, server_status) {
+            // If either is Closing, return Closing.
+            (StatusType::Closing, _) | (_, StatusType::Closing) => 4,
+            // If either is Offline or CriticalError, return CriticalError.
+            (StatusType::Offline, _)
+            | (_, StatusType::Offline)
+            | (StatusType::CriticalError, _)
+            | (_, StatusType::CriticalError) => 7,
+            // If either is Spawning, return Spawning.
+            (StatusType::Spawning, _) | (_, StatusType::Spawning) => 0,
+            // If either is Syncing, return Syncing.
+            (StatusType::Syncing, _) | (_, StatusType::Syncing) => 1,
+            // Otherwise, return Ready.
+            _ => 2,
+        }
     }
 
-    /// Returns the indexers current statustype.
-    pub fn statustype(&self) -> StatusType {
-        StatusType::from(self.status())
+    /// Returns the current StatusType of the indexer.
+    pub fn status(&self) -> StatusType {
+        StatusType::from(self.status_int() as usize)
     }
 
-    /// Returns the status of the indexer and its parts.
-    pub fn statuses(&self) -> IndexerStatus {
-        self.status.load()
+    /// Logs the indexers status.
+    pub fn log_status(&self) {
+        let service_status = match &self.service {
+            Some(service) => service.inner_ref().status().into(),
+            None => StatusType::Offline,
+        };
+        let grpc_server_status = match &self.server {
+            Some(server) => server.status().into(),
+            None => StatusType::Offline,
+        };
+
+        let service_status_symbol = service_status.get_status_symbol();
+        let grpc_server_status_symbol = grpc_server_status.get_status_symbol();
+
+        info!(
+            "Zaino status check - ChainState Service:{}{} gRPC Server:{}{}",
+            service_status_symbol, service_status, grpc_server_status_symbol, grpc_server_status
+        );
     }
 }
 
-fn set_ctrlc(status: IndexerStatus) {
-    ctrlc::set_handler(move || {
-        status.grpc_server_status.store(StatusType::Closing.into());
-        status.service_status.store(StatusType::Closing.into());
-        status.indexer_status.store(StatusType::Closing.into());
-        process::exit(0);
-    })
-    .expect("Error setting Ctrl-C handler");
+impl Drop for Indexer {
+    fn drop(&mut self) {
+        let _ = self.close();
+    }
 }
 
 /// Prints Zaino's startup message.

--- a/zainod/src/indexer.rs
+++ b/zainod/src/indexer.rs
@@ -158,21 +158,7 @@ impl Indexer {
             None => return 7,
         };
 
-        match (service_status, server_status) {
-            // If either is Closing, return Closing.
-            (StatusType::Closing, _) | (_, StatusType::Closing) => 4,
-            // If either is Offline or CriticalError, return CriticalError.
-            (StatusType::Offline, _)
-            | (_, StatusType::Offline)
-            | (StatusType::CriticalError, _)
-            | (_, StatusType::CriticalError) => 7,
-            // If either is Spawning, return Spawning.
-            (StatusType::Spawning, _) | (_, StatusType::Spawning) => 0,
-            // If either is Syncing, return Syncing.
-            (StatusType::Syncing, _) | (_, StatusType::Syncing) => 1,
-            // Otherwise, return Ready.
-            _ => 2,
-        }
+        StatusType::combine(service_status, server_status) as u16
     }
 
     /// Returns the current StatusType of the indexer.

--- a/zainod/src/main.rs
+++ b/zainod/src/main.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
-use zainodlib::{config::load_config, indexer::Indexer};
+use zainodlib::{config::load_config, error::IndexerError, indexer::Indexer};
 
 #[derive(Parser, Debug)]
 #[command(name = "Zaino", about = "The Zcash Indexing Service", version)]
@@ -37,8 +37,35 @@ async fn main() {
         .config
         .unwrap_or_else(|| PathBuf::from("./zainod/zindexer.toml"));
 
-    match Indexer::start(load_config(&config_path).unwrap()).await {
-        Ok(_) => info!("Zaino Indexer started successfully."),
-        Err(e) => error!(error = ?e, "Failed to start Zaino Indexer"),
+    loop {
+        match Indexer::start(load_config(&config_path).unwrap()).await {
+            Ok(joinhandle_result) => {
+                info!("Zaino Indexer started successfully.");
+                match joinhandle_result.await {
+                    Ok(indexer_result) => match indexer_result {
+                        Ok(()) => {
+                            info!("Exiting Zaino successfully.");
+                            break;
+                        }
+                        Err(IndexerError::Restart) => {
+                            error!("Zaino encountered critical error, restarting.");
+                            continue;
+                        }
+                        Err(e) => {
+                            error!("Exiting Zaino with error: {}", e);
+                            break;
+                        }
+                    },
+                    Err(e) => {
+                        error!("Zaino exited early with error: {}", e);
+                        break;
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Zaino failed to start with error: {}", e);
+                break;
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds automatic server restart for critical errors.
- propagates errors from child processes to Indexer.
- Updates Indexer::serve and Indexer::start to return IndexerErrors properly.
- Updates main  to restart on Critical errors.

PR details:
- Build on top of https://github.com/zingolabs/zaino/pull/170, https://github.com/zingolabs/zaino/pull/177, #180.
- Closes #128.