### PR TITLE
reverse get_latest_block block hash

### DIFF
--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -608,10 +608,7 @@ async fn fetch_service_get_latest_block(validator: &str) {
 
     let json_service_get_latest_block = dbg!(BlockId {
         height: json_service_blockchain_info.blocks.0 as u64,
-        hash: json_service_blockchain_info
-            .best_block_hash
-            .bytes_in_display_order()
-            .to_vec(),
+        hash: json_service_blockchain_info.best_block_hash.0.to_vec(),
     });
 
     assert_eq!(fetch_service_get_latest_block.height, 2);

--- a/integration-tests/tests/wallet_to_validator.rs
+++ b/integration-tests/tests/wallet_to_validator.rs
@@ -615,6 +615,8 @@ mod wallet_basic {
                 .await
         );
 
+        recipient_client.do_sync(true).await.unwrap();
+
         assert_eq!(
             recipient_client
                 .do_balance()

--- a/zaino-state/src/fetch.rs
+++ b/zaino-state/src/fetch.rs
@@ -490,12 +490,11 @@ impl LightWalletIndexer for FetchServiceSubscriber {
     /// Return the height of the tip of the best chain
     async fn get_latest_block(&self) -> Result<BlockId, Self::Error> {
         let latest_height = self.block_cache.get_chain_height().await?;
-        let mut latest_hash = self
+        let latest_hash = self
             .block_cache
             .get_compact_block(latest_height.0.to_string())
             .await?
             .hash;
-        latest_hash.reverse();
 
         Ok(BlockId {
             height: latest_height.0 as u64,


### PR DESCRIPTION
Reverses the byte order of the block hash returned by get_latest_block.

- Closes #256