### PR TITLE
fix breaking state service tests

### DIFF
--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -1713,7 +1713,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
 mod tests {
     use super::*;
     use zaino_fetch::jsonrpc::connector::test_node_and_return_url;
-    use zaino_testutils::{TestManager, ZCASHD_CHAIN_CACHE_BIN, ZEBRAD_CHAIN_CACHE_BIN};
+    use zaino_testutils::{TestManager, ZCASHD_CHAIN_CACHE_DIR, ZEBRAD_CHAIN_CACHE_DIR};
     use zebra_chain::parameters::Network;
     use zingo_infra_services::validator::Validator;
 
@@ -1724,7 +1724,7 @@ mod tests {
 
     #[tokio::test]
     async fn launch_fetch_service_zcashd_regtest_with_cache() {
-        launch_fetch_service("zcashd", ZCASHD_CHAIN_CACHE_BIN.clone()).await;
+        launch_fetch_service("zcashd", ZCASHD_CHAIN_CACHE_DIR.clone()).await;
     }
 
     #[tokio::test]
@@ -1734,7 +1734,7 @@ mod tests {
 
     #[tokio::test]
     async fn launch_fetch_service_zebrad_regtest_with_cache() {
-        launch_fetch_service("zebrad", ZEBRAD_CHAIN_CACHE_BIN.clone()).await;
+        launch_fetch_service("zebrad", ZEBRAD_CHAIN_CACHE_DIR.clone()).await;
     }
 
     async fn create_test_manager_and_fetch_service(

--- a/zaino-state/src/state.rs
+++ b/zaino-state/src/state.rs
@@ -1382,7 +1382,7 @@ mod tests {
     ) -> (TestManager, StateService) {
         let test_manager = TestManager::launch(
             "zebrad",
-            Some(zingo_infra_services::network::Network::Testnet),
+            Some(zingo_infra_services::network::Network::Regtest),
             ZEBRAD_CHAIN_CACHE_DIR.clone(),
             enable_zaino,
             zaino_no_sync,
@@ -1407,7 +1407,7 @@ mod tests {
             None,
             None,
             None,
-            Network::new_default_testnet(),
+            Network::new_regtest(Some(1), Some(1)),
         ))
         .await
         .unwrap();
@@ -1777,7 +1777,7 @@ mod tests {
     #[tokio::test]
     async fn state_service_regtest_get_block_object() {
         let (mut test_manager, state_service) =
-            create_test_manager_and_state_service(false, true, true, false).await;
+            create_test_manager_and_state_service(true, true, true, false).await;
         let fetch_service = zaino_fetch::jsonrpc::connector::JsonRpcConnector::new_with_basic_auth(
             test_node_and_return_url(
                 test_manager.zebrad_rpc_listen_address,

--- a/zaino-state/src/state.rs
+++ b/zaino-state/src/state.rs
@@ -1371,7 +1371,7 @@ mod tests {
     use futures::stream::StreamExt;
     use zaino_fetch::jsonrpc::connector::test_node_and_return_url;
     use zaino_proto::proto::service::BlockId;
-    use zaino_testutils::{TestManager, ZEBRAD_CHAIN_CACHE_BIN, ZEBRAD_TESTNET_CACHE_BIN};
+    use zaino_testutils::{TestManager, ZEBRAD_CHAIN_CACHE_DIR};
     use zebra_chain::parameters::Network;
     use zingo_infra_services::validator::Validator;
     async fn create_test_manager_and_state_service(
@@ -1383,7 +1383,7 @@ mod tests {
         let test_manager = TestManager::launch(
             "zebrad",
             Some(zingo_infra_services::network::Network::Testnet),
-            ZEBRAD_TESTNET_CACHE_BIN.clone(),
+            ZEBRAD_CHAIN_CACHE_DIR.clone(),
             enable_zaino,
             zaino_no_sync,
             zaino_no_db,
@@ -1455,7 +1455,7 @@ mod tests {
         let mut test_manager = TestManager::launch(
             "zebrad",
             None,
-            ZEBRAD_CHAIN_CACHE_BIN.clone(),
+            ZEBRAD_CHAIN_CACHE_DIR.clone(),
             false,
             true,
             true,
@@ -1498,7 +1498,7 @@ mod tests {
         let mut test_manager = TestManager::launch(
             "zebrad",
             None,
-            ZEBRAD_CHAIN_CACHE_BIN.clone(),
+            ZEBRAD_CHAIN_CACHE_DIR.clone(),
             false,
             true,
             true,
@@ -1562,7 +1562,7 @@ mod tests {
         let mut test_manager = TestManager::launch(
             "zebrad",
             None,
-            ZEBRAD_CHAIN_CACHE_BIN.clone(),
+            ZEBRAD_CHAIN_CACHE_DIR.clone(),
             false,
             true,
             true,

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -50,21 +50,21 @@ pub static ZAINOD_BIN: Lazy<Option<PathBuf>> = Lazy::new(|| {
 });
 
 /// Path for zcashd chain cache.
-pub static ZCASHD_CHAIN_CACHE_BIN: Lazy<Option<PathBuf>> = Lazy::new(|| {
+pub static ZCASHD_CHAIN_CACHE_DIR: Lazy<Option<PathBuf>> = Lazy::new(|| {
     let mut workspace_root_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     workspace_root_path.pop();
     Some(workspace_root_path.join("integration-tests/chain_cache/client_rpc_tests"))
 });
 
 /// Path for zebrad chain cache.
-pub static ZEBRAD_CHAIN_CACHE_BIN: Lazy<Option<PathBuf>> = Lazy::new(|| {
+pub static ZEBRAD_CHAIN_CACHE_DIR: Lazy<Option<PathBuf>> = Lazy::new(|| {
     let mut workspace_root_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     workspace_root_path.pop();
     Some(workspace_root_path.join("integration-tests/chain_cache/client_rpc_tests_large"))
 });
 
 /// Path for the Zebra chain cache in the user's home directory.
-pub static ZEBRAD_TESTNET_CACHE_BIN: Lazy<Option<PathBuf>> = Lazy::new(|| {
+pub static ZEBRAD_TESTNET_CACHE_DIR: Lazy<Option<PathBuf>> = Lazy::new(|| {
     let home_path = PathBuf::from(std::env::var("HOME").unwrap());
     Some(home_path.join(".cache/zebra"))
 });
@@ -508,7 +508,7 @@ mod tests {
         let mut test_manager = TestManager::launch(
             "zebrad",
             None,
-            ZEBRAD_CHAIN_CACHE_BIN.clone(),
+            ZEBRAD_CHAIN_CACHE_DIR.clone(),
             false,
             true,
             true,
@@ -528,7 +528,7 @@ mod tests {
         let mut test_manager = TestManager::launch(
             "zcashd",
             None,
-            ZCASHD_CHAIN_CACHE_BIN.clone(),
+            ZCASHD_CHAIN_CACHE_DIR.clone(),
             false,
             true,
             true,
@@ -811,7 +811,7 @@ mod tests {
         let mut test_manager = TestManager::launch(
             "zebrad",
             Some(services::network::Network::Testnet),
-            ZEBRAD_TESTNET_CACHE_BIN.clone(),
+            ZEBRAD_TESTNET_CACHE_DIR.clone(),
             true,
             true,
             true,


### PR DESCRIPTION
This PR aims to fix some problems that make the `state_service` fail.

A helper function (`create_test_manager_and_state_service`) isnt flexible enough and is being used for both `TESTNET` and `REGTEST` mode tests, withuot adjusting for each case.

Right now, the changes make the test `state_service_regtest_get_block_object` pass, but the helper function needs to be refactored to support other tests accordingly.
