### PR TITLE
Use Rustls instead of OpenSSL for `reqwest`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ tracing-futures = "0.2"
 # Network / RPC
 http = "1.1"
 url = "2.5"
-reqwest = { version = "0.12", features = ["cookies"] }
+reqwest = { version = "0.12", default-features = false, features = ["cookies", "rustls-tls"] }
 tower = { version = "0.4", features = ["buffer", "util"] }
 tonic = "0.12"
 tonic-build = "0.12"


### PR DESCRIPTION
This doesn't alter the repo's `Cargo.lock` due to the internal dependency on zingolabs/infrastructure, but for downstream Zaino library users this removes multiple dependencies and avoids OpenSSL. This also matches what the Zebra dependencies were doing internally (which was already pulling Rustls into Zaino's dependency tree).