### PR TITLE
The Update infrastructure dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6777,20 +6777,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "zingo-infra-fetcher-core"
-version = "0.1.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?rev=cca5d0705111e1e7064a691724c8501560c84782#cca5d0705111e1e7064a691724c8501560c84782"
-dependencies = [
- "hex",
- "reqwest",
- "sha2 0.10.9",
- "tokio",
-]
-
-[[package]]
 name = "zingo-infra-services"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?rev=cca5d0705111e1e7064a691724c8501560c84782#cca5d0705111e1e7064a691724c8501560c84782"
+source = "git+https://github.com/zingolabs/infrastructure.git?branch=dev#c3678c1b14e0b7d28646039fe0204ebc1dab71b6"
 dependencies = [
  "getset",
  "hex",
@@ -6809,13 +6798,12 @@ dependencies = [
  "zebra-chain 1.0.0-beta.46 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.3.0)",
  "zebra-node-services 1.0.0-beta.46 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.3.0)",
  "zebra-rpc 1.0.0-beta.46 (git+https://github.com/ZcashFoundation/zebra.git?tag=v2.3.0)",
- "zingo-infra-fetcher-core",
 ]
 
 [[package]]
 name = "zingo-infra-testutils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?rev=cca5d0705111e1e7064a691724c8501560c84782#cca5d0705111e1e7064a691724c8501560c84782"
+source = "git+https://github.com/zingolabs/infrastructure.git?branch=dev#c3678c1b14e0b7d28646039fe0204ebc1dab71b6"
 dependencies = [
  "http",
  "portpicker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ zingolib = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0.0-bet
     "test-elevation",
 ] }
 testvectors = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0.0-beta2" }
-zingo-infra-testutils = { git = "https://github.com/zingolabs/infrastructure.git", rev = "cca5d0705111e1e7064a691724c8501560c84782" }
-zingo-infra-services = { git = "https://github.com/zingolabs/infrastructure.git", rev = "cca5d0705111e1e7064a691724c8501560c84782" }
+zingo-infra-testutils = { git = "https://github.com/zingolabs/infrastructure.git", branch = "dev" }
+zingo-infra-services = { git = "https://github.com/zingolabs/infrastructure.git", branch = "dev" }
 
 # Librustzcash
 zcash_client_backend = { version = "0.18.0", features = ["lightwalletd-tonic"] }

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -107,6 +107,15 @@ impl zingo_infra_services::validator::Validator for LocalNet {
 
     type Config = ValidatorConfig;
 
+    fn activation_heights(&self) -> zingo_infra_services::network::ActivationHeights {
+        // Return the activation heights for the network
+        // This depends on which validator is running (zcashd or zebrad)
+        match self {
+            LocalNet::Zcashd(net) => net.validator().activation_heights(),
+            LocalNet::Zebrad(net) => net.validator().activation_heights(),
+        }
+    }
+
     #[allow(clippy::manual_async_fn)]
     fn launch(
         config: Self::Config,


### PR DESCRIPTION
Builds on https://github.com/zingolabs/zaino/pull/449 .

Points to zingo-infra-testutils branch "dev" removing fetcher from the dependency tree!