### PR TITLE
refactor(config): migrate from `figment` to `config-rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,6 +1132,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.15.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b30fa8254caad766fc03cb0ccae691e14bf3bd72bfff27f72802ce729551b3d6"
+dependencies = [
+ "pathdiff",
+ "serde_core",
+ "toml 0.9.8",
+ "winnow",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,10 +2023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
  "atomic 0.6.1",
- "parking_lot",
- "pear",
  "serde",
- "tempfile",
  "toml 0.8.23",
  "uncased",
  "version_check",
@@ -2882,12 +2891,6 @@ dependencies = [
  "serde",
  "serde_core",
 ]
-
-[[package]]
-name = "inlinable_string"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "inotify"
@@ -3965,6 +3968,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3972,29 +3981,6 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "password-hash",
-]
-
-[[package]]
-name = "pear"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
-dependencies = [
- "inlinable_string",
- "pear_codegen",
- "yansi",
-]
-
-[[package]]
-name = "pear_codegen"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
-dependencies = [
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -4315,19 +4301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
- "version_check",
- "yansi",
 ]
 
 [[package]]
@@ -5571,6 +5544,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6253,9 +6235,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+dependencies = [
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.3",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -6284,7 +6279,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.11.4",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow",
@@ -8363,12 +8358,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
 name = "yoke"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8557,9 +8546,10 @@ name = "zainod"
 version = "0.1.2"
 dependencies = [
  "clap",
- "figment",
+ "config",
  "http",
  "serde",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "toml 0.5.11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ zaino-common.path = "zaino-common"
 zaino-testutils = { path = "zaino-testutils" }
 zaino-testvectors = { path = "zaino-testvectors" }
 zainod = { path = "zainod" }
-figment = "0.10"
+config = { version = "0.15", default-features = false, features = ["toml"] }
 nonempty = "0.11.0"
 proptest = "~1.6"
 zip32 = "0.2.1"

--- a/zaino-common/src/config/storage.rs
+++ b/zaino-common/src/config/storage.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 /// Cache configuration for DashMaps.
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct CacheConfig {
     /// Capacity of the DashMaps used for caching
     pub capacity: usize,
@@ -69,6 +70,7 @@ impl DatabaseSize {
 /// Configures the file path and size limits for persistent storage
 /// used by Zaino services.
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct DatabaseConfig {
     /// Database file path.
     pub path: PathBuf,

--- a/zaino-common/src/config/validator.rs
+++ b/zaino-common/src/config/validator.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 /// Validator (full-node) type for Zaino configuration.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct ValidatorConfig {
     /// Full node / validator gprc listen port. Only exists for zebra
     pub validator_grpc_listen_address: Option<String>,
@@ -17,4 +18,17 @@ pub struct ValidatorConfig {
     pub validator_user: Option<String>,
     /// full node / validator Password.
     pub validator_password: Option<String>,
+}
+
+/// Required by `#[serde(default)]` to fill missing fields when deserializing partial TOML configs.
+impl Default for ValidatorConfig {
+    fn default() -> Self {
+        Self {
+            validator_grpc_listen_address: Some("127.0.0.1:18230".to_string()),
+            validator_jsonrpc_listen_address: "127.0.0.1:18232".to_string(),
+            validator_cookie_path: None,
+            validator_user: Some("xxxxxx".to_string()),
+            validator_password: Some("xxxxxx".to_string()),
+        }
+    }
 }

--- a/zaino-serve/src/server/config.rs
+++ b/zaino-serve/src/server/config.rs
@@ -19,6 +19,7 @@ pub struct GrpcTls {
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct GrpcServerConfig {
     /// gRPC server bind addr.
+    #[serde(alias = "grpc_listen_address")]
     pub listen_address: SocketAddr,
     /// Enables TLS.
     pub tls: Option<GrpcTls>,

--- a/zaino-state/src/config.rs
+++ b/zaino-state/src/config.rs
@@ -3,13 +3,14 @@
 use std::path::PathBuf;
 use zaino_common::{Network, ServiceConfig, StorageConfig};
 
-#[derive(Debug, Clone, serde::Deserialize, PartialEq, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 /// Type of backend to be used.
 pub enum BackendType {
     /// Uses ReadStateService (Zebrad)
     State,
     /// Uses JsonRPC client (Zcashd. Zainod)
+    #[default]
     Fetch,
 }
 

--- a/zainod/Cargo.toml
+++ b/zainod/Cargo.toml
@@ -49,4 +49,5 @@ thiserror = { workspace = true }
 
 # Formats
 toml = { workspace = true }
-figment= { workspace = true, features = ["toml", "env", "test"] }
+config = { workspace = true }
+tempfile = { workspace = true }

--- a/zainod/src/config.rs
+++ b/zainod/src/config.rs
@@ -1,58 +1,42 @@
 //! Zaino config.
-use figment::{
-    providers::{Format, Serialized, Toml},
-    Figment,
-};
+
 use std::{
     net::{IpAddr, SocketAddr},
     path::PathBuf,
 };
-// Added for Serde deserialization helpers
-use crate::error::IndexerError;
-use serde::{
-    de::{self, Deserializer},
-    Deserialize, Serialize,
-};
+
+use serde::{Deserialize, Serialize};
+use tracing::info;
 #[cfg(feature = "no_tls_use_unencrypted_traffic")]
 use tracing::warn;
-use tracing::{error, info};
+
+use crate::error::IndexerError;
 use zaino_common::{
     try_resolve_address, AddressResolution, CacheConfig, DatabaseConfig, DatabaseSize, Network,
     ServiceConfig, StorageConfig, ValidatorConfig,
 };
 use zaino_serve::server::config::{GrpcServerConfig, JsonRpcServerConfig};
-
 #[allow(deprecated)]
-use zaino_state::{BackendConfig, FetchServiceConfig, StateServiceConfig};
+use zaino_state::{BackendType, FetchServiceConfig, StateServiceConfig};
 
-/// Custom deserialization function for `BackendType` from a String.
-/// Used by Serde's `deserialize_with`.
-fn deserialize_backendtype_from_string<'de, D>(
-    deserializer: D,
-) -> Result<zaino_state::BackendType, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    match s.to_lowercase().as_str() {
-        "state" => Ok(zaino_state::BackendType::State),
-        "fetch" => Ok(zaino_state::BackendType::Fetch),
-        _ => Err(de::Error::custom(format!(
-            "Invalid backend type '{s}', valid options are 'state' or 'fetch'"
-        ))),
-    }
+/// Sensitive key suffixes that should not be set via environment variables.
+const SENSITIVE_KEY_SUFFIXES: [&str; 5] = ["password", "secret", "token", "cookie", "private_key"];
+
+/// Checks if a key is sensitive and should not be set via environment variables.
+fn is_sensitive_leaf_key(leaf_key: &str) -> bool {
+    let key = leaf_key.to_ascii_lowercase();
+    SENSITIVE_KEY_SUFFIXES
+        .iter()
+        .any(|suffix| key.ends_with(suffix))
 }
 
 /// Config information required for Zaino.
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(deny_unknown_fields, default)]
 pub struct ZainodConfig {
     /// Type of backend to be used.
-    #[serde(deserialize_with = "deserialize_backendtype_from_string")]
-    #[serde(serialize_with = "serialize_backendtype_to_string")]
-    pub backend: zaino_state::BackendType,
+    pub backend: BackendType,
     /// Enable JsonRPC server with a valid Some value.
-    #[serde(default)]
     pub json_server_settings: Option<JsonRpcServerConfig>,
     /// gRPC server settings including listen addr, tls status, key and cert.
     pub grpc_settings: GrpcServerConfig,
@@ -62,9 +46,7 @@ pub struct ZainodConfig {
     pub service: ServiceConfig,
     /// Storage configuration (cache and database).
     pub storage: StorageConfig,
-    /// Block Cache database file path.
-    ///
-    /// ZebraDB location.
+    /// Block Cache database file path (ZebraDB location).
     pub zebra_db_path: PathBuf,
     /// Network chain type.
     pub network: Network,
@@ -73,33 +55,21 @@ pub struct ZainodConfig {
 impl ZainodConfig {
     /// Performs checks on config data.
     pub(crate) fn check_config(&self) -> Result<(), IndexerError> {
-        // Network type is validated at the type level via Network enum.
         // Check TLS settings.
         if self.grpc_settings.tls.is_some() {
-            // then check if cert path exists or return error
-            let c_path = &self
-                .grpc_settings
-                .tls
-                .as_ref()
-                .expect("to be Some")
-                .cert_path;
-            if !std::path::Path::new(&c_path).exists() {
+            let tls = self.grpc_settings.tls.as_ref().expect("to be Some");
+
+            if !std::path::Path::new(&tls.cert_path).exists() {
                 return Err(IndexerError::ConfigError(format!(
                     "TLS is enabled, but certificate path {:?} does not exist.",
-                    c_path
+                    tls.cert_path
                 )));
             }
 
-            let k_path = &self
-                .grpc_settings
-                .tls
-                .as_ref()
-                .expect("to be Some")
-                .key_path;
-            if !std::path::Path::new(&k_path).exists() {
+            if !std::path::Path::new(&tls.key_path).exists() {
                 return Err(IndexerError::ConfigError(format!(
                     "TLS is enabled, but key path {:?} does not exist.",
-                    k_path
+                    tls.key_path
                 )));
             }
         }
@@ -107,9 +77,10 @@ impl ZainodConfig {
         // Check validator cookie authentication settings
         if let Some(ref cookie_path) = self.validator_settings.validator_cookie_path {
             if !std::path::Path::new(cookie_path).exists() {
-                return Err(IndexerError::ConfigError(
-                        format!("Validator cookie authentication is enabled, but cookie path '{:?}' does not exist.", cookie_path),
-                    ));
+                return Err(IndexerError::ConfigError(format!(
+                    "Validator cookie authentication is enabled, but cookie path '{:?}' does not exist.",
+                    cookie_path
+                )));
             }
         }
 
@@ -167,17 +138,13 @@ impl ZainodConfig {
         }
 
         // Check gRPC and JsonRPC server are not listening on the same address.
-        if self.json_server_settings.is_some()
-            && self
-                .json_server_settings
-                .as_ref()
-                .expect("json_server_settings to be Some")
-                .json_rpc_listen_address
-                == self.grpc_settings.listen_address
-        {
-            return Err(IndexerError::ConfigError(
-                "gRPC server and JsonRPC server must listen on different addresses.".to_string(),
-            ));
+        if let Some(ref json_settings) = self.json_server_settings {
+            if json_settings.json_rpc_listen_address == self.grpc_settings.listen_address {
+                return Err(IndexerError::ConfigError(
+                    "gRPC server and JsonRPC server must listen on different addresses."
+                        .to_string(),
+                ));
+            }
         }
 
         Ok(())
@@ -192,7 +159,7 @@ impl ZainodConfig {
 impl Default for ZainodConfig {
     fn default() -> Self {
         Self {
-            backend: zaino_state::BackendType::Fetch,
+            backend: BackendType::default(),
             json_server_settings: None,
             grpc_settings: GrpcServerConfig {
                 listen_address: "127.0.0.1:8137".parse().unwrap(),
@@ -254,9 +221,7 @@ fn fetch_socket_addr_from_hostname(address: &str) -> Result<SocketAddr, IndexerE
 
 /// Validates that the configured `address` is either:
 /// - An RFC1918 (private) IPv4 address, or
-/// - An IPv6 Unique Local Address (ULA) (using `is_unique_local()`)
-///
-/// Returns `Ok(BindAddress)` if valid.
+/// - An IPv6 Unique Local Address (ULA)
 pub(crate) fn is_private_listen_addr(addr: &SocketAddr) -> bool {
     let ip = addr.ip();
     match ip {
@@ -265,76 +230,84 @@ pub(crate) fn is_private_listen_addr(addr: &SocketAddr) -> bool {
     }
 }
 
-/// Attempts to load config data from a TOML file at the specified path.
+/// Loads configuration from a TOML file with optional environment variable overrides.
 ///
-/// If the file cannot be read, or if its contents cannot be parsed into `ZainodConfig`,
-/// a warning is logged, and a default configuration is returned.
-/// Finally, there is an override of the config using environmental variables.
-/// The loaded or default configuration undergoes further checks and finalization.
-pub fn load_config(file_path: &PathBuf) -> Result<ZainodConfig, IndexerError> {
-    // Configuration sources are layered: Env > TOML > Defaults.
-    let figment = Figment::new()
-        // 1. Base defaults from `ZainodConfig::default()`.
-        .merge(Serialized::defaults(ZainodConfig::default()))
-        // 2. Override with values from the TOML configuration file.
-        .merge(Toml::file(file_path))
-        // 3. Override with values from environment variables prefixed with "ZAINO_".
-        .merge(figment::providers::Env::prefixed("ZAINO_").split("__"));
-
-    match figment.extract::<ZainodConfig>() {
-        Ok(mut parsed_config) => {
-            if parsed_config
-                .json_server_settings
-                .clone()
-                .is_some_and(|json_settings| {
-                    json_settings.cookie_dir.is_some()
-                        && json_settings
-                            .cookie_dir
-                            .expect("cookie_dir to be Some")
-                            .as_os_str()
-                            // if the assigned pathbuf is empty (cookies enabled but no path defined).
-                            .is_empty()
-                })
-            {
-                if let Some(ref mut json_config) = parsed_config.json_server_settings {
-                    json_config.cookie_dir = Some(default_ephemeral_cookie_path());
-                }
-            };
-
-            parsed_config.check_config()?;
-            info!(
-                "Successfully loaded and validated config. Base TOML file checked: '{}'",
-                file_path.display()
-            );
-            Ok(parsed_config)
-        }
-        Err(figment_error) => {
-            error!(
-                "Failed to extract configuration using figment: {}",
-                figment_error
-            );
-            Err(IndexerError::ConfigError(format!(
-                "Zaino configuration loading failed during figment extract '{}' (could be TOML file or environment variables). Details: {}",
-                file_path.display(), figment_error
-            )))
-        }
-    }
+/// Configuration is layered: Defaults → TOML file → Environment variables (prefix: ZAINO_).
+/// Sensitive keys (password, secret, token, cookie, private_key) are blocked from env vars.
+pub fn load_config(file_path: &std::path::Path) -> Result<ZainodConfig, IndexerError> {
+    load_config_with_env(file_path, "ZAINO")
 }
 
-impl TryFrom<ZainodConfig> for BackendConfig {
-    type Error = IndexerError;
-
-    #[allow(deprecated)]
-    fn try_from(cfg: ZainodConfig) -> Result<Self, Self::Error> {
-        match cfg.backend {
-            zaino_state::BackendType::State => {
-                Ok(BackendConfig::State(StateServiceConfig::try_from(cfg)?))
-            }
-            zaino_state::BackendType::Fetch => {
-                Ok(BackendConfig::Fetch(FetchServiceConfig::try_from(cfg)?))
+/// Loads configuration with a custom environment variable prefix.
+pub fn load_config_with_env(
+    file_path: &std::path::Path,
+    env_prefix: &str,
+) -> Result<ZainodConfig, IndexerError> {
+    // Check for sensitive keys in environment variables before loading
+    let required_prefix = format!("{}_", env_prefix);
+    for (key, _) in std::env::vars() {
+        if let Some(without_prefix) = key.strip_prefix(&required_prefix) {
+            if let Some(leaf) = without_prefix.split("__").last() {
+                if is_sensitive_leaf_key(leaf) {
+                    return Err(IndexerError::ConfigError(format!(
+                        "Environment variable '{}' contains sensitive key '{}' - use config file instead",
+                        key, leaf
+                    )));
+                }
             }
         }
     }
+
+    let mut builder = config::Config::builder()
+        .set_default("backend", "fetch")
+        .map_err(|e| IndexerError::ConfigError(e.to_string()))?;
+
+    // Add TOML file source
+    builder = builder.add_source(
+        config::File::from(file_path)
+            .format(config::FileFormat::Toml)
+            .required(true),
+    );
+
+    // Add environment variable source with ZAINO_ prefix and __ separator for nesting
+    // Note: config-rs lowercases all env var keys after stripping the prefix
+    builder = builder.add_source(
+        config::Environment::with_prefix(env_prefix)
+            .prefix_separator("_")
+            .separator("__")
+            .try_parsing(true),
+    );
+
+    let settings = builder
+        .build()
+        .map_err(|e| IndexerError::ConfigError(format!("Configuration loading failed: {}", e)))?;
+
+    let mut parsed_config: ZainodConfig = settings
+        .try_deserialize()
+        .map_err(|e| IndexerError::ConfigError(format!("Configuration parsing failed: {}", e)))?;
+
+    // Handle empty cookie_dir: if json_server_settings exists with empty cookie_dir, set default
+    if parsed_config
+        .json_server_settings
+        .as_ref()
+        .is_some_and(|json_settings| {
+            json_settings
+                .cookie_dir
+                .as_ref()
+                .is_some_and(|dir| dir.as_os_str().is_empty())
+        })
+    {
+        if let Some(ref mut json_config) = parsed_config.json_server_settings {
+            json_config.cookie_dir = Some(default_ephemeral_cookie_path());
+        }
+    }
+
+    parsed_config.check_config()?;
+    info!(
+        "Successfully loaded and validated config. Base TOML file checked: '{}'",
+        file_path.display()
+    );
+    Ok(parsed_config)
 }
 
 #[allow(deprecated)]
@@ -351,6 +324,7 @@ impl TryFrom<ZainodConfig> for StateServiceConfig {
                     "Missing validator_grpc_listen_address in configuration".to_string(),
                 )
             })?;
+
         let validator_grpc_address =
             fetch_socket_addr_from_hostname(grpc_listen_address).map_err(|e| {
                 let msg = match e {
@@ -416,656 +390,582 @@ impl TryFrom<ZainodConfig> for FetchServiceConfig {
     }
 }
 
-/// Custom serializer for BackendType
-fn serialize_backendtype_to_string<S>(
-    backend_type: &zaino_state::BackendType,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    serializer.serialize_str(match backend_type {
-        zaino_state::BackendType::State => "state",
-        zaino_state::BackendType::Fetch => "fetch",
-    })
-}
 #[cfg(test)]
-mod test {
-    use crate::error::IndexerError;
+mod tests {
+    use super::*;
+    use std::{env, sync::Mutex};
+    use tempfile::TempDir;
 
-    use super::ZainodConfig;
+    const ZAINO_ENV_PREFIX: &str = "ZAINO_";
+    static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
-    use super::load_config;
+    /// RAII guard for managing environment variables in tests.
+    /// Ensures test isolation by clearing ZAINO_* vars before tests
+    /// and restoring original values after.
+    struct EnvGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        original_vars: Vec<(String, String)>,
+    }
 
-    use figment::Jail;
+    impl EnvGuard {
+        fn new() -> Self {
+            let guard = TEST_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+            let original_vars: Vec<_> = env::vars()
+                .filter(|(k, _)| k.starts_with(ZAINO_ENV_PREFIX))
+                .collect();
+            // Clear all ZAINO_* vars for test isolation
+            for (key, _) in &original_vars {
+                env::remove_var(key);
+            }
+            Self {
+                _guard: guard,
+                original_vars,
+            }
+        }
 
-    use std::path::PathBuf;
+        fn set_var(&self, key: &str, value: &str) {
+            env::set_var(key, value);
+        }
+    }
 
-    use zaino_common::{DatabaseSize, Network};
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // Clear test vars
+            for (k, _) in env::vars().filter(|(k, _)| k.starts_with(ZAINO_ENV_PREFIX)) {
+                env::remove_var(&k);
+            }
+            // Restore originals
+            for (k, v) in &self.original_vars {
+                env::set_var(k, v);
+            }
+        }
+    }
 
-    // Use the explicit library name `zainodlib` as defined in Cargo.toml [lib] name.
-
-    // If BackendType is used directly in assertions beyond what IndexerConfig holds:
-    use zaino_state::BackendType as ZainoBackendType;
+    fn create_test_config_file(dir: &TempDir, content: &str, filename: &str) -> PathBuf {
+        let path = dir.path().join(filename);
+        std::fs::write(&path, content).unwrap();
+        path
+    }
 
     #[test]
-    // Validates loading a valid configuration via `load_config`,
-    // ensuring fields are parsed and `check_config` passes with mocked prerequisite files.
-    pub(crate) fn test_deserialize_full_valid_config() {
-        Jail::expect_with(|jail| {
-            // Define RELATIVE paths/filenames for use within the jail
-            let cert_file_name = "test_cert.pem";
-            let key_file_name = "test_key.pem";
-            let validator_cookie_file_name = "validator.cookie";
-            let zaino_cookie_dir_name = "zaino_cookies_dir";
-            let zaino_db_dir_name = "zaino_db_dir";
-            let zebra_db_dir_name = "zebra_db_dir";
+    fn test_deserialize_full_valid_config() {
+        let _guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
 
-            // Create the directories within the jail FIRST
-            jail.create_dir(zaino_cookie_dir_name)?;
-            jail.create_dir(zaino_db_dir_name)?;
-            jail.create_dir(zebra_db_dir_name)?;
+        // Create mock files
+        let cert_file = temp_dir.path().join("test_cert.pem");
+        let key_file = temp_dir.path().join("test_key.pem");
+        let validator_cookie_file = temp_dir.path().join("validator.cookie");
+        let zaino_cookie_dir = temp_dir.path().join("zaino_cookies_dir");
+        let zaino_db_dir = temp_dir.path().join("zaino_db_dir");
+        let zebra_db_dir = temp_dir.path().join("zebra_db_dir");
 
-            // Use relative paths in the TOML string
-            let toml_str = format!(
-                r#"
-            backend = "fetch"
-            storage.database.path = "{zaino_db_dir_name}"
-            zebra_db_path = "{zebra_db_dir_name}"
-            db_size = 100
-            network = "Mainnet"
-            no_db = false
-            slow_sync = false
+        std::fs::write(&cert_file, "mock cert content").unwrap();
+        std::fs::write(&key_file, "mock key content").unwrap();
+        std::fs::write(&validator_cookie_file, "mock validator cookie content").unwrap();
+        std::fs::create_dir_all(&zaino_cookie_dir).unwrap();
+        std::fs::create_dir_all(&zaino_db_dir).unwrap();
+        std::fs::create_dir_all(&zebra_db_dir).unwrap();
 
-            [validator_settings]
-            validator_jsonrpc_listen_address = "192.168.1.10:18232"
-            validator_cookie_path = "{validator_cookie_file_name}"
-            validator_user = "user"
-            validator_password = "password"
+        let toml_content = format!(
+            r#"
+backend = "fetch"
+zebra_db_path = "{}"
+network = "Mainnet"
 
-            [json_server_settings]
-            json_rpc_listen_address = "127.0.0.1:8000"
-            cookie_dir = "{zaino_cookie_dir_name}"
+[storage.database]
+path = "{}"
 
-            [grpc_settings]
-            listen_address = "0.0.0.0:9000"
+[validator_settings]
+validator_jsonrpc_listen_address = "192.168.1.10:18232"
+validator_cookie_path = "{}"
+validator_user = "user"
+validator_password = "password"
 
-            [grpc_settings.tls]
-            cert_path = "{cert_file_name}"
-            key_path = "{key_file_name}"
-        "#
-            );
+[json_server_settings]
+json_rpc_listen_address = "127.0.0.1:8000"
+cookie_dir = "{}"
 
-            let temp_toml_path = jail.directory().join("full_config.toml");
-            jail.create_file(&temp_toml_path, &toml_str)?;
+[grpc_settings]
+listen_address = "0.0.0.0:9000"
 
-            // Create the actual mock files within the jail using the relative names
-            jail.create_file(cert_file_name, "mock cert content")?;
-            jail.create_file(key_file_name, "mock key content")?;
-            jail.create_file(validator_cookie_file_name, "mock validator cookie content")?;
+[grpc_settings.tls]
+cert_path = "{}"
+key_path = "{}"
+"#,
+            zebra_db_dir.display(),
+            zaino_db_dir.display(),
+            validator_cookie_file.display(),
+            zaino_cookie_dir.display(),
+            cert_file.display(),
+            key_file.display(),
+        );
 
-            let config_result = load_config(&temp_toml_path);
+        let config_path = create_test_config_file(&temp_dir, &toml_content, "full_config.toml");
+        let config = load_config(&config_path).expect("load_config failed");
+
+        assert_eq!(config.backend, BackendType::Fetch);
+        assert!(config.json_server_settings.is_some());
+        assert_eq!(
+            config
+                .json_server_settings
+                .as_ref()
+                .unwrap()
+                .json_rpc_listen_address,
+            "127.0.0.1:8000".parse().unwrap()
+        );
+        assert_eq!(config.network, Network::Mainnet);
+        assert_eq!(
+            config.grpc_settings.listen_address,
+            "0.0.0.0:9000".parse().unwrap()
+        );
+        assert!(config.grpc_settings.tls.is_some());
+        assert_eq!(
+            config.validator_settings.validator_user,
+            Some("user".to_string())
+        );
+        assert_eq!(
+            config.validator_settings.validator_password,
+            Some("password".to_string())
+        );
+    }
+
+    #[test]
+    fn test_deserialize_optional_fields_missing() {
+        let _guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
+
+        let toml_content = r#"
+backend = "state"
+network = "Testnet"
+zebra_db_path = "/opt/zebra/data"
+
+[storage.database]
+path = "/opt/zaino/data"
+
+[validator_settings]
+validator_jsonrpc_listen_address = "127.0.0.1:18232"
+
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
+
+        let config_path = create_test_config_file(&temp_dir, toml_content, "optional_missing.toml");
+        let config = load_config(&config_path).expect("load_config failed");
+        let default_values = ZainodConfig::default();
+
+        assert_eq!(config.backend, BackendType::State);
+        assert!(config.json_server_settings.is_none());
+        assert_eq!(
+            config.validator_settings.validator_user,
+            default_values.validator_settings.validator_user
+        );
+        assert_eq!(
+            config.storage.cache.capacity,
+            default_values.storage.cache.capacity
+        );
+    }
+
+    #[test]
+    fn test_cookie_dir_logic() {
+        let _guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
+
+        // Scenario 1: auth enabled, cookie_dir empty (should use default ephemeral path)
+        let toml_content = r#"
+backend = "fetch"
+network = "Testnet"
+zebra_db_path = "/zebra/db"
+
+[storage.database]
+path = "/zaino/db"
+
+[json_server_settings]
+json_rpc_listen_address = "127.0.0.1:8237"
+cookie_dir = ""
+
+[validator_settings]
+validator_jsonrpc_listen_address = "127.0.0.1:18232"
+
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
+
+        let config_path = create_test_config_file(&temp_dir, toml_content, "s1.toml");
+        let config = load_config(&config_path).expect("Config S1 failed");
+        assert!(config.json_server_settings.is_some());
+        assert!(config
+            .json_server_settings
+            .as_ref()
+            .unwrap()
+            .cookie_dir
+            .is_some());
+
+        // Scenario 2: auth enabled, cookie_dir specified
+        let toml_content2 = r#"
+backend = "fetch"
+network = "Testnet"
+zebra_db_path = "/zebra/db"
+
+[storage.database]
+path = "/zaino/db"
+
+[json_server_settings]
+json_rpc_listen_address = "127.0.0.1:8237"
+cookie_dir = "/my/cookie/path"
+
+[validator_settings]
+validator_jsonrpc_listen_address = "127.0.0.1:18232"
+
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
+
+        let config_path2 = create_test_config_file(&temp_dir, toml_content2, "s2.toml");
+        let config2 = load_config(&config_path2).expect("Config S2 failed");
+        assert_eq!(
+            config2.json_server_settings.as_ref().unwrap().cookie_dir,
+            Some(PathBuf::from("/my/cookie/path"))
+        );
+
+        // Scenario 3: cookie_dir not specified (should be None)
+        let toml_content3 = r#"
+backend = "fetch"
+network = "Testnet"
+zebra_db_path = "/zebra/db"
+
+[storage.database]
+path = "/zaino/db"
+
+[json_server_settings]
+json_rpc_listen_address = "127.0.0.1:8237"
+
+[validator_settings]
+validator_jsonrpc_listen_address = "127.0.0.1:18232"
+
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
+
+        let config_path3 = create_test_config_file(&temp_dir, toml_content3, "s3.toml");
+        let config3 = load_config(&config_path3).expect("Config S3 failed");
+        assert!(config3.json_server_settings.unwrap().cookie_dir.is_none());
+    }
+
+    #[test]
+    fn test_deserialize_empty_string_yields_default() {
+        let _guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
+
+        // Minimal valid config
+        let toml_content = r#"
+[validator_settings]
+validator_jsonrpc_listen_address = "127.0.0.1:18232"
+
+[storage.database]
+path = "/zaino/db"
+
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
+
+        let config_path = create_test_config_file(&temp_dir, toml_content, "empty.toml");
+        let config = load_config(&config_path).expect("Empty TOML load failed");
+        let default_config = ZainodConfig::default();
+
+        assert_eq!(config.network, default_config.network);
+        assert_eq!(config.backend, default_config.backend);
+        assert_eq!(
+            config.storage.cache.capacity,
+            default_config.storage.cache.capacity
+        );
+    }
+
+    #[test]
+    fn test_deserialize_invalid_backend_type() {
+        let _guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
+
+        let toml_content = r#"
+backend = "invalid_type"
+
+[validator_settings]
+validator_jsonrpc_listen_address = "127.0.0.1:18232"
+
+[storage.database]
+path = "/zaino/db"
+
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
+
+        let config_path = create_test_config_file(&temp_dir, toml_content, "invalid_backend.toml");
+        let result = load_config(&config_path);
+        assert!(result.is_err());
+        if let Err(IndexerError::ConfigError(msg)) = result {
             assert!(
-                config_result.is_ok(),
-                "load_config failed: {:?}",
-                config_result.err()
+                msg.contains("unknown variant") || msg.contains("invalid_type"),
+                "Unexpected error message: {}",
+                msg
             );
-            let finalized_config = config_result.unwrap();
-
-            assert_eq!(finalized_config.backend, ZainoBackendType::Fetch);
-            assert!(finalized_config.json_server_settings.is_some());
-            assert_eq!(
-                finalized_config
-                    .json_server_settings
-                    .as_ref()
-                    .expect("json settings to be Some")
-                    .json_rpc_listen_address,
-                "127.0.0.1:8000".parse().unwrap()
-            );
-            assert_eq!(
-                finalized_config
-                    .json_server_settings
-                    .as_ref()
-                    .expect("json settings to be Some")
-                    .cookie_dir,
-                Some(PathBuf::from(zaino_cookie_dir_name))
-            );
-            assert_eq!(
-                finalized_config
-                    .clone()
-                    .grpc_settings
-                    .tls
-                    .expect("tls to be Some in finalized conifg")
-                    .cert_path,
-                PathBuf::from(cert_file_name)
-            );
-            assert_eq!(
-                finalized_config
-                    .clone()
-                    .grpc_settings
-                    .tls
-                    .expect("tls to be Some in finalized_conifg")
-                    .key_path,
-                PathBuf::from(key_file_name)
-            );
-            assert_eq!(
-                finalized_config.validator_settings.validator_cookie_path,
-                Some(PathBuf::from(validator_cookie_file_name))
-            );
-            assert_eq!(
-                finalized_config.storage.database.path,
-                PathBuf::from(zaino_db_dir_name)
-            );
-            assert_eq!(
-                finalized_config.zebra_db_path,
-                PathBuf::from(zebra_db_dir_name)
-            );
-            assert_eq!(finalized_config.network, Network::Mainnet);
-            assert_eq!(
-                finalized_config.grpc_settings.listen_address,
-                "0.0.0.0:9000".parse().unwrap()
-            );
-            assert!(finalized_config.grpc_settings.tls.is_some());
-            assert_eq!(
-                finalized_config.validator_settings.validator_user,
-                Some("user".to_string())
-            );
-            assert_eq!(
-                finalized_config.validator_settings.validator_password,
-                Some("password".to_string())
-            );
-            assert_eq!(finalized_config.storage.cache.capacity, 10000);
-            assert_eq!(finalized_config.storage.cache.shard_count(), 16);
-            assert_eq!(
-                finalized_config.storage.database.size.to_byte_count(),
-                128 * 1024 * 1024 * 1024
-            );
-            assert!(match finalized_config.storage.database.size {
-                DatabaseSize::Gb(0) => false,
-                DatabaseSize::Gb(_) => true,
-            });
-
-            Ok(())
-        });
+        }
     }
 
     #[test]
-    // Verifies that when optional fields are omitted from TOML, `load_config` ensures they correctly adopt default values.
-    pub(crate) fn test_deserialize_optional_fields_missing() {
-        Jail::expect_with(|jail| {
-            let toml_str = r#"
-            backend = "state"
-            json_rpc_listen_address = "127.0.0.1:8237"
-            grpc_listen_address = "127.0.0.1:8137"
-            validator_listen_address = "127.0.0.1:18232"
-            zaino_db_path = "/opt/zaino/data"
-            zebra_db_path = "/opt/zebra/data"
-            network = "Testnet"
-        "#;
-            let temp_toml_path = jail.directory().join("optional_missing.toml");
-            jail.create_file(&temp_toml_path, toml_str)?;
+    fn test_deserialize_invalid_socket_address() {
+        let _guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
 
-            let config = load_config(&temp_toml_path).expect("load_config failed");
-            let default_values = ZainodConfig::default();
+        let toml_content = r#"
+[json_server_settings]
+json_rpc_listen_address = "not-a-valid-address"
+cookie_dir = ""
 
-            assert_eq!(config.backend, ZainoBackendType::State);
-            assert_eq!(
-                config.json_server_settings.is_some(),
-                default_values.json_server_settings.is_some()
-            );
-            assert_eq!(
-                config.validator_settings.validator_user,
-                default_values.validator_settings.validator_user
-            );
-            assert_eq!(
-                config.validator_settings.validator_password,
-                default_values.validator_settings.validator_password
-            );
-            assert_eq!(
-                config.storage.cache.capacity,
-                default_values.storage.cache.capacity
-            );
-            assert_eq!(
-                config.storage.cache.shard_count(),
-                default_values.storage.cache.shard_count(),
-            );
-            assert_eq!(
-                config.storage.database.size,
-                default_values.storage.database.size
-            );
-            assert_eq!(
-                config.storage.database.size.to_byte_count(),
-                default_values.storage.database.size.to_byte_count()
-            );
-            Ok(())
-        });
+[validator_settings]
+validator_jsonrpc_listen_address = "127.0.0.1:18232"
+
+[storage.database]
+path = "/zaino/db"
+
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
+
+        let config_path = create_test_config_file(&temp_dir, toml_content, "invalid_socket.toml");
+        let result = load_config(&config_path);
+        assert!(result.is_err());
     }
 
     #[test]
-    // Tests the logic (via `load_config` and its internal call to `finalize_config_logic`)
-    // for setting `cookie_dir` based on `enable_cookie_auth`.
-    pub(crate) fn test_cookie_dir_logic() {
-        Jail::expect_with(|jail| {
-            // Scenario 1: auth enabled, cookie_dir missing (should use default ephemeral path)
-            let s1_path = jail.directory().join("s1.toml");
-            jail.create_file(
-                &s1_path,
-                r#"
-            backend = "fetch"
-
-            [json_server_settings]
-            json_rpc_listen_address = "127.0.0.1:8237"
-            cookie_dir = ""
-
-            grpc_listen_address = "127.0.0.1:8137"
-            validator_listen_address = "127.0.0.1:18232"
-            zaino_db_path = "/zaino/db"
-            zebra_db_path = "/zebra/db"
-            network = "Testnet"
-        "#,
-            )?;
-
-            let config1 = load_config(&s1_path).expect("Config S1 failed");
-            assert!(config1.json_server_settings.is_some());
-            assert!(config1
-                .json_server_settings
-                .as_ref()
-                .expect("json settings is Some")
-                .cookie_dir
-                .is_some());
-
-            // Scenario 2: auth enabled, cookie_dir specified
-            let s2_path = jail.directory().join("s2.toml");
-            jail.create_file(
-                &s2_path,
-                r#"
-            backend = "fetch"
-
-            [json_server_settings]
-            json_rpc_listen_address = "127.0.0.1:8237"
-            cookie_dir = "/my/cookie/path"
-
-            grpc_listen_address = "127.0.0.1:8137"
-            validator_listen_address = "127.0.0.1:18232"
-            zaino_db_path = "/zaino/db"
-            zebra_db_path = "/zebra/db"
-            network = "Testnet"
-        "#,
-            )?;
-            let config2 = load_config(&s2_path).expect("Config S2 failed");
-            assert!(config2.json_server_settings.is_some());
-            assert_eq!(
-                config2
-                    .json_server_settings
-                    .as_ref()
-                    .expect("json settings to be Some")
-                    .cookie_dir,
-                Some(PathBuf::from("/my/cookie/path"))
-            );
-            let s3_path = jail.directory().join("s3.toml");
-            jail.create_file(
-                &s3_path,
-                r#"
-            backend = "fetch"
-
-            [json_server_settings]
-            json_rpc_listen_address = "127.0.0.1:8237"
-
-            grpc_listen_address = "127.0.0.1:8137"
-            validator_listen_address = "127.0.0.1:18232"
-            zaino_db_path = "/zaino/db"
-            zebra_db_path = "/zebra/db"
-            network = "Testnet"
-        "#,
-            )?;
-            let config3 = load_config(&s3_path).expect("Config S3 failed");
-            assert!(config3
-                .json_server_settings
-                .expect("json server settings to unwrap in config S3")
-                .cookie_dir
-                .is_none());
-            Ok(())
-        });
-    }
-
-    #[test]
-    pub(crate) fn test_string_none_as_path_for_cookie_dir() {
-        Jail::expect_with(|jail| {
-            let toml_auth_enabled_path = jail.directory().join("auth_enabled.toml");
-            // cookie auth on but no dir assigned
-            jail.create_file(
-                &toml_auth_enabled_path,
-                r#"
-            backend = "fetch"
-            grpc_listen_address = "127.0.0.1:8137"
-            validator_listen_address = "127.0.0.1:18232"
-            zaino_db_path = "/zaino/db"
-            zebra_db_path = "/zebra/db"
-            network = "Testnet"
-
-            [json_server_settings]
-            json_rpc_listen_address = "127.0.0.1:8237"
-            cookie_dir = ""
-        "#,
-            )?;
-            let config_auth_enabled =
-                load_config(&toml_auth_enabled_path).expect("Auth enabled failed");
-            assert!(config_auth_enabled.json_server_settings.is_some());
-            assert!(config_auth_enabled
-                .json_server_settings
-                .as_ref()
-                .expect("json settings to be Some")
-                .cookie_dir
-                .is_some());
-
-            // omitting cookie_dir will set it to None
-            let toml_auth_disabled_path = jail.directory().join("auth_disabled.toml");
-            jail.create_file(
-                &toml_auth_disabled_path,
-                r#"
-            backend = "fetch"
-
-            [json_server_settings]
-            json_rpc_listen_address = "127.0.0.1:8237"
-
-            grpc_listen_address = "127.0.0.1:8137"
-            validator_listen_address = "127.0.0.1:18232"
-            zaino_db_path = "/zaino/db"
-            zebra_db_path = "/zebra/db"
-            network = "Testnet"
-        "#,
-            )?;
-            let config_auth_disabled =
-                load_config(&toml_auth_disabled_path).expect("Auth disabled failed");
-            assert!(config_auth_disabled.json_server_settings.is_some());
-            assert_eq!(
-                config_auth_disabled
-                    .json_server_settings
-                    .as_ref()
-                    .expect("json settings to be Some")
-                    .cookie_dir,
-                None
-            );
-            Ok(())
-        });
-    }
-
-    #[test]
-    // Checks that `load_config` with an empty TOML string results in the default `IndexerConfig` values.
-    pub(crate) fn test_deserialize_empty_string_yields_default() {
-        Jail::expect_with(|jail| {
-            let empty_toml_path = jail.directory().join("empty.toml");
-            jail.create_file(&empty_toml_path, "")?;
-            let config = load_config(&empty_toml_path).expect("Empty TOML load failed");
-            let default_config = ZainodConfig::default();
-            // Compare relevant fields that should come from default
-            assert_eq!(config.network, default_config.network);
-            assert_eq!(config.backend, default_config.backend);
-            assert_eq!(
-                config.json_server_settings.is_some(),
-                default_config.json_server_settings.is_some()
-            );
-            assert_eq!(
-                config.validator_settings.validator_user,
-                default_config.validator_settings.validator_user
-            );
-            assert_eq!(
-                config.validator_settings.validator_password,
-                default_config.validator_settings.validator_password
-            );
-            assert_eq!(
-                config.storage.cache.capacity,
-                default_config.storage.cache.capacity
-            );
-            assert_eq!(
-                config.storage.cache.shard_count(),
-                default_config.storage.cache.shard_count()
-            );
-            assert_eq!(
-                config.storage.database.size,
-                default_config.storage.database.size
-            );
-            assert_eq!(
-                config.storage.database.size.to_byte_count(),
-                default_config.storage.database.size.to_byte_count()
-            );
-            Ok(())
-        });
-    }
-
-    #[test]
-    // Ensures `load_config` returns an error for an invalid `backend` type string in TOML.
-    pub(crate) fn test_deserialize_invalid_backend_type() {
-        Jail::expect_with(|jail| {
-            let invalid_toml_path = jail.directory().join("invalid_backend.toml");
-            jail.create_file(&invalid_toml_path, r#"backend = "invalid_type""#)?;
-            let result = load_config(&invalid_toml_path);
-            assert!(result.is_err());
-            if let Err(IndexerError::ConfigError(msg)) = result {
-                assert!(msg.contains("Invalid backend type"));
-            }
-            Ok(())
-        });
-    }
-
-    #[test]
-    // Ensures `load_config` returns an error for an invalid socket address string in TOML.
-    pub(crate) fn test_deserialize_invalid_socket_address() {
-        Jail::expect_with(|jail| {
-            let invalid_toml_path = jail.directory().join("invalid_socket.toml");
-            jail.create_file(
-                &invalid_toml_path,
-                r#"
-            [json_server_settings]
-            json_rpc_listen_address = "not-a-valid-address"
-            cookie_dir = ""
-            "#,
-            )?;
-            let result = load_config(&invalid_toml_path);
-            assert!(result.is_err());
-            if let Err(IndexerError::ConfigError(msg)) = result {
-                assert!(msg.contains("invalid socket address syntax"));
-            }
-            Ok(())
-        });
-    }
-
-    #[test]
-    // Validates that the actual zindexer.toml file (with optional values commented out)
-    // is parsed correctly by `load_config`, applying defaults for missing optional fields.
-    pub(crate) fn test_parse_zindexer_toml_integration() {
+    fn test_parse_zindexer_toml_integration() {
+        let _guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
         let zindexer_toml_content = include_str!("../zindexer.toml");
 
-        Jail::expect_with(|jail| {
-            let temp_toml_path = jail.directory().join("zindexer_test.toml");
-            jail.create_file(&temp_toml_path, zindexer_toml_content)?;
+        let config_path =
+            create_test_config_file(&temp_dir, zindexer_toml_content, "zindexer_test.toml");
+        let config = load_config(&config_path).expect("load_config failed to parse zindexer.toml");
+        let defaults = ZainodConfig::default();
 
-            let config_result = load_config(&temp_toml_path);
-            assert!(
-                config_result.is_ok(),
-                "load_config failed to parse zindexer.toml: {:?}",
-                config_result.err()
-            );
-            let config = config_result.unwrap();
-            let defaults = ZainodConfig::default();
-
-            assert_eq!(config.backend, ZainoBackendType::Fetch);
-            assert_eq!(
-                config.validator_settings.validator_user,
-                defaults.validator_settings.validator_user
-            );
-
-            Ok(())
-        });
-    }
-
-    // Figment-specific tests below are generally self-descriptive by name
-    #[test]
-    pub(crate) fn test_figment_env_override_toml_and_defaults() {
-        Jail::expect_with(|jail| {
-            jail.create_file(
-                "test_config.toml",
-                r#"
-            network = "Testnet"
-        "#,
-            )?;
-            jail.set_env("ZAINO_NETWORK", "Mainnet");
-            jail.set_env(
-                "ZAINO_JSON_SERVER_SETTINGS__JSON_RPC_LISTEN_ADDRESS",
-                "127.0.0.1:0",
-            );
-            jail.set_env("ZAINO_JSON_SERVER_SETTINGS__COOKIE_DIR", "/env/cookie/path");
-            jail.set_env("ZAINO_STORAGE__CACHE__CAPACITY", "12345");
-
-            let temp_toml_path = jail.directory().join("test_config.toml");
-            let config = load_config(&temp_toml_path).expect("load_config should succeed");
-
-            assert_eq!(config.network, Network::Mainnet);
-            assert_eq!(config.storage.cache.capacity, 12345);
-            assert!(config.json_server_settings.is_some());
-            assert_eq!(
-                config
-                    .json_server_settings
-                    .as_ref()
-                    .expect("json settings to be Some")
-                    .cookie_dir,
-                Some(PathBuf::from("/env/cookie/path"))
-            );
-            assert!(config.grpc_settings.tls.is_none());
-            Ok(())
-        });
+        assert_eq!(config.backend, BackendType::Fetch);
+        assert_eq!(
+            config.validator_settings.validator_user,
+            defaults.validator_settings.validator_user
+        );
     }
 
     #[test]
-    pub(crate) fn test_figment_toml_overrides_defaults() {
-        Jail::expect_with(|jail| {
-            jail.create_file(
-                "test_config.toml",
-                r#"
-            network = "Regtest"
+    fn test_env_override_toml_and_defaults() {
+        let guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
 
-            [json_server_settings]
-            json_rpc_listen_address = ""
-            cookie_dir = ""
-        "#,
-            )?;
-            let temp_toml_path = jail.directory().join("test_config.toml");
-            // a json_server_setting without a listening address is forbidden
-            assert!(load_config(&temp_toml_path).is_err());
-            Ok(())
-        });
+        let toml_content = r#"
+network = "Testnet"
+
+[validator_settings]
+validator_jsonrpc_listen_address = "127.0.0.1:18232"
+
+[storage.database]
+path = "/zaino/db"
+
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
+
+        guard.set_var("ZAINO_NETWORK", "Mainnet");
+        guard.set_var(
+            "ZAINO_JSON_SERVER_SETTINGS__JSON_RPC_LISTEN_ADDRESS",
+            "127.0.0.1:0",
+        );
+        guard.set_var("ZAINO_JSON_SERVER_SETTINGS__COOKIE_DIR", "/env/cookie/path");
+        guard.set_var("ZAINO_STORAGE__CACHE__CAPACITY", "12345");
+
+        let config_path = create_test_config_file(&temp_dir, toml_content, "test_config.toml");
+        let config = load_config(&config_path).expect("load_config should succeed");
+
+        assert_eq!(config.network, Network::Mainnet);
+        assert_eq!(config.storage.cache.capacity, 12345);
+        assert!(config.json_server_settings.is_some());
+        assert_eq!(
+            config.json_server_settings.as_ref().unwrap().cookie_dir,
+            Some(PathBuf::from("/env/cookie/path"))
+        );
     }
 
     #[test]
-    pub(crate) fn test_figment_all_defaults() {
-        Jail::expect_with(|jail| {
-            jail.create_file("empty_config.toml", "")?;
-            let temp_toml_path = jail.directory().join("empty_config.toml");
-            let config =
-                load_config(&temp_toml_path).expect("load_config should succeed with empty toml");
-            let defaults = ZainodConfig::default();
-            assert_eq!(config.network, defaults.network);
-            assert_eq!(
-                config.json_server_settings.is_some(),
-                defaults.json_server_settings.is_some()
-            );
-            assert_eq!(
-                config.storage.cache.capacity,
-                defaults.storage.cache.capacity
-            );
-            Ok(())
-        });
+    fn test_toml_overrides_defaults() {
+        let _guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
+
+        // json_server_settings without a listening address is forbidden
+        let toml_content = r#"
+network = "Regtest"
+
+[json_server_settings]
+json_rpc_listen_address = ""
+cookie_dir = ""
+
+[validator_settings]
+validator_jsonrpc_listen_address = "127.0.0.1:18232"
+
+[storage.database]
+path = "/zaino/db"
+
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
+
+        let config_path = create_test_config_file(&temp_dir, toml_content, "test_config.toml");
+        assert!(load_config(&config_path).is_err());
     }
 
     #[test]
-    pub(crate) fn test_figment_invalid_env_var_type() {
-        Jail::expect_with(|jail| {
-            jail.create_file("test_config.toml", "")?;
-            jail.set_env("ZAINO_STORAGE__CACHE__CAPACITY", "not_a_number");
-            let temp_toml_path = jail.directory().join("test_config.toml");
-            let result = load_config(&temp_toml_path);
-            assert!(result.is_err());
-            if let Err(IndexerError::ConfigError(msg)) = result {
-                assert!(msg.to_lowercase().contains("storage.cache.capacity") && msg.contains("invalid type"),
-                        "Error message should mention 'map_capacity' (case-insensitive) and 'invalid type'. Got: {msg}");
-            } else {
-                panic!("Expected ConfigError, got {result:?}");
-            }
-            Ok(())
-        });
+    fn test_invalid_env_var_type() {
+        let guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
+
+        let toml_content = r#"
+[validator_settings]
+validator_jsonrpc_listen_address = "127.0.0.1:18232"
+
+[storage.database]
+path = "/zaino/db"
+
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
+
+        guard.set_var("ZAINO_STORAGE__CACHE__CAPACITY", "not_a_number");
+
+        let config_path = create_test_config_file(&temp_dir, toml_content, "test_config.toml");
+        let result = load_config(&config_path);
+        assert!(result.is_err());
     }
 
     #[test]
-    /// Validates that cookie authentication is config-based, not address-type-based.
-    /// Non-loopback private IPs should work without cookie auth (operator's choice).
-    pub(crate) fn test_cookie_auth_not_forced_for_non_loopback_ip() {
-        Jail::expect_with(|jail| {
-            // Non-loopback private IP (192.168.x.x) WITHOUT cookie auth should succeed
-            let toml_str = r#"
-            backend = "fetch"
-            network = "Testnet"
+    fn test_cookie_auth_not_forced_for_non_loopback_ip() {
+        let _guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
 
-            [validator_settings]
-            validator_jsonrpc_listen_address = "192.168.1.10:18232"
-            # Note: NO validator_cookie_path - this is intentional
+        let toml_content = r#"
+backend = "fetch"
+network = "Testnet"
 
-            [grpc_settings]
-            listen_address = "127.0.0.1:8137"
-        "#;
-            let temp_toml_path = jail.directory().join("no_cookie_auth.toml");
-            jail.create_file(&temp_toml_path, toml_str)?;
+[validator_settings]
+validator_jsonrpc_listen_address = "192.168.1.10:18232"
 
-            let config_result = load_config(&temp_toml_path);
-            assert!(
-                config_result.is_ok(),
-                "Non-loopback IP without cookie auth should succeed. \
-                 Cookie auth is config-based, not address-type-based. Error: {:?}",
-                config_result.err()
-            );
+[storage.database]
+path = "/zaino/db"
 
-            let config = config_result.unwrap();
-            assert!(
-                config.validator_settings.validator_cookie_path.is_none(),
-                "Cookie path should be None as configured"
-            );
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
 
-            Ok(())
-        });
+        let config_path = create_test_config_file(&temp_dir, toml_content, "no_cookie_auth.toml");
+        let config_result = load_config(&config_path);
+        assert!(
+            config_result.is_ok(),
+            "Non-loopback IP without cookie auth should succeed. Error: {:?}",
+            config_result.err()
+        );
+
+        let config = config_result.unwrap();
+        assert!(config.validator_settings.validator_cookie_path.is_none());
     }
 
     #[test]
-    /// Validates symmetric behavior: both IP and hostname addresses respect configuration.
-    /// Public IPs should still be rejected (private IP requirement remains).
-    pub(crate) fn test_public_ip_still_rejected() {
-        Jail::expect_with(|jail| {
-            // Public IP should be rejected regardless of cookie auth
-            let toml_str = r#"
-            backend = "fetch"
-            network = "Testnet"
+    fn test_public_ip_still_rejected() {
+        let _guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
 
-            [validator_settings]
-            validator_jsonrpc_listen_address = "8.8.8.8:18232"
+        let toml_content = r#"
+backend = "fetch"
+network = "Testnet"
 
-            [grpc_settings]
-            listen_address = "127.0.0.1:8137"
-        "#;
-            let temp_toml_path = jail.directory().join("public_ip.toml");
-            jail.create_file(&temp_toml_path, toml_str)?;
+[validator_settings]
+validator_jsonrpc_listen_address = "8.8.8.8:18232"
 
-            let config_result = load_config(&temp_toml_path);
-            assert!(
-                config_result.is_err(),
-                "Public IP should be rejected - private IP requirement still applies"
-            );
+[storage.database]
+path = "/zaino/db"
 
-            if let Err(IndexerError::ConfigError(msg)) = config_result {
-                assert!(
-                    msg.contains("private IP"),
-                    "Error should mention private IP requirement. Got: {msg}"
-                );
-            }
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
 
-            Ok(())
-        });
+        let config_path = create_test_config_file(&temp_dir, toml_content, "public_ip.toml");
+        let result = load_config(&config_path);
+        assert!(result.is_err());
+
+        if let Err(IndexerError::ConfigError(msg)) = result {
+            assert!(msg.contains("private IP"));
+        }
+    }
+
+    #[test]
+    fn test_sensitive_env_var_blocked() {
+        let guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
+
+        let toml_content = r#"
+[validator_settings]
+validator_jsonrpc_listen_address = "127.0.0.1:18232"
+
+[storage.database]
+path = "/zaino/db"
+
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
+
+        guard.set_var("ZAINO_VALIDATOR_SETTINGS__VALIDATOR_PASSWORD", "secret123");
+
+        let config_path =
+            create_test_config_file(&temp_dir, toml_content, "sensitive_env_test.toml");
+        let result = load_config(&config_path);
+        assert!(result.is_err());
+
+        if let Err(IndexerError::ConfigError(msg)) = result {
+            assert!(msg.contains("sensitive key"));
+            assert!(msg.contains("VALIDATOR_PASSWORD"));
+        }
+    }
+
+    #[test]
+    fn test_sensitive_key_detection() {
+        assert!(is_sensitive_leaf_key("password"));
+        assert!(is_sensitive_leaf_key("PASSWORD"));
+        assert!(is_sensitive_leaf_key("validator_password"));
+        assert!(is_sensitive_leaf_key("VALIDATOR_PASSWORD"));
+        assert!(is_sensitive_leaf_key("secret"));
+        assert!(is_sensitive_leaf_key("api_token"));
+        assert!(is_sensitive_leaf_key("cookie"));
+        assert!(is_sensitive_leaf_key("private_key"));
+
+        assert!(!is_sensitive_leaf_key("username"));
+        assert!(!is_sensitive_leaf_key("address"));
+        assert!(!is_sensitive_leaf_key("network"));
+    }
+
+    #[test]
+    fn test_unknown_fields_rejected() {
+        let _guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
+
+        let toml_content = r#"
+unknown_field = "value"
+
+[validator_settings]
+validator_jsonrpc_listen_address = "127.0.0.1:18232"
+
+[storage.database]
+path = "/zaino/db"
+
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
+
+        let config_path = create_test_config_file(&temp_dir, toml_content, "unknown_fields.toml");
+        let result = load_config(&config_path);
+        assert!(result.is_err());
     }
 }

--- a/zainod/src/indexer.rs
+++ b/zainod/src/indexer.rs
@@ -5,11 +5,10 @@ use tracing::info;
 
 use zaino_fetch::jsonrpsee::connector::test_node_and_return_url;
 use zaino_serve::server::{config::GrpcServerConfig, grpc::TonicServer, jsonrpc::JsonRpcServer};
-
 #[allow(deprecated)]
 use zaino_state::{
-    BackendConfig, FetchService, IndexerService, LightWalletService, StateService, StatusType,
-    ZcashIndexer, ZcashService,
+    BackendType, FetchService, FetchServiceConfig, IndexerService, LightWalletService,
+    StateService, StateServiceConfig, StatusType, ZcashIndexer, ZcashService,
 };
 
 use crate::{config::ZainodConfig, error::IndexerError};
@@ -38,7 +37,6 @@ pub async fn start_indexer(
 }
 
 /// Spawns a new Indexer server.
-#[allow(deprecated)]
 pub async fn spawn_indexer(
     config: ZainodConfig,
 ) -> Result<tokio::task::JoinHandle<Result<(), IndexerError>>, IndexerError> {
@@ -56,18 +54,21 @@ pub async fn spawn_indexer(
         " - Connected to node using JsonRPSee at address {}.",
         zebrad_uri
     );
-    match BackendConfig::try_from(config.clone()) {
-        Ok(BackendConfig::State(state_service_config)) => {
-            Indexer::<StateService>::launch_inner(state_service_config, config)
+
+    #[allow(deprecated)]
+    match config.backend {
+        BackendType::State => {
+            let state_config = StateServiceConfig::try_from(config.clone())?;
+            Indexer::<StateService>::launch_inner(state_config, config)
                 .await
                 .map(|res| res.0)
         }
-        Ok(BackendConfig::Fetch(fetch_service_config)) => {
-            Indexer::<FetchService>::launch_inner(fetch_service_config, config)
+        BackendType::Fetch => {
+            let fetch_config = FetchServiceConfig::try_from(config.clone())?;
+            Indexer::<FetchService>::launch_inner(fetch_config, config)
                 .await
                 .map(|res| res.0)
         }
-        Err(e) => Err(e),
     }
 }
 

--- a/zainod/zindexer.toml
+++ b/zainod/zindexer.toml
@@ -40,13 +40,11 @@ backend = "fetch"
 # Validator config:
 # Required for valid zainod config.
 [validator_settings]
-  # Full node / validator listen address.
+  # Full node / validator gRPC listen address (Zebra only).
   #
-  # Must be a "private" address as defined in [IETF RFC 1918] for ipv4 addreses and [IETF RFC 4193] for ipv6 addreses.
-  #
-  # Must use validator rpc cookie authentication when connecting to non localhost addresses.
-  # Required
-  validator_grpc_listen_address =  "127.0.0.1:18232"
+  # Must be a "private" address as defined in [IETF RFC 1918] for IPv4 or [IETF RFC 4193] for IPv6.
+  # Cookie or user/password authentication is recommended for non-localhost addresses.
+  validator_grpc_listen_address = "127.0.0.1:18232"
 
   # SocketAddr, Required.
   validator_jsonrpc_listen_address = "127.0.0.1:18230"


### PR DESCRIPTION
### Motivation
Unify configuration across the Z3 stack and harden handling of sensitive values. This PR migrates from `figment` to `config-rs` and prevents sensitive fields from being overridden via environment variables, aligning Zaino with Zebra and improving default security posture.

### Solution
- Replace `figment` with `config-rs` using a 3-layer hierarchy: defaults → TOML → env
- Add case-insensitive, suffix-based env deny-list with **explicit error messages**:
  - Block env overrides whose leaf key ends with: `password`, `secret`, `token`, `cookie`, `private_key`
  - Returns clear error explaining why and directing users to config file
  - Supports nested config via `ZAINO_` prefix with `__` separator (e.g., `ZAINO_VALIDATOR_SETTINGS__VALIDATOR_USER`)
- Add `#[serde(deny_unknown_fields)]` to catch typos in TOML config files
- Add `#[serde(default)]` to config structs for partial config support
- Comprehensive inline test coverage using `EnvGuard` pattern

### Changes
| File | Change |
|------|--------|
| `Cargo.toml` | `figment` → `config-rs` |
| `zainod/Cargo.toml` | Update dependencies |
| `zainod/src/config.rs` | Major rewrite with config-rs, sensitive key protection, inline tests |
| `zainod/src/indexer.rs` | Simplify BackendType matching |
| `zaino-state/src/config.rs` | Add `Default`, `Eq`, `Serialize` to `BackendType` |
| `zaino-serve/src/server/config.rs` | Add `#[serde(alias)]` for backwards compatibility |
| `zaino-common/src/config/storage.rs` | Add `#[serde(default)]` |
| `zaino-common/src/config/validator.rs` | Add `#[serde(default)]` and `impl Default` |

### Security Enhancement
This PR prevents accidental exposure of sensitive configuration values through environment variables, which is particularly important in containerized deployments where env vars might be logged or visible to other processes.

**Key difference from silent filtering**: Instead of silently dropping sensitive env vars, this implementation returns an explicit error message explaining why the env var is blocked and directing users to use the config file instead. This follows the "fail loudly" principle for better security UX.

**Blocked env overrides**: `ZAINO_VALIDATOR_SETTINGS__VALIDATOR_PASSWORD`, `ZAINO_*_SECRET`, `ZAINO_*_TOKEN`, etc.
**Allowed env overrides**: `ZAINO_NETWORK`, `ZAINO_GRPC_SETTINGS__LISTEN_ADDRESS`, etc.

### Testing
- 15 config tests pass (inline in `zainod/src/config.rs`)
- Tests cover: sensitive key blocking, env overrides, TOML parsing, unknown field rejection
- Backward compatibility maintained via `#[serde(alias)]` for existing config files

### Related
- Aligns with Zebra's config security model
- Part of broader Z3 stack configuration unification