### PR TITLE
Fix getblock

### DIFF
--- a/zaino-fetch/src/jsonrpsee/response.rs
+++ b/zaino-fetch/src/jsonrpsee/response.rs
@@ -459,7 +459,9 @@ pub struct OrchardTrees {
 /// Wrapper struct for zebra's GetBlockTrees
 #[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct GetBlockTrees {
+    #[serde(default)]
     sapling: Option<SaplingTrees>,
+    #[serde(default)]
     orchard: Option<OrchardTrees>,
 }
 


### PR DESCRIPTION
Adds derive default to fields in GetBlockTrees to allow for missing fields.