### PR TITLE
Zebrad version check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-lock"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06acb4f71407ba205a07cb453211e0e6a67b21904e47f6ba1f9589e38f2e454"
+dependencies = [
+ "semver",
+ "serde",
+ "toml 0.8.23",
+ "url",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4058,6 +4070,9 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -5823,6 +5838,7 @@ name = "zaino-state"
 version = "0.1.2"
 dependencies = [
  "async-trait",
+ "cargo-lock",
  "chrono",
  "dashmap",
  "dcbor",

--- a/zaino-state/Cargo.toml
+++ b/zaino-state/Cargo.toml
@@ -60,3 +60,5 @@ zingolib = { workspace = true }
 
 [build-dependencies]
 whoami = { workspace = true }
+cargo-lock = "10.1.0"
+

--- a/zaino-state/build.rs
+++ b/zaino-state/build.rs
@@ -61,7 +61,7 @@ fn main() -> io::Result<()> {
     let dest_path = Path::new(&out_dir).join("zebraversion.rs");
     fs::write(
         &dest_path,
-        &format!(
+        format!(
             "const ZEBRA_VERSION: Option<&'static str> = {:?};",
             maybe_zebra_rev
         ),

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -160,32 +160,29 @@ impl ZcashService for StateService {
         // This const is optional, as the build script can only
         // generate it from hash-based dependencies.
         // in all other cases, this check will be skipped.
-        match crate::ZEBRA_VERSION {
-            Some(expected_zebrad_version) => {
-                // this `+` indicates a git describe run
-                // i.e. the first seven characters of the commit hash
-                // have been appended. We match on those
-                if zebra_build_data.build.contains('+') {
-                    if !zebra_build_data
-                        .build
-                        .contains(&expected_zebrad_version[0..7])
-                    {
-                        return Err(StateServiceError::ZebradVersionMismatch {
-                            expected_zebrad_version: expected_zebrad_version.to_string(),
-                            connected_zebrad_version: zebra_build_data.build,
-                        });
-                    }
-                } else {
-                    // With no `+`, we expect a version number to be an exact match
-                    if expected_zebrad_version != zebra_build_data.build {
-                        return Err(StateServiceError::ZebradVersionMismatch {
-                            expected_zebrad_version: expected_zebrad_version.to_string(),
-                            connected_zebrad_version: zebra_build_data.build,
-                        });
-                    }
+        if let Some(expected_zebrad_version) = crate::ZEBRA_VERSION {
+            // this `+` indicates a git describe run
+            // i.e. the first seven characters of the commit hash
+            // have been appended. We match on those
+            if zebra_build_data.build.contains('+') {
+                if !zebra_build_data
+                    .build
+                    .contains(&expected_zebrad_version[0..7])
+                {
+                    return Err(StateServiceError::ZebradVersionMismatch {
+                        expected_zebrad_version: expected_zebrad_version.to_string(),
+                        connected_zebrad_version: zebra_build_data.build,
+                    });
+                }
+            } else {
+                // With no `+`, we expect a version number to be an exact match
+                if expected_zebrad_version != zebra_build_data.build {
+                    return Err(StateServiceError::ZebradVersionMismatch {
+                        expected_zebrad_version: expected_zebrad_version.to_string(),
+                        connected_zebrad_version: zebra_build_data.build,
+                    });
                 }
             }
-            None => (),
         };
         let data = ServiceMetadata::new(
             get_build_info(),

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -156,8 +156,15 @@ impl ZcashService for StateService {
         .await?;
 
         let zebra_build_data = rpc_client.get_info().await?;
+
+        // This const is optional, as the build script can only
+        // generate it from hash-based dependencies.
+        // in all other cases, this check will be skipped.
         match crate::ZEBRA_VERSION {
             Some(expected_zebrad_version) => {
+                // this `+` indicates a git describe run
+                // i.e. the first seven characters of the commit hash
+                // have been appended. We match on those
                 if zebra_build_data.build.contains('+') {
                     if !zebra_build_data
                         .build
@@ -169,6 +176,7 @@ impl ZcashService for StateService {
                         });
                     }
                 } else {
+                    // With no `+`, we expect a version number to be an exact match
                     if expected_zebrad_version != zebra_build_data.build {
                         return Err(StateServiceError::ZebradVersionMismatch {
                             expected_zebrad_version: expected_zebrad_version.to_string(),

--- a/zaino-state/src/error.rs
+++ b/zaino-state/src/error.rs
@@ -46,6 +46,20 @@ pub enum StateServiceError {
     /// A generic boxed error.
     #[error("Generic error: {0}")]
     Generic(#[from] Box<dyn std::error::Error + Send + Sync>),
+
+    /// The zebrad version and zebra library version do not align
+    #[error(
+        "zebrad version mismatch. this build of zaino requires a \
+        version of {expected_zebrad_version}, but the connected zebrad \
+        is version {connected_zebrad_version}"
+    )]
+    ZebradVersionMismatch {
+        /// The version string or commit hash we specify in Cargo.lock
+        expected_zebrad_version: String,
+        /// The version string of the zebrad, plus its git describe
+        /// information if applicable
+        connected_zebrad_version: String,
+    },
 }
 
 impl From<StateServiceError> for tonic::Status {
@@ -79,6 +93,9 @@ impl From<StateServiceError> for tonic::Status {
             }
             StateServiceError::Generic(err) => {
                 tonic::Status::internal(format!("Generic error: {}", err))
+            }
+            ref err @ StateServiceError::ZebradVersionMismatch { .. } => {
+                tonic::Status::internal(err.to_string())
             }
         }
     }

--- a/zaino-state/src/lib.rs
+++ b/zaino-state/src/lib.rs
@@ -9,6 +9,8 @@
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
 
+include!(concat!(env!("OUT_DIR"), "/zebraversion.rs"));
+
 // Zaino's Indexer library frontend.
 pub(crate) mod indexer;
 

--- a/zainod/tests/config.rs
+++ b/zainod/tests/config.rs
@@ -377,10 +377,10 @@ fn test_figment_env_override_toml_and_defaults() {
         let config = load_config(&temp_toml_path).expect("load_config should succeed");
 
         assert_eq!(config.network, "Mainnet");
-        assert_eq!(config.enable_json_server, true);
+        assert!(config.enable_json_server);
         assert_eq!(config.map_capacity, Some(12345));
         assert_eq!(config.cookie_dir, Some(PathBuf::from("/env/cookie/path")));
-        assert_eq!(config.grpc_tls, false);
+        assert!(!config.grpc_tls);
         Ok(())
     });
 }
@@ -398,7 +398,7 @@ fn test_figment_toml_overrides_defaults() {
         let temp_toml_path = jail.directory().join("test_config.toml");
         let config = load_config(&temp_toml_path).expect("load_config should succeed");
         assert_eq!(config.network, "Regtest");
-        assert_eq!(config.enable_json_server, true);
+        assert!(config.enable_json_server);
         Ok(())
     });
 }


### PR DESCRIPTION
This fixes #361 by adding a zebrad version check the case of commit-hash zebra dependencies. If we depend on tagged/version-based zebra, the check won't be ran, but ideally when we're stable enough to depend on tagged/version-based zebra, this check shouldn't be necessary. 