### PR TITLE
Chaintip update subscriber

### DIFF
--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -1050,7 +1050,7 @@ mod zebrad {
         #[tokio::test]
         async fn state_service_chaintip_update_subscriber() {
             let (
-                mut test_manager,
+                test_manager,
                 _fetch_service,
                 _fetch_service_subscriber,
                 _state_service,

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -1067,11 +1067,7 @@ mod zebrad {
             for _ in 0..5 {
                 test_manager.generate_blocks_with_delay(1).await;
                 assert_eq!(
-                    chaintip_subscriber
-                        .next_tip_hash()
-                        .await
-                        .unwrap()
-                        .bytes_in_display_order(),
+                    chaintip_subscriber.next_tip_hash().await.unwrap().0,
                     <[u8; 32]>::try_from(
                         state_service_subscriber
                             .get_latest_block()

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -1048,6 +1048,43 @@ mod zebrad {
         }
 
         #[tokio::test]
+        async fn state_service_chaintip_update_subscriber() {
+            let (
+                mut test_manager,
+                _fetch_service,
+                _fetch_service_subscriber,
+                _state_service,
+                state_service_subscriber,
+            ) = create_test_manager_and_services(
+                &ValidatorKind::Zebrad,
+                None,
+                false,
+                false,
+                Some(services::network::Network::Regtest),
+            )
+            .await;
+            let mut chaintip_subscriber = state_service_subscriber.chaintip_update_subscriber();
+            for _ in 0..5 {
+                test_manager.generate_blocks_with_delay(1).await;
+                assert_eq!(
+                    chaintip_subscriber
+                        .next_tip_hash()
+                        .await
+                        .unwrap()
+                        .bytes_in_display_order(),
+                    <[u8; 32]>::try_from(
+                        state_service_subscriber
+                            .get_latest_block()
+                            .await
+                            .unwrap()
+                            .hash
+                    )
+                    .unwrap()
+                )
+            }
+        }
+
+        #[tokio::test]
         #[ignore = "We no longer use chain caches. See zcashd::check_info::regtest_no_cache."]
         async fn regtest_with_cache() {
             state_service_check_info(

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -110,6 +110,8 @@ pub struct StateService {
     config: StateServiceConfig,
     /// Thread-safe status indicator.
     status: AtomicStatus,
+    /// Listener for when the chain tip changes
+    chain_tip_change: zebra_state::ChainTipChange,
 }
 
 impl StateService {
@@ -163,7 +165,7 @@ impl ZcashService for StateService {
         info!("Using Zcash build: {}", data);
 
         info!("Launching Chain Syncer..");
-        let (mut read_state_service, _latest_chain_tip, _chain_tip_change, sync_task_handle) =
+        let (mut read_state_service, _latest_chain_tip, chain_tip_change, sync_task_handle) =
             init_read_state_with_syncer(
                 config.validator_config.clone(),
                 &config.network,
@@ -205,6 +207,7 @@ impl ZcashService for StateService {
         let mempool = Mempool::spawn(&rpc_client, None).await?;
 
         let state_service = Self {
+            chain_tip_change,
             read_state_service,
             sync_task_handle: Some(Arc::new(sync_task_handle)),
             rpc_client: rpc_client.clone(),
@@ -229,6 +232,7 @@ impl ZcashService for StateService {
             mempool: self.mempool.subscriber(),
             data: self.data.clone(),
             config: self.config.clone(),
+            chain_tip_change: self.chain_tip_change.clone(),
         })
     }
 
@@ -278,6 +282,25 @@ pub struct StateServiceSubscriber {
     pub data: ServiceMetadata,
     /// StateService config data.
     config: StateServiceConfig,
+    /// Listener for when the chain tip changes
+    chain_tip_change: zebra_state::ChainTipChange,
+}
+
+/// A subscriber to any chaintip updates
+#[derive(Clone)]
+pub struct ChainTipSubscriber(zebra_state::ChainTipChange);
+
+impl ChainTipSubscriber {
+    /// Waits until the tip hash has changed (relative to the last time this method
+    /// was called), then returns the best tip's block hash.
+    pub async fn next_tip_hash(
+        &mut self,
+    ) -> Result<zebra_chain::block::Hash, tokio::sync::watch::error::RecvError> {
+        self.0
+            .wait_for_tip_change()
+            .await
+            .map(|tip| tip.best_tip_hash())
+    }
 }
 
 /// Private RPC methods, which are used as helper methods by the public ones
@@ -285,6 +308,10 @@ pub struct StateServiceSubscriber {
 /// These would be simple to add to the public interface if
 /// needed, there are currently no plans to do so.
 impl StateServiceSubscriber {
+    /// Gets a Subscriber to any updates to the latest chain tip
+    pub async fn chaintip_update_subscriber(&self) -> ChainTipSubscriber {
+        ChainTipSubscriber(self.chain_tip_change.clone())
+    }
     /// Returns the requested block header by hash or height, as a [`GetBlockHeader`] JSON string.
     /// If the block is not in Zebra's state,
     /// returns [error code `-8`.](https://github.com/zcash/zcash/issues/5758)

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -309,7 +309,7 @@ impl ChainTipSubscriber {
 /// needed, there are currently no plans to do so.
 impl StateServiceSubscriber {
     /// Gets a Subscriber to any updates to the latest chain tip
-    pub async fn chaintip_update_subscriber(&self) -> ChainTipSubscriber {
+    pub fn chaintip_update_subscriber(&self) -> ChainTipSubscriber {
         ChainTipSubscriber(self.chain_tip_change.clone())
     }
     /// Returns the requested block header by hash or height, as a [`GetBlockHeader`] JSON string.


### PR DESCRIPTION
This adds a chaintip upgrade subscriber to the StateService. Ideally, this should be a ZcashIndexer trait method, but the StateService implementation is easier than the FetchService implementation, and I didn't want to block one on the other.