### PR TITLE
increment threads in nextest config

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,5 @@
 [profile.default]
-test-threads = 4
+test-threads = 5
 fail-fast = false
 retries = 1
 

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,5 @@
 [profile.default]
-test-threads = 5
+test-threads = 6
 fail-fast = false
 retries = 1
 


### PR DESCRIPTION
In a way this is a work in progress.

The idea is to speed development velocity by simply increasing our number of parallel threads running tests, in a way that works for our core devs.

I was able to increment the thread count to 5 without any issues. At 6 I have a single test being flaky, `integration-tests::state_service state_service_get_address_balance_regtest_zebrad`

Confirming that even incrementing 5 works for people will increase our testrun speed by 25%!