### PR TITLE
correct zaino-fetch comments

### DIFF
--- a/zaino-fetch/src/lib.rs
+++ b/zaino-fetch/src/lib.rs
@@ -1,6 +1,6 @@
 //! A mempool-fetching, chain-fetching and transaction submission service that uses zcashd's JsonRPC interface.
 //!
-//! Used as a reference, legacy option, and for backwards compatibility.
+//! Usable as a backwards-compatible, legacy option.
 
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]

--- a/zaino-fetch/src/lib.rs
+++ b/zaino-fetch/src/lib.rs
@@ -1,6 +1,6 @@
-//! A mempool-fetching, chain-fetching and transaction submission service that uses zebra's RPC interface.
+//! A mempool-fetching, chain-fetching and transaction submission service that uses zcashd's JsonRPC interface.
 //!
-//! Used primarily as a backup and legacy option for backwards compatibility.
+//! Used as a reference, legacy option, and for backwards compatibility.
 
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
micro PR

I took a little liberty on the second line changed, saying this crate could be used for reference (which IIUC is part of the plan now: to have all RPCs behave as if they are interacting with `zcashd`)