### PR TITLE
Update Rust version in .env.testing-artifacts

### DIFF
--- a/.env.testing-artifacts
+++ b/.env.testing-artifacts
@@ -1,5 +1,5 @@
 # Rust toolchain version (for rust:<version>-bookworm base image)
-RUST_VERSION=1.87
+RUST_VERSION=1.88
 
 # zcashd Git tag (https://github.com/zcash/zcash/releases)
 ZCASH_VERSION=6.2.0


### PR DESCRIPTION
- RUST_VERSION updated from 1.87 to 1.88

To ensure the environment uses the latest compatible Rust version.