### PR TITLE
use_rustls_instead_of_openSSL_for_reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ tracing-futures = "0.2"
 # Network / RPC
 http = "1.1"
 url = "2.5"
-reqwest = { version = "0.12", features = ["cookies"] }
+reqwest = { version = "0.12", default-features = false, features = ["cookies", "rustls-tls"] }
 tower = { version = "0.4", features = ["buffer", "util"] }
 tonic = "0.12"
 tonic-build = "0.12"


### PR DESCRIPTION
Changes from https://github.com/zingolabs/zaino/pull/257.

Opened in new PR as unverified commits are not allowed in Zingolabs repos. (I reviewed original PR before realising commits were not signed.) 