### PR TITLE
refactor test_binaries/bins pattern

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -5,6 +5,7 @@ default_to_workspace = false
 
 [env]
 IMAGE_NAME = "zingodevops/zaino-ci"
+TEST_BINARIES_DIR = "/usr/local/bin"
 
 [tasks.help]
 description = "List available commands and usage notes"
@@ -125,7 +126,10 @@ set -euo pipefail
 
 TAG=$(./utils/get-ci-image-tag.sh)
 
-info "Running tests using image: ${IMAGE_NAME}:$TAG"
+info "Running tests using:"
+info "-- IMAGE             = ${IMAGE_NAME}"
+info "-- TAG               = $TAG"
+# info "-- TEST_BINARIES_DIR = ${TEST_BINARIES_DIR}"
 
 docker run --rm \
   --name zaino-testing \
@@ -133,12 +137,10 @@ docker run --rm \
   -v "$PWD/target":/root/target \
   -v "$PWD/docker_cargo/git":/root/.cargo/git \
   -v "$PWD/docker_cargo/registry":/root/.cargo/registry \
+  -e "TEST_BINARIES_DIR=${TEST_BINARIES_DIR}" \
   -w /app \
   "${IMAGE_NAME}:$TAG" \
   cargo nextest run --profile ci "${@}"
-'''
-script.post = '''
-docker stop zaino-testing
 '''
 
 [tasks.copy-bins]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -32,7 +32,6 @@ echo "  build-image         Build the Docker image with current artifact version
 echo "  push-image          Push the image (used in CI, can be used manually)"
 echo "  compute-image-tag   Compute the tag for the Docker image based on versions"
 echo "  ensure-image-exists Check if the required image exists locally, build if not"
-echo "  copy-bins           Extract binaries from the image to ./test_binaries/bins"
 echo ""
 echo "Environment:"
 echo "  Defined by: .env.testing-artifacts"
@@ -141,16 +140,4 @@ docker run --rm \
   -w /app \
   "${IMAGE_NAME}:$TAG" \
   cargo nextest run --profile ci "${@}"
-'''
-
-[tasks.copy-bins]
-description = "Copy bins from image into test_binaries/bins"
-extend = "base-script"
-script.main = '''
-set -euo pipefail
-
-docker create --name my_zaino_container zingodevops/zaino-ci:"$TAG"
-docker cp my_zaino_container:/usr/local/bin ./test_binaries/
-cp -r ./test_binaries/bin ./test_binaries/bins
-docker rm my_zaino_container
 '''

--- a/zaino-state/src/local_cache.rs
+++ b/zaino-state/src/local_cache.rs
@@ -313,35 +313,30 @@ async fn try_fetcher_path(
                     block_hex.as_ref(),
                     Some(display_txids_to_server(tx).map_err(|e| {
                         RpcRequestError::Method(GetBlockError::Custom(format!(
-                            "Error parsing txids: {}",
-                            e
+                            "Error parsing txids: {e}"
                         )))
                     })?),
                 )
                 .map_err(|e| {
                     RpcRequestError::Method(GetBlockError::Custom(format!(
-                        "Error parsing block: {}",
-                        e
+                        "Error parsing block: {e}"
                     )))
                 })?
                 .into_compact(
                     u32::try_from(trees.sapling()).map_err(|e| {
                         RpcRequestError::Method(GetBlockError::Custom(format!(
-                            "Error parsing sapling tree: {}",
-                            e
+                            "Error parsing sapling tree: {e}"
                         )))
                     })?,
                     u32::try_from(trees.orchard()).map_err(|e| {
                         RpcRequestError::Method(GetBlockError::Custom(format!(
-                            "Error parsing orchard tree: {}",
-                            e
+                            "Error parsing orchard tree: {e}"
                         )))
                     })?,
                 )
                 .map_err(|e| {
                     RpcRequestError::Method(GetBlockError::Custom(format!(
-                        "Error parsing compact block: {}",
-                        e
+                        "Error parsing compact block: {e}"
                     )))
                 })?,
             )),

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -21,40 +21,27 @@ pub use zingolib::{
     get_base_address_macro, lightclient::LightClient, testutils::lightclient::from_inputs,
 };
 
+/// Helper to get the test binary path from the TEST_BINARIES_DIR env var.
+fn binary_path(binary_name: &str) -> Option<PathBuf> {
+    std::env::var("TEST_BINARIES_DIR")
+        .ok()
+        .map(|dir| PathBuf::from(dir).join(binary_name))
+}
+
 /// Path for zcashd binary.
-pub static ZCASHD_BIN: Lazy<Option<PathBuf>> = Lazy::new(|| {
-    let mut workspace_root_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
-    workspace_root_path.pop();
-    Some(workspace_root_path.join("test_binaries/bins/zcashd"))
-});
+pub static ZCASHD_BIN: Lazy<Option<PathBuf>> = Lazy::new(|| binary_path("zcashd"));
 
 /// Path for zcash-cli binary.
-pub static ZCASH_CLI_BIN: Lazy<Option<PathBuf>> = Lazy::new(|| {
-    let mut workspace_root_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
-    workspace_root_path.pop();
-    Some(workspace_root_path.join("test_binaries/bins/zcash-cli"))
-});
+pub static ZCASH_CLI_BIN: Lazy<Option<PathBuf>> = Lazy::new(|| binary_path("zcash-cli"));
 
 /// Path for zebrad binary.
-pub static ZEBRAD_BIN: Lazy<Option<PathBuf>> = Lazy::new(|| {
-    let mut workspace_root_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
-    workspace_root_path.pop();
-    Some(workspace_root_path.join("test_binaries/bins/zebrad"))
-});
+pub static ZEBRAD_BIN: Lazy<Option<PathBuf>> = Lazy::new(|| binary_path("zebrad"));
 
 /// Path for lightwalletd binary.
-pub static LIGHTWALLETD_BIN: Lazy<Option<PathBuf>> = Lazy::new(|| {
-    let mut workspace_root_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
-    workspace_root_path.pop();
-    Some(workspace_root_path.join("test_binaries/bins/lightwalletd"))
-});
+pub static LIGHTWALLETD_BIN: Lazy<Option<PathBuf>> = Lazy::new(|| binary_path("lightwalletd"));
 
 /// Path for zainod binary.
-pub static ZAINOD_BIN: Lazy<Option<PathBuf>> = Lazy::new(|| {
-    let mut workspace_root_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
-    workspace_root_path.pop();
-    Some(workspace_root_path.join("target/release/zainod"))
-});
+pub static ZAINOD_BIN: Lazy<Option<PathBuf>> = Lazy::new(|| binary_path("zainod"));
 
 /// Path for zcashd chain cache.
 pub static ZCASHD_CHAIN_CACHE_DIR: Lazy<Option<PathBuf>> = Lazy::new(|| {


### PR DESCRIPTION
This PR moves away from the current pattern of counting on the testing binaries to be stashed in `test_binaries/bins`.
It should prevent issues with de-synced bins copied over from the testing images, making a yet stronger case for `cargo make test` being a plug-and-test command.

New pattern:
---
The new pattern expects an env var `TEST_BINARIES_DIR` to be set while running tests.
This var must contain the path to a directory with all the needed bins.

This also updates the `cargo-make` tools to make sure tests run with `cargo make test` always have this variable set correctly.

Testers who won't use the docker approach can opt for manually setting the env var before running tests or keeping it unset if they add all the binaries to their `$PATH` 
