### PR TITLE
refactor tests (local cache)

### DIFF
--- a/integration-tests/tests/local_cache.rs
+++ b/integration-tests/tests/local_cache.rs
@@ -86,18 +86,8 @@ async fn zcashd_local_cache_launch_no_db() {
 }
 
 #[tokio::test]
-async fn zebrad_local_cache_launch_no_db() {
-    launch_local_cache(&ValidatorKind::Zebrad, true).await;
-}
-
-#[tokio::test]
 async fn zcashd_local_cache_launch_with_db() {
     launch_local_cache(&ValidatorKind::Zcashd, false).await;
-}
-
-#[tokio::test]
-async fn zebrad_local_cache_launch_with_db() {
-    launch_local_cache(&ValidatorKind::Zebrad, false).await;
 }
 
 async fn launch_local_cache(validator: &ValidatorKind, no_db: bool) {
@@ -108,18 +98,8 @@ async fn launch_local_cache(validator: &ValidatorKind, no_db: bool) {
 }
 
 #[tokio::test]
-async fn zebrad_local_cache_process_100_blocks() {
-    launch_local_cache_process_n_block_batches(&ValidatorKind::Zebrad, 1).await;
-}
-
-#[tokio::test]
 async fn zcashd_local_cache_process_100_blocks() {
     launch_local_cache_process_n_block_batches(&ValidatorKind::Zcashd, 1).await;
-}
-
-#[tokio::test]
-async fn zebrad_local_cache_process_200_blocks() {
-    launch_local_cache_process_n_block_batches(&ValidatorKind::Zebrad, 2).await;
 }
 
 #[tokio::test]
@@ -186,5 +166,33 @@ async fn launch_local_cache_process_n_block_batches(validator: &ValidatorKind, b
         dbg!(non_finalised_state_blocks.last());
         dbg!(finalised_state_blocks.first());
         dbg!(finalised_state_blocks.last());
+    }
+}
+
+mod zcashd {}
+
+mod zebrad {
+    use zaino_testutils::ValidatorKind;
+
+    use crate::{launch_local_cache, launch_local_cache_process_n_block_batches};
+
+    #[tokio::test]
+    async fn zebrad_local_cache_launch_no_db() {
+        launch_local_cache(&ValidatorKind::Zebrad, true).await;
+    }
+
+    #[tokio::test]
+    async fn zebrad_local_cache_launch_with_db() {
+        launch_local_cache(&ValidatorKind::Zebrad, false).await;
+    }
+
+    #[tokio::test]
+    async fn zebrad_local_cache_process_100_blocks() {
+        launch_local_cache_process_n_block_batches(&ValidatorKind::Zebrad, 1).await;
+    }
+
+    #[tokio::test]
+    async fn zebrad_local_cache_process_200_blocks() {
+        launch_local_cache_process_n_block_batches(&ValidatorKind::Zebrad, 2).await;
     }
 }

--- a/integration-tests/tests/local_cache.rs
+++ b/integration-tests/tests/local_cache.rs
@@ -155,22 +155,22 @@ mod zcashd {
     use crate::{launch_local_cache, launch_local_cache_process_n_block_batches};
 
     #[tokio::test]
-    async fn zcashd_local_cache_launch_no_db() {
+    async fn launch_no_db() {
         launch_local_cache(&ValidatorKind::Zcashd, true).await;
     }
 
     #[tokio::test]
-    async fn zcashd_local_cache_launch_with_db() {
+    async fn launch_with_db() {
         launch_local_cache(&ValidatorKind::Zcashd, false).await;
     }
 
     #[tokio::test]
-    async fn zcashd_local_cache_process_100_blocks() {
+    async fn process_100_blocks() {
         launch_local_cache_process_n_block_batches(&ValidatorKind::Zcashd, 1).await;
     }
 
     #[tokio::test]
-    async fn zcashd_local_cache_process_200_blocks() {
+    async fn process_200_blocks() {
         launch_local_cache_process_n_block_batches(&ValidatorKind::Zcashd, 2).await;
     }
 }
@@ -181,22 +181,22 @@ mod zebrad {
     use crate::{launch_local_cache, launch_local_cache_process_n_block_batches};
 
     #[tokio::test]
-    async fn zebrad_local_cache_launch_no_db() {
+    async fn launch_no_db() {
         launch_local_cache(&ValidatorKind::Zebrad, true).await;
     }
 
     #[tokio::test]
-    async fn zebrad_local_cache_launch_with_db() {
+    async fn launch_with_db() {
         launch_local_cache(&ValidatorKind::Zebrad, false).await;
     }
 
     #[tokio::test]
-    async fn zebrad_local_cache_process_100_blocks() {
+    async fn process_100_blocks() {
         launch_local_cache_process_n_block_batches(&ValidatorKind::Zebrad, 1).await;
     }
 
     #[tokio::test]
-    async fn zebrad_local_cache_process_200_blocks() {
+    async fn process_200_blocks() {
         launch_local_cache_process_n_block_batches(&ValidatorKind::Zebrad, 2).await;
     }
 }

--- a/integration-tests/tests/local_cache.rs
+++ b/integration-tests/tests/local_cache.rs
@@ -80,31 +80,11 @@ async fn create_test_manager_and_block_cache(
     )
 }
 
-#[tokio::test]
-async fn zcashd_local_cache_launch_no_db() {
-    launch_local_cache(&ValidatorKind::Zcashd, true).await;
-}
-
-#[tokio::test]
-async fn zcashd_local_cache_launch_with_db() {
-    launch_local_cache(&ValidatorKind::Zcashd, false).await;
-}
-
 async fn launch_local_cache(validator: &ValidatorKind, no_db: bool) {
     let (_test_manager, _json_service, _block_cache, block_cache_subscriber) =
         create_test_manager_and_block_cache(validator, None, false, true, no_db, false).await;
 
     dbg!(block_cache_subscriber.status());
-}
-
-#[tokio::test]
-async fn zcashd_local_cache_process_100_blocks() {
-    launch_local_cache_process_n_block_batches(&ValidatorKind::Zcashd, 1).await;
-}
-
-#[tokio::test]
-async fn zcashd_local_cache_process_200_blocks() {
-    launch_local_cache_process_n_block_batches(&ValidatorKind::Zcashd, 2).await;
 }
 
 /// Launches a testmanager and block cache and generates `n*100` blocks, checking blocks are stored and fetched correctly.
@@ -169,7 +149,31 @@ async fn launch_local_cache_process_n_block_batches(validator: &ValidatorKind, b
     }
 }
 
-mod zcashd {}
+mod zcashd {
+    use zaino_testutils::ValidatorKind;
+
+    use crate::{launch_local_cache, launch_local_cache_process_n_block_batches};
+
+    #[tokio::test]
+    async fn zcashd_local_cache_launch_no_db() {
+        launch_local_cache(&ValidatorKind::Zcashd, true).await;
+    }
+
+    #[tokio::test]
+    async fn zcashd_local_cache_launch_with_db() {
+        launch_local_cache(&ValidatorKind::Zcashd, false).await;
+    }
+
+    #[tokio::test]
+    async fn zcashd_local_cache_process_100_blocks() {
+        launch_local_cache_process_n_block_batches(&ValidatorKind::Zcashd, 1).await;
+    }
+
+    #[tokio::test]
+    async fn zcashd_local_cache_process_200_blocks() {
+        launch_local_cache_process_n_block_batches(&ValidatorKind::Zcashd, 2).await;
+    }
+}
 
 mod zebrad {
     use zaino_testutils::ValidatorKind;


### PR DESCRIPTION
this pr refactors all `local_cache` tests into two separate modules and renames them to avoid redundancy

- **moved all zebrad tests into zebrad mod**
- **moved all zcashd tests into zcashd mod**
- **renamed tests to avoid redundancy**

Intial structure:
```
integration-tests::local_cache:
    zcashd_local_cache_launch_no_db
    zcashd_local_cache_launch_with_db
    zcashd_local_cache_process_100_blocks
    zcashd_local_cache_process_200_blocks
    zebrad_local_cache_launch_no_db
    zebrad_local_cache_launch_with_db
    zebrad_local_cache_process_100_blocks
    zebrad_local_cache_process_200_blocks
```
Current structure:
```
integration-tests::local_cache:
    zcashd::launch_no_db
    zcashd::launch_with_db
    zcashd::process_100_blocks
    zcashd::process_200_blocks
    zebrad::launch_no_db
    zebrad::launch_with_db
    zebrad::process_100_blocks
    zebrad::process_200_blocks
```
