### PR TITLE
Update docs cxxflags

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,6 +15,9 @@
 **Client Rpc Tests** _For the client rpc tests to pass a Zaino release binary must be built and added to PATH.
 WARNING: these tests do not use the binary built by cargo nextest._
 
+Note: Recently the newest GCC version on Arch has broken a build script in the `rocksdb` dependency. A workaround is:
+`export CXXFLAGS="$CXXFLAGS -include cstdint"`
+
 4) Build release binary `cargo build --release` and add to PATH. For example, `export PATH=./target/release:$PATH`
 
 5) Run `cargo nextest run`

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -4,7 +4,11 @@
 2) [Zingolib](https://github.com/zingolabs/zingolib.git) [if running Zingo-Cli]
 
 ### Running ZainoD
-- To run a Zaino server, backed locally by Zebrad first build Zaino:
+- To run a Zaino server, backed locally by Zebrad first build Zaino.
+
+Recently the newest GCC version on Arch has broken a build script in the `rocksdb` dependency. A workaround is:
+`export CXXFLAGS="$CXXFLAGS -include cstdint"`
+
 1) Run `$ cargo build --release`
 2) Add compiled binary held at `#PATH_TO/zaino/target/release/zainod` to PATH.
 


### PR DESCRIPTION
Building on unembellished Arch Linux currently fails on running a build script of the rocksdb dependency. This appears to be because this script breaks when using a new version of GCC.