### PR TITLE
Docker: Bump Rust stable version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.84.1-bookworm AS builder
+FROM rust:1.86.0-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     musl-dev \


### PR DESCRIPTION
This fixes Docker builds on dev. I'm excited how close we're getting to ziserv + docker hub pushing on the main repo!