### PR TITLE
Zaino-state serialiser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,6 +870,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,7 +1219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca4f333d4ccc9d23c06593733673026efa71a332e028b00f12cf427b9677dce9"
 dependencies = [
  "blake2b_simd",
- "core2",
+ "core2 0.3.3",
  "document-features",
 ]
 
@@ -2793,7 +2802,7 @@ dependencies = [
  "aes",
  "bitvec",
  "blake2b_simd",
- "core2",
+ "core2 0.3.3",
  "ff",
  "fpe",
  "getset",
@@ -3935,7 +3944,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "bls12_381",
- "core2",
+ "core2 0.3.3",
  "document-features",
  "ff",
  "fpe",
@@ -5811,6 +5820,7 @@ dependencies = [
  "byteorder",
  "cargo-lock",
  "chrono",
+ "core2 0.4.0",
  "dashmap",
  "futures",
  "hex",
@@ -5899,7 +5909,7 @@ checksum = "71591bb4eb2fd7622e88eed42e7d7d8501cd1e920a0698c7fb08723a8c1d0b4f"
 dependencies = [
  "bech32",
  "bs58",
- "core2",
+ "core2 0.3.3",
  "f4jumble",
  "zcash_encoding",
  "zcash_protocol",
@@ -5958,7 +5968,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bca38087e6524e5f51a5b0fb3fc18f36d7b84bf67b2056f494ca0c281590953d"
 dependencies = [
- "core2",
+ "core2 0.3.3",
  "nonempty",
 ]
 
@@ -5985,7 +5995,7 @@ dependencies = [
  "bls12_381",
  "bs58",
  "byteorder",
- "core2",
+ "core2 0.3.3",
  "document-features",
  "group",
  "memuse",
@@ -6025,7 +6035,7 @@ dependencies = [
  "bip32",
  "blake2b_simd",
  "bs58",
- "core2",
+ "core2 0.3.3",
  "document-features",
  "equihash",
  "ff",
@@ -6085,7 +6095,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f116cd111d813b7afc814be013566b16e32a7b887597f906ac42b0f7f6a1681"
 dependencies = [
- "core2",
+ "core2 0.3.3",
  "document-features",
  "hex",
  "memuse",
@@ -6119,7 +6129,7 @@ dependencies = [
  "bip32",
  "blake2b_simd",
  "bs58",
- "core2",
+ "core2 0.3.3",
  "document-features",
  "getset",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ ctrlc = "3.4"
 chrono = "0.4"
 which = "4"
 whoami = "1.5"
+core2 = "0.4"
 
 # Formats
 base64 = "0.22"

--- a/zaino-state/Cargo.toml
+++ b/zaino-state/Cargo.toml
@@ -50,6 +50,7 @@ jsonrpsee-core = { workspace = true }
 prost = { workspace = true }
 primitive-types = { workspace = true }
 byteorder = { workspace = true }
+core2 = { workspace = true }
 nonempty = "0.11.0"
 
 [dev-dependencies]

--- a/zaino-state/src/chain_index.rs
+++ b/zaino-state/src/chain_index.rs
@@ -11,6 +11,7 @@
 //!     - b. Build trasparent tx indexes efficiently
 //!   - NOTE: Full transaction and block data is served from the backend finalizer.
 
+pub mod encoding;
 pub mod finalised_state;
 pub mod mempool;
 pub mod non_finalised_state;

--- a/zaino-state/src/chain_index/encoding.rs
+++ b/zaino-state/src/chain_index/encoding.rs
@@ -1,0 +1,433 @@
+//! Holds traits and primitive functions for Zaino's Serialisation schema.
+#![allow(dead_code)]
+
+use core::iter::FromIterator;
+use core2::io::{self, Read, Write};
+
+/// Wire-format version tags.
+/// `pub(crate)` → visible everywhere inside *this* crate,
+/// not re-exported to downstream users.
+pub mod version {
+    /// Tag byte for data encoded with *v1* layout.
+    pub const V1: u8 = 1;
+
+    /// Tag byte for data encoded with *v2* layout.
+    pub const V2: u8 = 2;
+
+    // Add new versions as required.
+    // pub const V3: u8 = 3;
+}
+
+/* ────────────────────────── Zaino Serialiser Trait ─────────────────────────── */
+/// # Zaino wire-format: one-byte version tag
+///
+/// ## Quick summary
+///
+/// ┌─ byte 0 ─┬──────────── body depends on that tag ────────────┐
+/// │ version  │              (little-endian by default)          │
+/// └──────────┴──────────────────────────────────────────────────┘
+///
+/// * `Self::VERSION` = the tag **this build *writes***.
+/// * On **read**, we peek at the tag:
+///   * if it equals `Self::VERSION` call `decode_latest`;
+///   * otherwise fall back to the relevant `decode_vN` helper  
+///     (defaults to “unsupported” unless overwritten).
+///
+/// ## Update guide.
+///
+/// ### Initial release (`VERSION = 1`)
+/// 1. `pub struct TxV1 { … }`   // layout frozen forever  
+/// 2. `impl ZainoVersionedSerialise for TxV1`  
+///    * `const VERSION = 1`  
+///    * `encode_body` – **v1** layout  
+///    * `decode_latest` – parses **v1** bytes  
+///    * (optional) `decode_v1 = Self::decode_latest`
+///
+/// ### Bump to v2
+/// 1. `pub struct TxV2 { … }`   // new “current” layout  
+/// 2. `impl From<TxV1> for TxV2` // loss-less upgrade path  
+/// 3. `impl ZainoVersionedSerialise for TxV2`  
+///    * `const VERSION = 2`  
+///    * `encode_body` – **v2** layout  
+///    * `decode_latest` – parses **v2** bytes  
+///    * `decode_v1` – `TxV1::decode_latest(r).map(Self::from)`
+///    * (optional) `decode_v2 = Self::decode_latest`
+///
+/// ### Next bumps (v3, v4, …)
+/// * Set `const VERSION = N`.  
+/// * Implement `decode_latest` for N’s layout.  
+/// * Add `decode_v(N-1)` (and older).
+/// * Extend the `match` table inside **this trait** when a brand-new tag first appears.
+///
+/// ## Mandatory items per implementation
+/// * `const VERSION`  
+/// * `encode_body`  
+/// * `decode_latest` — **must** parse `Self::VERSION` bytes.
+///
+/// Historical helpers (`decode_v1`, `decode_v2`, …) must be implemented
+/// for compatibility with historical versions
+pub trait ZainoVersionedSerialise: Sized {
+    /// Tag this build writes.
+    const VERSION: u8;
+
+    /*──────────── encoding ────────────*/
+
+    /// Encode **only** the body (no tag).
+    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()>;
+
+    #[inline]
+    fn serialize<W: Write>(&self, mut w: W) -> io::Result<()> {
+        w.write_all(&[Self::VERSION])?;
+        self.encode_body(&mut w)
+    }
+
+    /*──────────── mandatory decoder for *this* version ────────────*/
+
+    /// Parses a body whose tag equals `Self::VERSION`.
+    fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self>;
+
+    /*──────────── optional historical decoders ────────────*/
+    // Add more versions here when required.
+
+    #[inline(always)]
+    #[allow(unused)]
+    fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
+        Err(io::Error::new(io::ErrorKind::InvalidData, "v1 unsupported"))
+    }
+    #[inline(always)]
+    #[allow(unused)]
+    fn decode_v2<R: Read>(r: &mut R) -> io::Result<Self> {
+        Err(io::Error::new(io::ErrorKind::InvalidData, "v2 unsupported"))
+    }
+
+    /*──────────── router ────────────*/
+
+    #[inline]
+    fn decode_body<R: Read>(r: &mut R, version_tag: u8) -> io::Result<Self> {
+        if version_tag == Self::VERSION {
+            Self::decode_latest(r)
+        } else {
+            match version_tag {
+                version::V1 => Self::decode_v1(r),
+                version::V2 => Self::decode_v2(r),
+                _ => Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("unsupported Zaino version tag {version_tag}"),
+                )),
+            }
+        }
+    }
+
+    /*──────────── convenience entry point ────────────*/
+
+    #[inline]
+    fn deserialize<R: Read>(mut r: R) -> io::Result<Self> {
+        let mut tag = [0u8; 1];
+        r.read_exact(&mut tag)?;
+        Self::decode_body(&mut r, tag[0])
+    }
+}
+
+/* ──────────────────────────── CompactSize helpers ────────────────────────────── */
+/*Namespace for functions for compact encoding of integers.
+
+This codec requires integers to be in the range `0x0..=0x02000000`, for compatibility
+with Zcash consensus rules. */
+
+pub struct CompactSize;
+
+pub const MAX_COMPACT_SIZE: u32 = 0x0200_0000;
+
+impl CompactSize {
+    /// Reads an integer encoded in compact form.
+    pub fn read<R: Read>(mut reader: R) -> io::Result<u64> {
+        let mut flag_bytes = [0; 1];
+        reader.read_exact(&mut flag_bytes)?;
+        let flag = flag_bytes[0];
+
+        let result = if flag < 253 {
+            Ok(flag as u64)
+        } else if flag == 253 {
+            let mut bytes = [0; 2];
+            reader.read_exact(&mut bytes)?;
+            match u16::from_le_bytes(bytes) {
+                n if n < 253 => Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "non-canonical CompactSize",
+                )),
+                n => Ok(n as u64),
+            }
+        } else if flag == 254 {
+            let mut bytes = [0; 4];
+            reader.read_exact(&mut bytes)?;
+            match u32::from_le_bytes(bytes) {
+                n if n < 0x10000 => Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "non-canonical CompactSize",
+                )),
+                n => Ok(n as u64),
+            }
+        } else {
+            let mut bytes = [0; 8];
+            reader.read_exact(&mut bytes)?;
+            match u64::from_le_bytes(bytes) {
+                n if n < 0x100000000 => Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "non-canonical CompactSize",
+                )),
+                n => Ok(n),
+            }
+        }?;
+
+        match result {
+            s if s > <u64>::from(MAX_COMPACT_SIZE) => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "CompactSize too large",
+            )),
+            s => Ok(s),
+        }
+    }
+
+    /// Reads an integer encoded in contact form and performs checked conversion
+    /// to the target type.
+    pub fn read_t<R: Read, T: TryFrom<u64>>(mut reader: R) -> io::Result<T> {
+        let n = Self::read(&mut reader)?;
+        <T>::try_from(n).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "CompactSize value exceeds range of target type.",
+            )
+        })
+    }
+
+    /// Writes the provided `usize` value to the provided Writer in compact form.
+    pub fn write<W: Write>(mut writer: W, size: usize) -> io::Result<()> {
+        match size {
+            s if s < 253 => writer.write_all(&[s as u8]),
+            s if s <= 0xFFFF => {
+                writer.write_all(&[253])?;
+                writer.write_all(&(s as u16).to_le_bytes())
+            }
+            s if s <= 0xFFFFFFFF => {
+                writer.write_all(&[254])?;
+                writer.write_all(&(s as u32).to_le_bytes())
+            }
+            s => {
+                writer.write_all(&[255])?;
+                writer.write_all(&(s as u64).to_le_bytes())
+            }
+        }
+    }
+
+    /// Returns the number of bytes needed to encode the given size in compact form.
+    pub fn serialized_size(size: usize) -> usize {
+        match size {
+            s if s < 253 => 1,
+            s if s <= 0xFFFF => 3,
+            s if s <= 0xFFFFFFFF => 5,
+            _ => 9,
+        }
+    }
+}
+
+/* ───────────────────────────── integer helpers ───────────────────────────── */
+
+#[inline]
+pub(crate) fn read_u16_le<R: Read>(mut r: R) -> io::Result<u16> {
+    let mut buf = [0u8; 2];
+    r.read_exact(&mut buf)?;
+    Ok(u16::from_le_bytes(buf))
+}
+#[inline]
+pub(crate) fn read_u16_be<R: Read>(mut r: R) -> io::Result<u16> {
+    let mut buf = [0u8; 2];
+    r.read_exact(&mut buf)?;
+    Ok(u16::from_be_bytes(buf))
+}
+#[inline]
+pub(crate) fn write_u16_le<W: Write>(mut w: W, v: u16) -> io::Result<()> {
+    w.write_all(&v.to_le_bytes())
+}
+#[inline]
+pub(crate) fn write_u16_be<W: Write>(mut w: W, v: u16) -> io::Result<()> {
+    w.write_all(&v.to_be_bytes())
+}
+
+#[inline]
+pub(crate) fn read_u32_le<R: Read>(mut r: R) -> io::Result<u32> {
+    let mut buf = [0u8; 4];
+    r.read_exact(&mut buf)?;
+    Ok(u32::from_le_bytes(buf))
+}
+#[inline]
+pub(crate) fn read_u32_be<R: Read>(mut r: R) -> io::Result<u32> {
+    let mut buf = [0u8; 4];
+    r.read_exact(&mut buf)?;
+    Ok(u32::from_be_bytes(buf))
+}
+#[inline]
+pub(crate) fn write_u32_le<W: Write>(mut w: W, v: u32) -> io::Result<()> {
+    w.write_all(&v.to_le_bytes())
+}
+#[inline]
+pub(crate) fn write_u32_be<W: Write>(mut w: W, v: u32) -> io::Result<()> {
+    w.write_all(&v.to_be_bytes())
+}
+
+#[inline]
+pub(crate) fn read_u64_le<R: Read>(mut r: R) -> io::Result<u64> {
+    let mut buf = [0u8; 8];
+    r.read_exact(&mut buf)?;
+    Ok(u64::from_le_bytes(buf))
+}
+#[inline]
+pub(crate) fn read_u64_be<R: Read>(mut r: R) -> io::Result<u64> {
+    let mut buf = [0u8; 8];
+    r.read_exact(&mut buf)?;
+    Ok(u64::from_be_bytes(buf))
+}
+#[inline]
+pub(crate) fn write_u64_le<W: Write>(mut w: W, v: u64) -> io::Result<()> {
+    w.write_all(&v.to_le_bytes())
+}
+#[inline]
+pub(crate) fn write_u64_be<W: Write>(mut w: W, v: u64) -> io::Result<()> {
+    w.write_all(&v.to_be_bytes())
+}
+
+#[inline]
+pub(crate) fn read_i64_le<R: Read>(mut r: R) -> io::Result<i64> {
+    let mut buf = [0u8; 8];
+    r.read_exact(&mut buf)?;
+    Ok(i64::from_le_bytes(buf))
+}
+#[inline]
+pub(crate) fn read_i64_be<R: Read>(mut r: R) -> io::Result<i64> {
+    let mut buf = [0u8; 8];
+    r.read_exact(&mut buf)?;
+    Ok(i64::from_be_bytes(buf))
+}
+#[inline]
+pub(crate) fn write_i64_le<W: Write>(mut w: W, v: i64) -> io::Result<()> {
+    w.write_all(&v.to_le_bytes())
+}
+#[inline]
+pub(crate) fn write_i64_be<W: Write>(mut w: W, v: i64) -> io::Result<()> {
+    w.write_all(&v.to_be_bytes())
+}
+
+/* ───────────────────────────── fixed-array helpers ───────────────────────── */
+
+/// Read exactly `N` bytes **as-is** (little-endian / “native order”).
+#[inline]
+pub(crate) fn read_fixed_le<const N: usize, R: Read>(mut r: R) -> io::Result<[u8; N]> {
+    let mut buf = [0u8; N];
+    r.read_exact(&mut buf)?;
+    Ok(buf)
+}
+
+/// Write an `[u8; N]` **as-is** (little-endian / “native order”).
+#[inline]
+pub(crate) fn write_fixed_le<const N: usize, W: Write>(
+    mut w: W,
+    bytes: &[u8; N],
+) -> io::Result<()> {
+    w.write_all(bytes)
+}
+
+/// Read exactly `N` bytes from the stream and **reverse** them so the caller
+/// receives little-endian/internal order while the wire sees big-endian.
+#[inline]
+pub(crate) fn read_fixed_be<const N: usize, R: Read>(mut r: R) -> io::Result<[u8; N]> {
+    let mut buf = [0u8; N];
+    r.read_exact(&mut buf)?;
+    buf.reverse();
+    Ok(buf)
+}
+
+/// Take an internal little-endian `[u8; N]`, reverse it, and write big-endian
+/// order to the stream.
+#[inline]
+pub(crate) fn write_fixed_be<const N: usize, W: Write>(
+    mut w: W,
+    bytes: &[u8; N],
+) -> io::Result<()> {
+    let mut tmp = *bytes;
+    tmp.reverse();
+    w.write_all(&tmp)
+}
+
+/* ─────────────────────────── Option<T> helpers ──────────────────────────── */
+
+/// 0 = None, 1 = Some.
+pub(crate) fn write_option<W, T, F>(mut w: W, value: &Option<T>, mut f: F) -> io::Result<()>
+where
+    W: Write,
+    F: FnMut(&mut W, &T) -> io::Result<()>,
+{
+    match value {
+        None => w.write_all(&[0]),
+        Some(val) => {
+            w.write_all(&[1])?;
+            f(&mut w, val)
+        }
+    }
+}
+
+pub(crate) fn read_option<R, T, F>(mut r: R, mut f: F) -> io::Result<Option<T>>
+where
+    R: Read,
+    F: FnMut(&mut R) -> io::Result<T>,
+{
+    let mut flag = [0u8; 1];
+    r.read_exact(&mut flag)?;
+    match flag[0] {
+        0 => Ok(None),
+        1 => f(&mut r).map(Some),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "non-canonical Option tag",
+        )),
+    }
+}
+
+/* ──────────────────────────── Vec<T> helpers ────────────────────────────── */
+/* Uses Bitcoin/Zcash “CompactSize” for the length field, capped at 0x02000000.
+If you prefer a raw u32 length, swap the two small helpers.                */
+
+pub(crate) fn write_vec<W, T, F>(mut w: W, vec: &[T], mut f: F) -> io::Result<()>
+where
+    W: Write,
+    F: FnMut(&mut W, &T) -> io::Result<()>,
+{
+    CompactSize::write(&mut w, vec.len())?; // <── uses your codec
+    for item in vec {
+        f(&mut w, item)?
+    }
+    Ok(())
+}
+
+pub(crate) fn read_vec<R, T, F>(mut r: R, mut f: F) -> io::Result<Vec<T>>
+where
+    R: Read,
+    F: FnMut(&mut R) -> io::Result<T>,
+{
+    let len = CompactSize::read(&mut r)? as usize; // <── uses your codec
+    let mut v = Vec::with_capacity(len);
+    for _ in 0..len {
+        v.push(f(&mut r)?);
+    }
+    Ok(v)
+}
+
+/// Same as `read_vec` but collects straight into any container that
+/// implements `FromIterator`.
+pub(crate) fn read_vec_into<R, T, C, F>(mut r: R, mut f: F) -> io::Result<C>
+where
+    R: Read,
+    F: FnMut(&mut R) -> io::Result<T>,
+    C: FromIterator<T>,
+{
+    let len = CompactSize::read(&mut r)? as usize; // <── uses your codec
+    (0..len).map(|_| f(&mut r)).collect()
+}

--- a/zaino-state/src/chain_index/encoding.rs
+++ b/zaino-state/src/chain_index/encoding.rs
@@ -181,7 +181,7 @@ impl CompactSize {
         }
     }
 
-    /// Reads an integer encoded in contact form and performs checked conversion
+    /// Reads an integer encoded in compact form and performs checked conversion
     /// to the target type.
     pub fn read_t<R: Read, T: TryFrom<u64>>(mut reader: R) -> io::Result<T> {
         let n = Self::read(&mut reader)?;

--- a/zaino-state/src/chain_index/encoding.rs
+++ b/zaino-state/src/chain_index/encoding.rs
@@ -30,38 +30,38 @@ pub mod version {
 /// * `Self::VERSION` = the tag **this build *writes***.
 /// * On **read**, we peek at the tag:
 ///   * if it equals `Self::VERSION` call `decode_latest`;
-///   * otherwise fall back to the relevant `decode_vN` helper  
+///   * otherwise fall back to the relevant `decode_vN` helper
 ///     (defaults to “unsupported” unless overwritten).
 ///
 /// ## Update guide.
 ///
 /// ### Initial release (`VERSION = 1`)
-/// 1. `pub struct TxV1 { … }`   // layout frozen forever  
-/// 2. `impl ZainoVersionedSerialise for TxV1`  
-///    * `const VERSION = 1`  
-///    * `encode_body` – **v1** layout  
-///    * `decode_latest` – parses **v1** bytes  
+/// 1. `pub struct TxV1 { … }`   // layout frozen forever
+/// 2. `impl ZainoVersionedSerialise for TxV1`
+///    * `const VERSION = 1`
+///    * `encode_body` – **v1** layout
+///    * `decode_latest` – parses **v1** bytes
 ///    * (optional) `decode_v1 = Self::decode_latest`
 ///
 /// ### Bump to v2
-/// 1. `pub struct TxV2 { … }`   // new “current” layout  
-/// 2. `impl From<TxV1> for TxV2` // loss-less upgrade path  
-/// 3. `impl ZainoVersionedSerialise for TxV2`  
-///    * `const VERSION = 2`  
-///    * `encode_body` – **v2** layout  
-///    * `decode_latest` – parses **v2** bytes  
+/// 1. `pub struct TxV2 { … }`   // new “current” layout
+/// 2. `impl From<TxV1> for TxV2` // loss-less upgrade path
+/// 3. `impl ZainoVersionedSerialise for TxV2`
+///    * `const VERSION = 2`
+///    * `encode_body` – **v2** layout
+///    * `decode_latest` – parses **v2** bytes
 ///    * `decode_v1` – `TxV1::decode_latest(r).map(Self::from)`
 ///    * (optional) `decode_v2 = Self::decode_latest`
 ///
 /// ### Next bumps (v3, v4, …)
-/// * Set `const VERSION = N`.  
-/// * Implement `decode_latest` for N’s layout.  
+/// * Set `const VERSION = N`.
+/// * Implement `decode_latest` for N’s layout.
 /// * Add `decode_v(N-1)` (and older).
 /// * Extend the `match` table inside **this trait** when a brand-new tag first appears.
 ///
 /// ## Mandatory items per implementation
-/// * `const VERSION`  
-/// * `encode_body`  
+/// * `const VERSION`
+/// * `encode_body`
 /// * `decode_latest` — **must** parse `Self::VERSION` bytes.
 ///
 /// Historical helpers (`decode_v1`, `decode_v2`, …) must be implemented

--- a/zaino-state/src/chain_index/types.rs
+++ b/zaino-state/src/chain_index/types.rs
@@ -769,7 +769,7 @@ impl ZainoVersionedSerialise for EquihashSolution {
             }
             Self::Regtest(bytes) => {
                 w.write_all(&[1])?;
-                write_fixed_le::<32, _>(&mut w, bytes)
+                write_fixed_le::<36, _>(&mut w, bytes)
             }
         }
     }
@@ -785,7 +785,7 @@ impl ZainoVersionedSerialise for EquihashSolution {
                 Ok(EquihashSolution::Standard(bytes))
             }
             1 => {
-                let bytes = read_fixed_le::<32, _>(&mut r)?;
+                let bytes = read_fixed_le::<36, _>(&mut r)?;
                 Ok(EquihashSolution::Regtest(bytes))
             }
             other => Err(io::Error::new(


### PR DESCRIPTION
Defines Zaino's serialisation scheme and implements for chain-index types.

- adds trait `ZainoVersionedSerialise`
- adds primitive read / write functuions
- implements `ZainoVersionedSerialise` for chain-index types

- Built atop #396 