### PR TITLE
test targets automation

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -35,6 +35,8 @@ echo "  compute-image-tag          Compute the tag for the Docker image based on
 echo "  get-docker-hash            Get DOCKER_DIR_HASH value (hash for the image defining files)"
 echo "  ensure-image-exists        Check if the required image exists locally, build if not"
 echo "  check-matching-zebras      Verify Zebra versions match between Cargo.toml and .env"
+echo "  validate-test-targets      Check if nextest targets match CI workflow matrix"
+echo "  update-test-targets        Update CI workflow matrix to match nextest targets"
 echo "  validate-makefile-tasks    Run minimal validation of all maker tasks"
 echo "  hello-rust                 Test rust-script functionality"
 echo ""
@@ -408,4 +410,161 @@ fn get_image_tag() -> Result<String, Box<dyn std::error::Error>> {
     println!("DEBUG: Computed tag: {}", tag);
     Ok(tag)
 }
+'''
+
+# -------------------------------------------------------------------
+
+[tasks.validate-test-targets]
+description = "Validate that nextest targets match CI workflow matrix"
+script_runner = "bash"
+extend = "base-script"
+script.main = '''
+set -euo pipefail
+
+UPDATE_MODE="${UPDATE_MODE:-false}"
+
+info "🔍 Validating test targets between nextest and CI workflow..."
+
+# Extract nextest targets with non-empty testcases
+info "Extracting targets from nextest..."
+NEXTEST_TARGETS=$(mktemp)
+cargo nextest list --profile ci -T json-pretty | jq -r '.["rust-suites"] | to_entries[] | select(.value.testcases | length > 0) | .key' | sort > "$NEXTEST_TARGETS"
+
+# Extract CI matrix partition values  
+info "Extracting targets from CI workflow..."
+CI_TARGETS=$(mktemp)
+yq '.jobs.test.strategy.matrix.partition[]' .github/workflows/ci.yml | sed 's/"//g' | sort > "$CI_TARGETS"
+
+# Compare the lists
+info "Comparing target lists..."
+
+MISSING_IN_CI=$(mktemp)
+EXTRA_IN_CI=$(mktemp)
+
+# Find targets in nextest but not in CI
+comm -23 "$NEXTEST_TARGETS" "$CI_TARGETS" > "$MISSING_IN_CI"
+
+# Find targets in CI but not in nextest (or with empty testcases)
+comm -13 "$NEXTEST_TARGETS" "$CI_TARGETS" > "$EXTRA_IN_CI"
+
+# Display results
+if [[ ! -s "$MISSING_IN_CI" && ! -s "$EXTRA_IN_CI" ]]; then
+    info "✅ All test targets are synchronized!"
+    echo "Nextest targets ($(wc -l < "$NEXTEST_TARGETS")):"
+    cat "$NEXTEST_TARGETS" | sed 's/^/  - /'
+else
+    warn "❌ Test target synchronization issues found:"
+    
+    if [[ -s "$MISSING_IN_CI" ]]; then
+        echo ""
+        warn "📋 Targets with tests missing from CI matrix ($(wc -l < "$MISSING_IN_CI")):"
+        cat "$MISSING_IN_CI" | sed 's/^/  - /'
+    fi
+    
+    if [[ -s "$EXTRA_IN_CI" ]]; then
+        echo ""
+        warn "🗑️  Targets in CI matrix with no tests ($(wc -l < "$EXTRA_IN_CI")):"
+        cat "$EXTRA_IN_CI" | sed 's/^/  - /'
+    fi
+    
+    if [[ "$UPDATE_MODE" == "true" ]]; then
+        info ""
+        info "🔧 Updating CI workflow matrix..."
+        
+        # Create new matrix from nextest targets
+        NEW_MATRIX=$(mktemp)
+        echo "          - \"$(head -1 "$NEXTEST_TARGETS")\"" > "$NEW_MATRIX"
+        tail -n +2 "$NEXTEST_TARGETS" | sed 's/^/          - "/' | sed 's/$/"/' >> "$NEW_MATRIX"
+        
+        # Update the CI workflow file
+        # Find the partition section and replace it
+        START_LINE=$(grep -n "partition:" .github/workflows/ci.yml | cut -d: -f1)
+        END_LINE=$(tail -n +$((START_LINE + 1)) .github/workflows/ci.yml | grep -n "^[[:space:]]*[^[:space:]-]" | head -1 | cut -d: -f1)
+        END_LINE=$((START_LINE + END_LINE - 1))
+        
+        # Create backup
+        cp .github/workflows/ci.yml .github/workflows/ci.yml.backup
+        
+        # Replace the partition section
+        {
+            head -n $START_LINE .github/workflows/ci.yml
+            cat "$NEW_MATRIX"
+            tail -n +$((END_LINE + 1)) .github/workflows/ci.yml
+        } > .github/workflows/ci.yml.tmp
+        
+        mv .github/workflows/ci.yml.tmp .github/workflows/ci.yml
+        
+        info "✅ CI workflow updated successfully!"
+        info "📄 Backup saved as .github/workflows/ci.yml.backup"
+        
+        # Show the changes
+        echo ""
+        info "Changes made:"
+        diff -u .github/workflows/ci.yml.backup .github/workflows/ci.yml || true
+        
+        rm "$NEW_MATRIX"
+    else
+        echo ""
+        info "💡 To automatically update the CI workflow, run:"
+        info "   makers update-test-targets"
+    fi
+    
+    # Cleanup temp files
+    rm "$MISSING_IN_CI" "$EXTRA_IN_CI"
+fi
+
+rm "$NEXTEST_TARGETS" "$CI_TARGETS"
+'''
+
+# -------------------------------------------------------------------
+
+[tasks.update-test-targets]
+description = "Update CI workflow matrix to match nextest targets"
+dependencies = ["validate-test-targets"]
+env = { UPDATE_MODE = "true" }
+script_runner = "bash"
+extend = "base-script"
+script.main = '''
+set -euo pipefail
+
+info "🔧 Updating CI workflow matrix to match nextest targets..."
+
+# Extract nextest targets with non-empty testcases
+info "Extracting targets from nextest..."
+NEXTEST_TARGETS=$(mktemp)
+cargo nextest list --profile ci -T json-pretty | jq -r '.["rust-suites"] | to_entries[] | select(.value.testcases | length > 0) | .key' | sort > "$NEXTEST_TARGETS"
+
+# Create new matrix from nextest targets
+NEW_MATRIX=$(mktemp)
+echo "          - \"$(head -1 "$NEXTEST_TARGETS")\"" > "$NEW_MATRIX"
+tail -n +2 "$NEXTEST_TARGETS" | sed 's/^/          - "/' | sed 's/$/"/' >> "$NEW_MATRIX"
+
+# Update the CI workflow file
+# Find the partition section and replace it
+START_LINE=$(grep -n "partition:" .github/workflows/ci.yml | cut -d: -f1)
+END_LINE=$(tail -n +$((START_LINE + 1)) .github/workflows/ci.yml | grep -n "^[[:space:]]*[^[:space:]-]" | head -1 | cut -d: -f1)
+END_LINE=$((START_LINE + END_LINE - 1))
+
+# Create backup
+cp .github/workflows/ci.yml .github/workflows/ci.yml.backup
+
+# Replace the partition section
+{
+    head -n $START_LINE .github/workflows/ci.yml
+    cat "$NEW_MATRIX"
+    tail -n +$((END_LINE + 1)) .github/workflows/ci.yml
+} > .github/workflows/ci.yml.tmp
+
+mv .github/workflows/ci.yml.tmp .github/workflows/ci.yml
+
+info "✅ CI workflow updated successfully!"
+info "📄 Backup saved as .github/workflows/ci.yml.backup"
+
+# Show the changes
+echo ""
+info "Changes made:"
+diff -u .github/workflows/ci.yml.backup .github/workflows/ci.yml || true
+
+# Cleanup temp files
+rm "$NEW_MATRIX" "$NEXTEST_TARGETS"
 '''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -421,8 +421,6 @@ extend = "base-script"
 script.main = '''
 set -euo pipefail
 
-UPDATE_MODE="${UPDATE_MODE:-false}"
-
 info "🔍 Validating test targets between nextest and CI workflow..."
 
 # Extract nextest targets with non-empty testcases
@@ -467,61 +465,19 @@ else
         cat "$EXTRA_IN_CI" | sed 's/^/  - /'
     fi
     
-    if [[ "$UPDATE_MODE" == "true" ]]; then
-        info ""
-        info "🔧 Updating CI workflow matrix..."
-        
-        # Create new matrix from nextest targets
-        NEW_MATRIX=$(mktemp)
-        echo "          - \"$(head -1 "$NEXTEST_TARGETS")\"" > "$NEW_MATRIX"
-        tail -n +2 "$NEXTEST_TARGETS" | sed 's/^/          - "/' | sed 's/$/"/' >> "$NEW_MATRIX"
-        
-        # Update the CI workflow file
-        # Find the partition section and replace it
-        START_LINE=$(grep -n "partition:" .github/workflows/ci.yml | cut -d: -f1)
-        END_LINE=$(tail -n +$((START_LINE + 1)) .github/workflows/ci.yml | grep -n "^[[:space:]]*[^[:space:]-]" | head -1 | cut -d: -f1)
-        END_LINE=$((START_LINE + END_LINE - 1))
-        
-        # Create backup
-        cp .github/workflows/ci.yml .github/workflows/ci.yml.backup
-        
-        # Replace the partition section
-        {
-            head -n $START_LINE .github/workflows/ci.yml
-            cat "$NEW_MATRIX"
-            tail -n +$((END_LINE + 1)) .github/workflows/ci.yml
-        } > .github/workflows/ci.yml.tmp
-        
-        mv .github/workflows/ci.yml.tmp .github/workflows/ci.yml
-        
-        info "✅ CI workflow updated successfully!"
-        info "📄 Backup saved as .github/workflows/ci.yml.backup"
-        
-        # Show the changes
-        echo ""
-        info "Changes made:"
-        diff -u .github/workflows/ci.yml.backup .github/workflows/ci.yml || true
-        
-        rm "$NEW_MATRIX"
-    else
-        echo ""
-        info "💡 To automatically update the CI workflow, run:"
-        info "   makers update-test-targets"
-    fi
-    
-    # Cleanup temp files
-    rm "$MISSING_IN_CI" "$EXTRA_IN_CI"
+    echo ""
+    info "💡 To automatically update the CI workflow, run:"
+    info "   makers update-test-targets"
 fi
 
-rm "$NEXTEST_TARGETS" "$CI_TARGETS"
+# Cleanup temp files
+rm "$NEXTEST_TARGETS" "$CI_TARGETS" "$MISSING_IN_CI" "$EXTRA_IN_CI"
 '''
 
 # -------------------------------------------------------------------
 
 [tasks.update-test-targets]
 description = "Update CI workflow matrix to match nextest targets"
-dependencies = ["validate-test-targets"]
-env = { UPDATE_MODE = "true" }
 script_runner = "bash"
 extend = "base-script"
 script.main = '''
@@ -530,41 +486,40 @@ set -euo pipefail
 info "🔧 Updating CI workflow matrix to match nextest targets..."
 
 # Extract nextest targets with non-empty testcases
-info "Extracting targets from nextest..."
+info "Extracting current nextest targets..."
 NEXTEST_TARGETS=$(mktemp)
 cargo nextest list --profile ci -T json-pretty | jq -r '.["rust-suites"] | to_entries[] | select(.value.testcases | length > 0) | .key' | sort > "$NEXTEST_TARGETS"
 
-# Create new matrix from nextest targets
-NEW_MATRIX=$(mktemp)
-echo "          - \"$(head -1 "$NEXTEST_TARGETS")\"" > "$NEW_MATRIX"
-tail -n +2 "$NEXTEST_TARGETS" | sed 's/^/          - "/' | sed 's/$/"/' >> "$NEW_MATRIX"
+echo "Found $(wc -l < "$NEXTEST_TARGETS") targets with tests:"
+cat "$NEXTEST_TARGETS" | sed 's/^/  - /'
 
-# Update the CI workflow file
-# Find the partition section and replace it
-START_LINE=$(grep -n "partition:" .github/workflows/ci.yml | cut -d: -f1)
-END_LINE=$(tail -n +$((START_LINE + 1)) .github/workflows/ci.yml | grep -n "^[[:space:]]*[^[:space:]-]" | head -1 | cut -d: -f1)
-END_LINE=$((START_LINE + END_LINE - 1))
+# Update only the partition array using sed to preserve formatting
+# First, create the new partition list in the exact format we need
+NEW_PARTITION_LINES=$(mktemp)
+while IFS= read -r target; do
+    echo "          - \"${target}\""
+done < "$NEXTEST_TARGETS" > "$NEW_PARTITION_LINES"
 
-# Create backup
-cp .github/workflows/ci.yml .github/workflows/ci.yml.backup
+# Use sed to replace just the partition array section
+# Find the partition: line and replace everything until the next non-indented item
+sed -i '/^[[:space:]]*partition:/,/^[[:space:]]*[^[:space:]-]/{
+    /^[[:space:]]*partition:/!{
+        /^[[:space:]]*[^[:space:]-]/!d
+    }
+}' .github/workflows/ci.yml
 
-# Replace the partition section
-{
-    head -n $START_LINE .github/workflows/ci.yml
-    cat "$NEW_MATRIX"
-    tail -n +$((END_LINE + 1)) .github/workflows/ci.yml
-} > .github/workflows/ci.yml.tmp
+# Now insert the new partition lines after the "partition:" line
+sed -i "/^[[:space:]]*partition:$/r $NEW_PARTITION_LINES" .github/workflows/ci.yml
 
-mv .github/workflows/ci.yml.tmp .github/workflows/ci.yml
+rm "$NEW_PARTITION_LINES"
 
 info "✅ CI workflow updated successfully!"
-info "📄 Backup saved as .github/workflows/ci.yml.backup"
 
-# Show the changes
+# Show what was changed using git diff
 echo ""
 info "Changes made:"
-diff -u .github/workflows/ci.yml.backup .github/workflows/ci.yml || true
+git diff --no-index /dev/null .github/workflows/ci.yml 2>/dev/null | grep "^[+-].*partition\|^[+-].*integration-tests\|^[+-].*zaino\|^[+-].*zainod" || git diff .github/workflows/ci.yml || echo "No changes detected"
 
 # Cleanup temp files
-rm "$NEW_MATRIX" "$NEXTEST_TARGETS"
+rm "$NEXTEST_TARGETS"
 '''


### PR DESCRIPTION
## Motivation

Up until now, CI would pick tests to run in partitions based on hard coded nextest filters (*).
This meant that new tests would be ignored in CI if they didn't fall under these categories AND the new category wasn't manually added to the list (these categories are esentially what is called a binary-id in `nextest list` context).

(*) See `.github/workflows/ci.yml` partition values:

```yaml
  test:
    name: Tests
    needs: [compute-tag, build-test-artifacts]
    runs-on: arc-sh-runners
    container:
      image: zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
    strategy:
      fail-fast: false
      matrix:
        partition:
          - "integration-tests::chain_cache"
          - "integration-tests::fetch_service"
          ...

```

## Solution

2 new `cargo-make` tasks:

- `validate-test-targets`      Check if nextest targets match CI workflow matrix
- `update-test-targets`        Update CI workflow matrix to match nextest targets

This tasks check for `binary-id`s with actual tests in them.

### Tests

I manually tested this


### Follow-up Work

None that I can think of except possible bug fixes. Maybe have some cronjob github action run this periodically or include it on some other tasks bundles.

### PR Checklist

- [ ] The PR name is suitable for the release notes.
- [X] The solution is tested.
- [X] The documentation is up to date.
