### PR TITLE
feat(docker): refactor Dockerfile for better caching and flexibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,23 @@
-target/
-.git/
-.github/
-.gitignore
-.dockerignore
-Dockerfile
-*.md
-.env*
+# Before the docker CLI sends the context to the docker daemon, it looks for a file
+# named .dockerignore in the root directory of the context. If this file exists, the
+# CLI modifies the context to exclude files and directories that match patterns in it.
+#
+# You may want to specify which files to include in the context, rather than which
+# to exclude. To achieve this, specify * as the first pattern, followed by one or
+# more ! exception patterns.
+#
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+# Exclude everything:
+#
+*
+
+# Now un-exclude required files and folders:
+#
+!.cargo
+!*.toml
+!*.lock
+!integration-tests
+!utils-*
+!zaino-*
+!zainod

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,26 @@
-# Specify the base image for building
-FROM rust:1.86.0-bookworm AS builder
+# syntax=docker/dockerfile:1
+
+# Set the build arguments used across the stages.
+# Each stage must define the build arguments (ARGs) it uses.
 
 # Accept an argument to control no-tls builds
 ARG NO_TLS=false
 
+# High UID/GID (10003) to avoid overlap with host system users.
+ARG UID=10003
+ARG GID=${UID}
+ARG USER="zaino"
+ARG HOME="/home/zaino"
+ARG CARGO_HOME="${HOME}/.cargo"
+ARG CARGO_TARGET_DIR="${HOME}/target"
+
+ARG RUST_VERSION=1.86.0
+
+  # This stage prepares Zaino's build deps and captures build args as env vars.
+FROM rust:${RUST_VERSION}-bookworm AS deps
+SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
+
+# Install build deps (if any beyond Rust).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     musl-dev \
     gcc \
@@ -14,72 +31,83 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make \
     # Install OpenSSL only if not building with no-tls
     && if [ "$NO_TLS" = "false" ]; then apt-get install -y libssl-dev; fi \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*  /tmp/*
 
-WORKDIR /app
+# Build arguments and variables
+ARG CARGO_INCREMENTAL
+ENV CARGO_INCREMENTAL=${CARGO_INCREMENTAL:-0}
 
-# Dependency caching: create a dummy project structure
-RUN cargo new --bin zainod && \
-    cargo new --bin integration-tests && \
-    cargo new --lib zaino-fetch && \
-    cargo new --lib zaino-proto && \
-    cargo new --lib zaino-serve && \
-    cargo new --lib zaino-state && \
-    cargo new --lib zaino-testutils && \
-    echo "pub fn main() {}" > zainod/src/lib.rs && \
-    echo "pub fn main() {}" > integration-tests/src/lib.rs
+ARG CARGO_HOME
+ENV CARGO_HOME=${CARGO_HOME}
 
-COPY Cargo.toml Cargo.lock ./
-COPY integration-tests/Cargo.toml integration-tests/
-COPY zaino-fetch/Cargo.toml zaino-fetch/
-COPY zaino-proto/Cargo.toml zaino-proto/
-COPY zaino-serve/Cargo.toml zaino-serve/
-COPY zaino-state/Cargo.toml zaino-state/
-COPY zaino-testutils/Cargo.toml zaino-testutils/
-COPY zainod/Cargo.toml zainod/
+ARG CARGO_TARGET_DIR
+ENV CARGO_TARGET_DIR=${CARGO_TARGET_DIR}
 
-# Build dependencies only for the given features
-RUN cargo fetch && \
+# This stage builds the zainod release binary.
+FROM deps AS builder
+
+ARG HOME
+WORKDIR ${HOME}
+
+ARG CARGO_HOME
+ARG CARGO_TARGET_DIR
+
+# Mount the root Cargo.toml/Cargo.lock and all relevant workspace members.
+RUN --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
+    --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
+    --mount=type=bind,source=integration-tests,target=integration-tests \
+    --mount=type=bind,source=zaino-fetch,target=zaino-fetch \
+    --mount=type=bind,source=zaino-proto,target=zaino-proto \
+    --mount=type=bind,source=zaino-serve,target=zaino-serve \
+    --mount=type=bind,source=zaino-state,target=zaino-state \
+    --mount=type=bind,source=zaino-testutils,target=zaino-testutils \
+    --mount=type=bind,source=zainod,target=zainod \
+    --mount=type=cache,target=${CARGO_HOME} \
+    --mount=type=cache,target=${CARGO_TARGET_DIR} \
+    # Conditional build based on NO_TLS argument
     if [ "$NO_TLS" = "true" ]; then \
-        echo "Building with no TLS"; \
-        cargo build --release --all-targets --workspace --features disable_tls_unencrypted_traffic_mode; \
+      cargo build --locked --release --package zainod --bin zainod --features disable_tls_unencrypted_traffic_mode; \
     else \
-        echo "Building with TLS"; \
-        cargo build --release --all-targets --workspace; \
+      cargo build --locked --release --package zainod --bin zainod; \
     fi && \
-    # Remove the dummy source files but keep the target directory
-    rm -rf */src
+    # Copy the built binary \
+    cp ${CARGO_TARGET_DIR}/release/zainod /usr/local/bin/
 
-# Now build everything
-COPY . .
+# This stage prepares the runtime image.
+FROM debian:bookworm-slim AS runtime
 
-# Build the final application according to the NO_TLS flag
-RUN find . -name "*.rs" -exec touch {} + && \
-    if [ "$NO_TLS" = "true" ]; then \
-        cargo build --release --features disable_tls_unencrypted_traffic_mode; \
-    else \
-        cargo build --release; \
-    fi
+ARG UID
+ARG GID
+ARG USER
+ARG HOME
 
-# Final stage using a slim base image
-FROM debian:bookworm-slim
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get -qq update && \
+    apt-get -qq install -y --no-install-recommends \
+    curl \
     openssl \
     libc6 \
     libgcc-s1 && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN groupadd -r -g 2003 zaino && useradd -r -u 2003 -g zaino zaino
+RUN addgroup --quiet --gid ${GID} ${USER} && \
+    adduser --quiet --gid ${GID} --uid ${UID} --home ${HOME} ${USER} --disabled-password --gecos ""
 
-WORKDIR /app
+WORKDIR ${HOME}
+RUN chown -R ${UID}:${GID} ${HOME}
 
-COPY --from=builder /app/target/release/zainod /app/zainod
+# Copy the zainod binary from the builder stage
+COPY --link --from=builder /usr/local/bin/zainod /usr/local/bin/
 
-RUN chown zaino:zaino /app/zainod
+USER ${USER}
 
-USER zaino
+ARG ZAINO_GRPC_PORT=8137
+ARG ZAINO_JSON_RPC_PORT=8237
 
-EXPOSE 8137
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 CMD curl -f http://127.0.0.1:${ZAINO_GRPC_PORT} || exit 1
 
-ENTRYPOINT ["/app/zainod"]
+# Expose gRPC and JSON-RPC ports if they are typically used.
+# These are the default ports zainod might listen on.
+EXPOSE ${ZAINO_GRPC_PORT} ${ZAINO_JSON_RPC_PORT}
+
+# Default command if no arguments are passed to `docker run`
+CMD ["zainod"]


### PR DESCRIPTION
This PR updates the `Dockerfile` and build mechanisms. The main goals are to improve build efficiency, provide more flexibility for image generation, use an FHS-compliant base directory, and add runtime health monitoring.

### Key Changes:

1.  **Updated Docker Syntax & Multi-Stage Build:**
    *   The Dockerfile now uses `syntax=docker/dockerfile:1`, which allows features like improved cache mount capabilities.
    *   The build process has been changed from two to **three distinct stages**:
        *   `deps`: Prepares build dependencies and captures ARGs. This stage is more likely to remain cached if only application code changes.
        *   `builder`: Compiles the `zainod` binary, using cache mounts for Cargo's target and home directories.
        *   `runtime`: A slim image that includes only the necessary runtime dependencies and the compiled binary.
    *   This multi-stage setup improves layer caching, which can lead to faster rebuilds.

2.  **Improved Caching with Cache Mounts:**
    *   The `builder` stage now uses `RUN --mount=type=cache` for `CARGO_HOME` (`~/.cargo`) and `CARGO_TARGET_DIR` (`target/`). This speeds up rebuilds when dependencies (`Cargo.lock`) have not changed, as pre-compiled dependencies can be reused.

3.  **More Rebuild Flexibility with ARGs:**
    *   Several build arguments (`ARG`) have been introduced or standardized, allowing users to customize the image build without modifying the Dockerfile directly:
        *   `UID`, `GID`, `USER`, `HOME`: Users can specify the user ID, group ID, username, and home directory for the `zaino` user within the container. This is useful for environments with specific security policies or UID/GID mapping requirements.
        *   `RUST_VERSION`: Allows for building Zaino with different Rust toolchain versions for testing and compatibility.
        *   `NO_TLS`: (Existing) Controls whether to build with TLS support.
        *   `ZAINO_GRPC_PORT`, `ZAINO_JSON_RPC_PORT`: Define the default gRPC and JSON-RPC ports, used in `EXPOSE` and the `HEALTHCHECK` instruction.

4.  **Runtime Health Monitoring:**
    *   `curl` has been added to the `runtime` stage.
    *   A `HEALTHCHECK` instruction is now included. It uses `curl` to periodically check the availability of the Zaino gRPC service on `127.0.0.1:${ZAINO_GRPC_PORT}`. This helps Docker determine if the container is healthy.

5.  **Standard Binary Location:**
    *   The `zainod` binary is now copied to `/usr/local/bin/` in the runtime image, making it accessible from any location within the container's `PATH`.

6.  **Updated Build Context:**
    *   The `.dockerignore` file has been updated to use an "exclude all, then include specific" pattern (`*` followed by `!pattern`). This sends a more precise and minimal build context to the Docker daemon, which can speed up the initial phase of the build.
    
This is a subset of:
- #331