### PR TITLE
fix clippy in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # This is key to decide on te clippy job to run.
+      # The one from actions-rs prints nice annotations accross the pr, when browsing the changed files, right where the actual warning/error was found.
+      # It requires access to the GITHUB_TOKEN tho, a secret github automatically injects into every workflow run, but only for internally owned branches, not for forks.
+      # If that's the case, then we just run clippy with console output and that's it. One get's no annotations and has to check the actual job logs to see what went wrong.
+      - name: Check GITHUB_TOKEN accessibility
+        id: check_token
+        run: |
+          if [ -z "${{ secrets.GITHUB_TOKEN }}" ]; then
+            echo "GITHUB_TOKEN unavailable. If you are an external contributor, this is normal. If this is an internal PR, something is wrong."
+            echo "token_accessible=false" >> $GITHUB_ENV
+          else
+            echo "token_accessible=true" >> $GITHUB_ENV
+          fi
+
       - name: MinIO Cache (cargo + target)
         uses: tespkg/actions-cache@v1
         with:
@@ -218,11 +232,12 @@ jobs:
             ~/.cargo
             target
 
-      - name: Run clippy with console output
+      - name: Run clippy with console output (external contributors)
+        if: env.token_accessible == 'false'
         run: cargo clippy --all-targets -- --deny warnings
-        continue-on-error: true
 
       - name: Output clippy to Github
+        if: env.token_accessible == 'true'
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,7 @@ jobs:
 
       - name: Run clippy with console output
         run: cargo clippy --all-targets -- --deny warnings
+        continue-on-error: true
 
       - name: Output clippy to Github
         uses: actions-rs/clippy-check@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,11 +220,9 @@ jobs:
 
       - name: Run clippy with console output
         run: cargo clippy --all-targets -- --deny warnings
-        continue-on-error: true
 
       - name: Output clippy to Github
         uses: actions-rs/clippy-check@v1
-        continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets
+          args: --all-targets -- --deny warnings
 
   doc:
     name: Cargo Doc


### PR DESCRIPTION
To enforce errors to be addressed before proceeding.
I'm not sure that this is the fix, as in the past I noticed clippy being a bit quirky in the way it's output is interpreted by the job runner, hence why this config was in place IIUC.

Let's see what CI make's of it.
