### PR TITLE
test(chain_cache): ignore tests involving `cache`

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,11 +7,6 @@
 ### Tests
 1) Symlink or copy compiled `zebrad`, `zcashd` and `zcash-cli` binaries to `zaino/test_binaries/bins/*`
 
-**Chain Cache** _Several tests rely on a cached chain to run, for these tests to pass the chain must first be generated:_
-
-2) Generate the zcashd chain cache `cargo nextest run generate_zcashd_chain_cache --run-ignored ignored-only`
-3) Generate the zebrad chain cache `cargo nextest run generate_zebrad_large_chain_cache --run-ignored ignored-only`
-
 **Client Rpc Tests** _For the client rpc tests to pass a Zaino release binary must be built and added to PATH.
 WARNING: these tests do not use the binary built by cargo nextest._
 

--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -1161,6 +1161,7 @@ mod zcashd {
         }
 
         #[tokio::test]
+        #[ignore = "We no longer use chain caches. See zcashd::launch::regtest_no_cache."]
         pub(crate) async fn regtest_with_cache() {
             launch_fetch_service(
                 &ValidatorKind::Zcashd,
@@ -1325,6 +1326,7 @@ mod zebrad {
         }
 
         #[tokio::test]
+        #[ignore = "We no longer use chain caches. See zebrad::launch::regtest_no_cache."]
         pub(crate) async fn regtest_with_cache() {
             launch_fetch_service(
                 &ValidatorKind::Zebrad,

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -1048,6 +1048,7 @@ mod zebrad {
         }
 
         #[tokio::test]
+        #[ignore = "We no longer use chain caches. See zcashd::check_info::regtest_no_cache."]
         async fn regtest_with_cache() {
             state_service_check_info(
                 &ValidatorKind::Zebrad,


### PR DESCRIPTION
This PR ignores tests that include `*_with_cache` in their name and removes instructions for generating such cache from `testing.md`.