### PR TITLE
add benchmark-testing script

### DIFF
--- a/utils/benchmark-testing.sh
+++ b/utils/benchmark-testing.sh
@@ -10,7 +10,7 @@ do
     echo "-----------" >> benchmark_for_tests.txt
     echo "try:" >> benchmark_for_tests.txt
     echo $x >> benchmark_for_tests.txt
-        cargo nextest run --test-threads=$i --failure-output final --status-level none --final-status-level retry --hide-progress-bar &>> benchmark_for_tests.txt
+        cargo nextest run --test-threads=$i --cargo-quiet --cargo-quiet --failure-output final --status-level none --final-status-level slow --hide-progress-bar &>> benchmark_for_tests.txt
     echo "-----------" >> benchmark_for_tests.txt
     done
     echo "-----------" >> benchmark_for_tests.txt

--- a/utils/benchmark-testing.sh
+++ b/utils/benchmark-testing.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+for i in {5..10}
+do
+    echo "-----------" >> benchmark_for_tests.txt
+    echo "starting runs for thread count of*************************:" >> benchmark_for_tests.txt
+    echo $i >> benchmark_for_tests.txt
+    echo "*****************-----------************" >> benchmark_for_tests.txt
+    for x in {1..10}
+    do
+    echo "-----------" >> benchmark_for_tests.txt
+    echo "try:" >> benchmark_for_tests.txt
+    echo $x >> benchmark_for_tests.txt
+        cargo nextest run --test-threads=$i --failure-output final --status-level none --final-status-level retry --hide-progress-bar &>> benchmark_for_tests.txt
+    echo "-----------" >> benchmark_for_tests.txt
+    done
+    echo "-----------" >> benchmark_for_tests.txt
+    echo "ending runs for thread count of:" >> benchmark_for_tests.txt
+    echo $i >> benchmark_for_tests.txt
+    echo "-----------" >> benchmark_for_tests.txt
+done


### PR DESCRIPTION
WIP!

This PR is intended to add a script for benchmarking local `cargo nextest run` - the core of Zaino testing. Our need for it now is to accelerate testing by observing at what threshold what tests begin to flake or fail.

It is also intended to track the configuration of nextest itself, which was begun in the now merged #282 
