### PR TITLE
Docker: Build zaino with container support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN cargo fetch && \
 COPY . .
 
 RUN find . -name "*.rs" -exec touch {} + && \
-    cargo build --release
+    cargo build --release --features test_only_very_insecure
 
 FROM debian:bookworm-slim
 


### PR DESCRIPTION
Use the new feature flag to build Zaino with support for containers, only in Docker builds.