### PR TITLE
Fix trailing whitespace in nextest.toml 

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,8 +9,8 @@ fail-fast = false
 
 [profile.ci]
 default-filter = """
-    not test(testnet) 
-    & not test(regtest) 
+    not test(testnet)
+    & not test(regtest)
     & not test(client_rpcs)
     & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::address_balance))
     & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::address_tx_ids))
@@ -26,8 +26,8 @@ default-filter = """
     & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::transaction_mempool))
     & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::transaction_mined))
     & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::z::subtrees_by_index))
-    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::z::treestate))    
-    & not (binary_id(integration-tests::state_service) and test(zebrad::get::address_utxos))    
+    & not (binary_id(integration-tests::fetch_service) and test(zebrad::get::z::treestate))
+    & not (binary_id(integration-tests::state_service) and test(zebrad::get::address_utxos))
 """
 
 [profile.ci.junit]  # this can be some other profile, too


### PR DESCRIPTION
Removed trailing whitespace from excluded tests in `.config/nextest.toml`