### PR TITLE
Exclude failing tests in CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,8 +3,32 @@ test-threads = 6
 fail-fast = false
 # retries = 1
 
+# All the following tests keep failing because of zebra with the following error message:
+# "Serialization/Deserialization Error: data did not match any variant of untagged enum Input at line 1 column <X>"
+# We will ignore these tests for now in CI, until zebra releases the fix
+
 [profile.ci]
-default-filter = "not test(testnet) & not test(regtest) & not test(client_rpcs)"
+default-filter = """
+    not test(testnet) 
+    & not test(regtest) 
+    & not test(client_rpcs)
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::address_balance))
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::address_tx_ids))
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::address_utxos))
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::mempool_stream))
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::mempool_tx))
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::raw_mempool))
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::raw_transaction))
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::taddress_balance))
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::taddress_txids))
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::taddress_utxos))
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::taddress_utxos_stream))
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::transaction_mempool))
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::transaction_mined))
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::z::subtrees_by_index))
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::z::treestate))    
+    & not (binary_id(integration-tests::state_service) and test(zebrad::get::address_utxos))    
+"""
 
 [profile.ci.junit]  # this can be some other profile, too
 path = "junit.xml"


### PR DESCRIPTION
# Zebrad release needed for tests to pass

All the following tests keep failing because of zebra with the following error message:

> "Serialization/Deserialization Error: data did not match any variant of untagged enum Input at line 1 column <X>"

## `integration-tests::fetch_service`

- `zebrad::get::address_balance`
- `zebrad::get::address_tx_ids`
- `zebrad::get::address_utxos`
- `zebrad::get::mempool_stream`
- `zebrad::get::mempool_tx`
- `zebrad::get::raw_mempool`
- `zebrad::get::raw_transaction`
- `zebrad::get::taddress_balance`
- `zebrad::get::taddress_txids`
- `zebrad::get::taddress_utxos`
- `zebrad::get::taddress_utxos_stream`
- `zebrad::get::transaction_mempool`
- `zebrad::get::transaction_mined`
- `zebrad::get::z::subtrees_by_index`
- `zebrad::get::z::treestate`

## `integration-tests::state_service`

- `zebrad::get::address_utxos`
