### PR TITLE
dummy pr to try out clippy job fixes (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Output clippy to Github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: env.token_accessible != null
+        if: env.GITHUB_TOKEN != null
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,11 +205,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # This is key to decide on te clippy job to run.
-      # The one from actions-rs prints nice annotations accross the pr, when browsing the changed files, right where the actual warning/error was found.
-      # It requires access to the GITHUB_TOKEN tho, a secret github automatically injects into every workflow run, but only for internally owned branches, not for forks.
-      # If that's the case, then we just run clippy with console output and that's it. One get's no annotations and has to check the actual job logs to see what went wrong.
-
       - name: MinIO Cache (cargo + target)
         uses: tespkg/actions-cache@v1
         with:
@@ -222,6 +217,11 @@ jobs:
           path: |
             ~/.cargo
             target
+
+      # This is key to decide on the clippy job to run.
+      # The one from actions-rs prints nice annotations accross the pr, when browsing the changed files, right where the actual warning/error was found.
+      # It requires access to the GITHUB_TOKEN tho, a secret github automatically injects into every workflow run, but only for internally owned branches, not for forks.
+      # If that's the case, then we just run clippy with console output and that's it. One get's no annotations and has to check the actual job logs to see what went wrong.
 
       - name: Run clippy with console output (external contributors)
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,15 +209,6 @@ jobs:
       # The one from actions-rs prints nice annotations accross the pr, when browsing the changed files, right where the actual warning/error was found.
       # It requires access to the GITHUB_TOKEN tho, a secret github automatically injects into every workflow run, but only for internally owned branches, not for forks.
       # If that's the case, then we just run clippy with console output and that's it. One get's no annotations and has to check the actual job logs to see what went wrong.
-      - name: Check GITHUB_TOKEN accessibility
-        id: check_token
-        run: |
-          if [ -z "${{ secrets.GITHUB_TOKEN }}" ]; then
-            echo "GITHUB_TOKEN unavailable. If you are an external contributor, this is normal. If this is an internal PR, something is wrong."
-            echo "token_accessible=false" >> $GITHUB_ENV
-          else
-            echo "token_accessible=true" >> $GITHUB_ENV
-          fi
 
       - name: MinIO Cache (cargo + target)
         uses: tespkg/actions-cache@v1
@@ -233,11 +224,15 @@ jobs:
             target
 
       - name: Run clippy with console output (external contributors)
-        if: env.token_accessible == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: env.GITHUB_TOKEN == null
         run: cargo clippy --all-targets -- --deny warnings
 
       - name: Output clippy to Github
-        if: env.token_accessible == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: env.token_accessible != null
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,13 +226,13 @@ jobs:
       - name: Run clippy with console output (external contributors)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: env.GITHUB_TOKEN == null
+        if: env.GITHUB_TOKEN == ''
         run: cargo clippy --all-targets -- --deny warnings
 
       - name: Output clippy to Github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: env.GITHUB_TOKEN != null
+        if: env.GITHUB_TOKEN != ''
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,15 +224,11 @@ jobs:
       # If that's the case, then we just run clippy with console output and that's it. One get's no annotations and has to check the actual job logs to see what went wrong.
 
       - name: Run clippy with console output (external contributors)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: env.GITHUB_TOKEN == ''
+        if: github.secret_source != 'Actions'
         run: cargo clippy --all-targets -- --deny warnings
 
       - name: Output clippy to Github
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: env.GITHUB_TOKEN != ''
+        if: github.secret_source == 'Actions'
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Zaino
+
 Zaino is an indexer for the Zcash blockchain implemented in Rust.
 
 Zaino provides all necessary functionality for "light" clients (wallets and other applications that don't rely on the complete history of blockchain) and "full" clients / wallets and block explorers providing access to both the finalized chain and the non-finalized best chain and mempool held by either a Zebra or Zcashd full validator.


### PR DESCRIPTION
Since this comes from a fork, it should skip the rich annotations clippy step and run just the console output step.
It should fail as well, with 2 clippy anotations for unnecesary closures.