### PR TITLE
fix toggle-hooks task

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -43,7 +43,7 @@ echo "  lint                       Run all lints (fmt, clippy, doc). Use as a pr
 echo "  fmt                        Check formatting (cargo fmt --all -- --check)"
 echo "  clippy                     Run Clippy with -D warnings (--all-targets --all-features)"
 echo "  doc                        Build docs (no deps, all features, document private items) with RUSTDOCFLAGS='-D warnings'"
-echo "  toogle-hooks               Toggle the git config for core.hooksPath to use .githooks/"
+echo "  toggle-hooks               Toggle the git config for core.hooksPath to use .githooks/"
 echo ""
 echo "Environment:"
 echo "  Defined by: .env.testing-artifacts"

--- a/makefiles/lints.toml
+++ b/makefiles/lints.toml
@@ -19,7 +19,9 @@ dependencies = ["fmt", "clippy", "doc"]
 description = "Toggles the git config for core.hooksPath"
 script = [
     '''
-    current_path=$(git config --local --get core.hooksPath)
+    set -euo pipefail
+
+    current_path=$(git config --local --get core.hooksPath || echo "unset")
     new_path=".githooks/"
     if [ "$current_path" = "$new_path" ]; then
         echo "Disabling custom hooks path"


### PR DESCRIPTION
**Fix failing toggle-hooks task**
- Added 'set -euo pipefail' to enhance script safety and error handling
- Changed default value of 'current_path' to 'unset' if not found for robustness
