### PR TITLE
fix tests in CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,7 +10,6 @@ fail-fast = false
 [profile.ci]
 default-filter = """
     not test(testnet)
-    & not test(regtest)
     & not test(client_rpcs)
 """
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
         env:
           TEST_BINARIES_DIR: ${{ github.workspace }}/test_binaries/bins
         run: |
-          cargo nextest run --verbose --profile ci --retries 2 --archive-file nextest-archive.tar.zst \
+          cargo nextest run --verbose --profile ci --retries 2 --no-tests warn --archive-file nextest-archive.tar.zst \
             --workspace-remap ./ --filterset "binary_id(${{ matrix.partition }})" ${{ env.NEXTEST-FLAGS }}
 
       - name: Test Summary


### PR DESCRIPTION
Reason for change: to allow regtest tests to run during CI for broader test coverage.
