### PR TITLE
address todo in getinfo comment

### DIFF
--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -180,16 +180,9 @@ impl ZcashIndexer for FetchServiceSubscriber {
     ///
     /// # Notes
     ///
-    /// TODO: [Issue #221](https://github.com/zingolabs/zaino/issues/221)
-    /// Eleven fields have been added to this type, since this comment
-    /// was written. Investigate whether there is field-parity between us and
-    /// zcashd, or if fields are still missing from some implementations
     /// [The zcashd reference](https://zcash.github.io/rpc/getinfo.html) might not show some fields
     /// in Zebra's [`GetInfo`]. Zebra uses the field names and formats from the
     /// [zcashd code](https://github.com/zcash/zcash/blob/v4.6.0-1/src/rpc/misc.cpp#L86-L87).
-    ///
-    /// Some fields from the zcashd reference are missing from Zebra's [`GetInfo`]. It only contains the fields
-    /// [required for lightwalletd support.](https://github.com/zcash/lightwalletd/blob/v0.4.9/common/common.go#L91-L95)
     async fn get_info(&self) -> Result<GetInfo, Self::Error> {
         Ok(self.fetcher.get_info().await?.into())
     }


### PR DESCRIPTION
 fixes #221 

Turns out there is field-parity, so the TODO comments can simply be removed. 