### PR TITLE
ci test split reorg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           - "integration-tests::state_service"
           - "integration-tests::local_cache"
           - "integration-tests::wallet_to_validator"
-          - "zaino-testutils::launch_testmanager"
+          - "zaino-testutils"
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         # continue-on-error: true
         run: |
           cargo nextest run --verbose --profile ci --retries 2 --archive-file nextest-archive.tar.zst \
-            --workspace-remap ./ --filterset "binary_id(${[ matrix.partition }})" ${{ env.NEXTEST-FLAGS }}
+            --workspace-remap ./ --filterset "binary_id(${{ matrix.partition }})" ${{ env.NEXTEST-FLAGS }}
 
       - name: Test Summary
         uses: test-summary/action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
 
   test:
-    name: Run Tests
+    name: Tests
     needs: build-test-artifacts
     runs-on: ziserv-2
     container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2, 3, 4, 5, 6, 7, 8]
+        partition: 
+          - "integration-tests::fetch_service"
+          - "integration-tests::state_service"
+          - "integration-tests::local_cache"
+          - "integration-tests::wallet_to_validator"
+          - "zaino-testutils::launch_testmanager"
 
     steps:
 
@@ -79,7 +84,7 @@ jobs:
         # continue-on-error: true
         run: |
           cargo nextest run --verbose --profile ci --retries 2 --archive-file nextest-archive.tar.zst \
-            --workspace-remap ./ --partition count:${{ matrix.partition }}/8 ${{ env.NEXTEST-FLAGS }}
+            --workspace-remap ./ --filterset "binary_id(${[ matrix.partition }})" ${{ env.NEXTEST-FLAGS }}
 
       - name: Test Summary
         uses: test-summary/action@v2


### PR DESCRIPTION
This configures CI to run tests in groups based on actual test blocks.
It makes the reporting more readable.

One very aspect to note is, this now doesn't target all tests in the codebase by default, since it explicitely lists the test blocks to include in ci. If new test blocks are written, they should explictely be added in CI.

`.config/nextest.toml` also is crucial, as it excludes several tests.


- **changed partition to test bins**
- **typo**
- **fix: zaino-testutils targeting**
- **Shorten "Run Tests" job name for better readability in GH webui**
