### PR TITLE
Update transaction hash byte order in ChainBlock

### DIFF
--- a/integration-tests/tests/chain_cache.rs
+++ b/integration-tests/tests/chain_cache.rs
@@ -301,15 +301,15 @@ mod chain_query_interface {
         for txid in snapshot
             .blocks
             .values()
-            .flat_map(|block| block.transactions().iter().map(|txdata| txdata.txid()))
+            .flat_map(|block| block.transactions().iter().map(|txdata| txdata.txid().0))
         {
             let raw_transaction = chain_index
-                .get_raw_transaction(&snapshot, *txid)
+                .get_raw_transaction(&snapshot, txid)
                 .await
                 .unwrap()
                 .unwrap();
             assert_eq!(
-                *txid,
+                txid,
                 zebra_chain::transaction::Transaction::zcash_deserialize(&raw_transaction[..])
                     .unwrap()
                     .hash()
@@ -337,11 +337,9 @@ mod chain_query_interface {
             block
                 .transactions()
                 .iter()
-                .map(|txdata| (txdata.txid(), block.height(), block.hash()))
+                .map(|txdata| (txdata.txid().0, block.height(), block.hash()))
         }) {
-            let transaction_status = chain_index
-                .get_transaction_status(&snapshot, *txid)
-                .unwrap();
+            let transaction_status = chain_index.get_transaction_status(&snapshot, txid).unwrap();
             assert_eq!(1, transaction_status.len());
             assert_eq!(transaction_status.keys().next().unwrap(), block_hash);
             assert_eq!(transaction_status.values().next().unwrap(), &height)

--- a/zaino-state/src/chain_index/finalised_state.rs
+++ b/zaino-state/src/chain_index/finalised_state.rs
@@ -20,7 +20,7 @@ use zebra_chain::parameters::NetworkKind;
 
 use crate::{
     chain_index::source::BlockchainSourceError, config::BlockCacheConfig,
-    error::FinalisedStateError, ChainBlock, ChainWork, BlockHash, Height, StatusType,
+    error::FinalisedStateError, BlockHash, ChainBlock, ChainWork, Height, StatusType,
 };
 
 use std::{sync::Arc, time::Duration};
@@ -338,7 +338,10 @@ impl ZainoDB {
     /// Returns the block height for the given block hash *if* present in the finalised state.
     ///
     /// TODO: Should theis return `Result<Option<Height>, FinalisedStateError>`?
-    pub(crate) async fn get_block_height(&self, hash: BlockHash) -> Result<Height, FinalisedStateError> {
+    pub(crate) async fn get_block_height(
+        &self,
+        hash: BlockHash,
+    ) -> Result<Height, FinalisedStateError> {
         self.db.get_block_height(hash).await
     }
 

--- a/zaino-state/src/chain_index/finalised_state.rs
+++ b/zaino-state/src/chain_index/finalised_state.rs
@@ -20,7 +20,7 @@ use zebra_chain::parameters::NetworkKind;
 
 use crate::{
     chain_index::source::BlockchainSourceError, config::BlockCacheConfig,
-    error::FinalisedStateError, ChainBlock, ChainWork, Hash, Height, StatusType,
+    error::FinalisedStateError, ChainBlock, ChainWork, BlockHash, Height, StatusType,
 };
 
 use std::{sync::Arc, time::Duration};
@@ -250,7 +250,7 @@ impl ZainoDB {
                 }
             };
 
-            let block_hash = Hash::from(block.hash().0);
+            let block_hash = BlockHash::from(block.hash().0);
 
             let (sapling_root, sapling_size, orchard_root, orchard_size) =
                 match source.get_commitment_tree_roots(block_hash).await? {
@@ -338,12 +338,12 @@ impl ZainoDB {
     /// Returns the block height for the given block hash *if* present in the finalised state.
     ///
     /// TODO: Should theis return `Result<Option<Height>, FinalisedStateError>`?
-    pub(crate) async fn get_block_height(&self, hash: Hash) -> Result<Height, FinalisedStateError> {
+    pub(crate) async fn get_block_height(&self, hash: BlockHash) -> Result<Height, FinalisedStateError> {
         self.db.get_block_height(hash).await
     }
 
     /// Returns the block block hash for the given block height *if* present in the finlaised state.
-    pub(crate) async fn get_block_hash(&self, h: Height) -> Result<Hash, FinalisedStateError> {
+    pub(crate) async fn get_block_hash(&self, h: Height) -> Result<BlockHash, FinalisedStateError> {
         self.db.get_block_hash(h).await
     }
 

--- a/zaino-state/src/chain_index/finalised_state/capability.rs
+++ b/zaino-state/src/chain_index/finalised_state/capability.rs
@@ -3,7 +3,12 @@
 use core::fmt;
 
 use crate::{
-    chain_index::types::{AddrEventBytes, TransactionHash}, error::FinalisedStateError, read_fixed_le, read_u32_le, read_u8, version, write_fixed_le, write_u32_le, write_u8, AddrScript, BlockHash, BlockHeaderData, ChainBlock, CommitmentTreeData, FixedEncodedLen, Height, OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx, TransparentTxList, TxLocation, TxidList, ZainoVersionedSerialise
+    chain_index::types::{AddrEventBytes, TransactionHash},
+    error::FinalisedStateError,
+    read_fixed_le, read_u32_le, read_u8, version, write_fixed_le, write_u32_le, write_u8,
+    AddrScript, BlockHash, BlockHeaderData, ChainBlock, CommitmentTreeData, FixedEncodedLen,
+    Height, OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType,
+    TransparentCompactTx, TransparentTxList, TxLocation, TxidList, ZainoVersionedSerialise,
 };
 
 use async_trait::async_trait;
@@ -454,11 +459,16 @@ pub trait BlockCoreExt: Send + Sync {
     ) -> Result<Vec<TxidList>, FinalisedStateError>;
 
     /// Fetch the txid bytes for a given TxLocation.
-    async fn get_txid(&self, tx_location: TxLocation) -> Result<TransactionHash, FinalisedStateError>;
+    async fn get_txid(
+        &self,
+        tx_location: TxLocation,
+    ) -> Result<TransactionHash, FinalisedStateError>;
 
     /// Fetch the TxLocation for the given txid, transaction data is indexed by TxLocation internally.
-    async fn get_tx_location(&self, txid: &TransactionHash)
-        -> Result<Option<TxLocation>, FinalisedStateError>;
+    async fn get_tx_location(
+        &self,
+        txid: &TransactionHash,
+    ) -> Result<Option<TxLocation>, FinalisedStateError>;
 }
 
 /// Transparent block data extension.

--- a/zaino-state/src/chain_index/finalised_state/capability.rs
+++ b/zaino-state/src/chain_index/finalised_state/capability.rs
@@ -3,11 +3,7 @@
 use core::fmt;
 
 use crate::{
-    chain_index::types::AddrEventBytes, error::FinalisedStateError, read_fixed_le, read_u32_le,
-    read_u8, version, write_fixed_le, write_u32_le, write_u8, AddrScript, BlockHeaderData,
-    ChainBlock, CommitmentTreeData, FixedEncodedLen, BlockHash, Height, OrchardCompactTx, OrchardTxList,
-    Outpoint, SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx, TransparentTxList,
-    TxLocation, TxidList, ZainoVersionedSerialise,
+    chain_index::types::{AddrEventBytes, TransactionHash}, error::FinalisedStateError, read_fixed_le, read_u32_le, read_u8, version, write_fixed_le, write_u32_le, write_u8, AddrScript, BlockHash, BlockHeaderData, ChainBlock, CommitmentTreeData, FixedEncodedLen, Height, OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx, TransparentTxList, TxLocation, TxidList, ZainoVersionedSerialise
 };
 
 use async_trait::async_trait;
@@ -458,10 +454,10 @@ pub trait BlockCoreExt: Send + Sync {
     ) -> Result<Vec<TxidList>, FinalisedStateError>;
 
     /// Fetch the txid bytes for a given TxLocation.
-    async fn get_txid(&self, tx_location: TxLocation) -> Result<BlockHash, FinalisedStateError>;
+    async fn get_txid(&self, tx_location: TxLocation) -> Result<TransactionHash, FinalisedStateError>;
 
     /// Fetch the TxLocation for the given txid, transaction data is indexed by TxLocation internally.
-    async fn get_tx_location(&self, txid: &BlockHash)
+    async fn get_tx_location(&self, txid: &TransactionHash)
         -> Result<Option<TxLocation>, FinalisedStateError>;
 }
 

--- a/zaino-state/src/chain_index/finalised_state/capability.rs
+++ b/zaino-state/src/chain_index/finalised_state/capability.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use crate::{
     chain_index::types::AddrEventBytes, error::FinalisedStateError, read_fixed_le, read_u32_le,
     read_u8, version, write_fixed_le, write_u32_le, write_u8, AddrScript, BlockHeaderData,
-    ChainBlock, CommitmentTreeData, FixedEncodedLen, Hash, Height, OrchardCompactTx, OrchardTxList,
+    ChainBlock, CommitmentTreeData, FixedEncodedLen, BlockHash, Height, OrchardCompactTx, OrchardTxList,
     Outpoint, SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx, TransparentTxList,
     TxLocation, TxidList, ZainoVersionedSerialise,
 };
@@ -390,10 +390,10 @@ pub trait DbRead: Send + Sync {
     async fn db_height(&self) -> Result<Option<Height>, FinalisedStateError>;
 
     /// Lookup height of a block by its hash.
-    async fn get_block_height(&self, hash: Hash) -> Result<Height, FinalisedStateError>;
+    async fn get_block_height(&self, hash: BlockHash) -> Result<Height, FinalisedStateError>;
 
     /// Lookup hash of a block by its height.
-    async fn get_block_hash(&self, height: Height) -> Result<Hash, FinalisedStateError>;
+    async fn get_block_hash(&self, height: Height) -> Result<BlockHash, FinalisedStateError>;
 
     /// Return the persisted `DbMetadata` singleton.
     async fn get_metadata(&self) -> Result<DbMetadata, FinalisedStateError>;
@@ -458,10 +458,10 @@ pub trait BlockCoreExt: Send + Sync {
     ) -> Result<Vec<TxidList>, FinalisedStateError>;
 
     /// Fetch the txid bytes for a given TxLocation.
-    async fn get_txid(&self, tx_location: TxLocation) -> Result<Hash, FinalisedStateError>;
+    async fn get_txid(&self, tx_location: TxLocation) -> Result<BlockHash, FinalisedStateError>;
 
     /// Fetch the TxLocation for the given txid, transaction data is indexed by TxLocation internally.
-    async fn get_tx_location(&self, txid: &Hash)
+    async fn get_tx_location(&self, txid: &BlockHash)
         -> Result<Option<TxLocation>, FinalisedStateError>;
 }
 

--- a/zaino-state/src/chain_index/finalised_state/db.rs
+++ b/zaino-state/src/chain_index/finalised_state/db.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     config::BlockCacheConfig,
     error::FinalisedStateError,
-    AddrScript, BlockHeaderData, ChainBlock, CommitmentTreeData, Hash, Height, OrchardCompactTx,
+    AddrScript, BlockHeaderData, ChainBlock, CommitmentTreeData, BlockHash, Height, OrchardCompactTx,
     OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx,
     TransparentTxList, TxLocation, TxidList,
 };
@@ -108,14 +108,14 @@ impl DbRead for DbBackend {
         }
     }
 
-    async fn get_block_height(&self, hash: Hash) -> Result<Height, FinalisedStateError> {
+    async fn get_block_height(&self, hash: BlockHash) -> Result<Height, FinalisedStateError> {
         match self {
             Self::V0(db) => db.get_block_height(hash).await,
             Self::V1(db) => db.get_block_height(hash).await,
         }
     }
 
-    async fn get_block_hash(&self, height: Height) -> Result<Hash, FinalisedStateError> {
+    async fn get_block_hash(&self, height: Height) -> Result<BlockHash, FinalisedStateError> {
         match self {
             Self::V0(db) => db.get_block_hash(height).await,
             Self::V1(db) => db.get_block_hash(height).await,
@@ -204,7 +204,7 @@ impl BlockCoreExt for DbBackend {
         }
     }
 
-    async fn get_txid(&self, tx_location: TxLocation) -> Result<Hash, FinalisedStateError> {
+    async fn get_txid(&self, tx_location: TxLocation) -> Result<BlockHash, FinalisedStateError> {
         match self {
             Self::V1(db) => db.get_txid(tx_location).await,
             _ => Err(FinalisedStateError::FeatureUnavailable("block_core")),
@@ -213,7 +213,7 @@ impl BlockCoreExt for DbBackend {
 
     async fn get_tx_location(
         &self,
-        txid: &Hash,
+        txid: &BlockHash,
     ) -> Result<Option<TxLocation>, FinalisedStateError> {
         match self {
             Self::V1(db) => db.get_tx_location(txid).await,

--- a/zaino-state/src/chain_index/finalised_state/db.rs
+++ b/zaino-state/src/chain_index/finalised_state/db.rs
@@ -7,15 +7,10 @@ use v0::DbV0;
 use v1::DbV1;
 
 use crate::{
-    chain_index::finalised_state::capability::{
+    chain_index::{finalised_state::capability::{
         BlockCoreExt, BlockShieldedExt, BlockTransparentExt, ChainBlockExt, CompactBlockExt,
         DbCore, DbMetadata, DbRead, DbWrite, TransparentHistExt,
-    },
-    config::BlockCacheConfig,
-    error::FinalisedStateError,
-    AddrScript, BlockHeaderData, ChainBlock, CommitmentTreeData, BlockHash, Height, OrchardCompactTx,
-    OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx,
-    TransparentTxList, TxLocation, TxidList,
+    }, types::TransactionHash}, config::BlockCacheConfig, error::FinalisedStateError, AddrScript, BlockHash, BlockHeaderData, ChainBlock, CommitmentTreeData, Height, OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx, TransparentTxList, TxLocation, TxidList
 };
 
 use async_trait::async_trait;
@@ -204,7 +199,7 @@ impl BlockCoreExt for DbBackend {
         }
     }
 
-    async fn get_txid(&self, tx_location: TxLocation) -> Result<BlockHash, FinalisedStateError> {
+    async fn get_txid(&self, tx_location: TxLocation) -> Result<TransactionHash, FinalisedStateError> {
         match self {
             Self::V1(db) => db.get_txid(tx_location).await,
             _ => Err(FinalisedStateError::FeatureUnavailable("block_core")),
@@ -213,7 +208,7 @@ impl BlockCoreExt for DbBackend {
 
     async fn get_tx_location(
         &self,
-        txid: &BlockHash,
+        txid: &TransactionHash,
     ) -> Result<Option<TxLocation>, FinalisedStateError> {
         match self {
             Self::V1(db) => db.get_tx_location(txid).await,

--- a/zaino-state/src/chain_index/finalised_state/db.rs
+++ b/zaino-state/src/chain_index/finalised_state/db.rs
@@ -7,10 +7,18 @@ use v0::DbV0;
 use v1::DbV1;
 
 use crate::{
-    chain_index::{finalised_state::capability::{
-        BlockCoreExt, BlockShieldedExt, BlockTransparentExt, ChainBlockExt, CompactBlockExt,
-        DbCore, DbMetadata, DbRead, DbWrite, TransparentHistExt,
-    }, types::TransactionHash}, config::BlockCacheConfig, error::FinalisedStateError, AddrScript, BlockHash, BlockHeaderData, ChainBlock, CommitmentTreeData, Height, OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx, TransparentTxList, TxLocation, TxidList
+    chain_index::{
+        finalised_state::capability::{
+            BlockCoreExt, BlockShieldedExt, BlockTransparentExt, ChainBlockExt, CompactBlockExt,
+            DbCore, DbMetadata, DbRead, DbWrite, TransparentHistExt,
+        },
+        types::TransactionHash,
+    },
+    config::BlockCacheConfig,
+    error::FinalisedStateError,
+    AddrScript, BlockHash, BlockHeaderData, ChainBlock, CommitmentTreeData, Height,
+    OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType,
+    TransparentCompactTx, TransparentTxList, TxLocation, TxidList,
 };
 
 use async_trait::async_trait;
@@ -199,7 +207,10 @@ impl BlockCoreExt for DbBackend {
         }
     }
 
-    async fn get_txid(&self, tx_location: TxLocation) -> Result<TransactionHash, FinalisedStateError> {
+    async fn get_txid(
+        &self,
+        tx_location: TxLocation,
+    ) -> Result<TransactionHash, FinalisedStateError> {
         match self {
             Self::V1(db) => db.get_txid(tx_location).await,
             _ => Err(FinalisedStateError::FeatureUnavailable("block_core")),

--- a/zaino-state/src/chain_index/finalised_state/db/v0.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v0.rs
@@ -40,7 +40,7 @@ impl DbRead for DbV0 {
 
     async fn get_block_height(
         &self,
-        hash: crate::Hash,
+        hash: crate::BlockHash,
     ) -> Result<crate::Height, FinalisedStateError> {
         self.get_block_height_by_hash(hash).await
     }
@@ -48,7 +48,7 @@ impl DbRead for DbV0 {
     async fn get_block_hash(
         &self,
         height: crate::Height,
-    ) -> Result<crate::Hash, FinalisedStateError> {
+    ) -> Result<crate::BlockHash, FinalisedStateError> {
         self.get_block_hash_by_height(height).await
     }
 
@@ -600,7 +600,7 @@ impl DbV0 {
     /// Fetch the block height in the main chain for a given block hash.
     async fn get_block_height_by_hash(
         &self,
-        hash: crate::Hash,
+        hash: crate::BlockHash,
     ) -> Result<crate::Height, FinalisedStateError> {
         let zebra_hash: ZebraHash = zebra_chain::block::Hash::from(hash);
         let hash_key = serde_json::to_vec(&DbHash(zebra_hash))?;
@@ -619,7 +619,7 @@ impl DbV0 {
     async fn get_block_hash_by_height(
         &self,
         height: crate::Height,
-    ) -> Result<crate::Hash, FinalisedStateError> {
+    ) -> Result<crate::BlockHash, FinalisedStateError> {
         let zebra_height: ZebraHeight = height.into();
         let height_key = DbHeight(zebra_height).to_be_bytes();
 
@@ -629,7 +629,7 @@ impl DbV0 {
             let hash_bytes: &[u8] = txn.get(self.heights_to_hashes, &height_key)?;
             let db_hash: DbHash = serde_json::from_slice(hash_bytes)?;
 
-            Ok(crate::Hash::from(db_hash.0))
+            Ok(crate::BlockHash::from(db_hash.0))
         })
     }
 

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -895,10 +895,10 @@ impl DbV1 {
         let mut addrhist_outputs_map: HashMap<AddrScript, Vec<AddrHistRecord>> = HashMap::new();
 
         for (tx_index, tx) in block.transactions().iter().enumerate() {
-            let hash = TransactionHash::from_bytes_in_display_order(tx.txid());
+            let hash = tx.txid();
 
-            if txid_set.insert(hash) {
-                txids.push(hash);
+            if txid_set.insert(*hash) {
+                txids.push(*hash);
             }
 
             // Transparent transactions
@@ -1307,10 +1307,10 @@ impl DbV1 {
         let mut addrhist_outputs_map: HashMap<AddrScript, Vec<AddrHistRecord>> = HashMap::new();
 
         for (tx_index, tx) in block.transactions().iter().enumerate() {
-            let h = TransactionHash::from_bytes_in_display_order(tx.txid());
+            let hash = tx.txid();
 
-            if txid_set.insert(h) {
-                txids.push(h);
+            if txid_set.insert(*hash) {
+                txids.push(*hash);
             }
 
             // Transparent transactions
@@ -2873,8 +2873,7 @@ impl DbV1 {
 
             let txs: Vec<CompactTxData> = (0..len)
                 .map(|i| {
-                    let txid = txids[i].bytes_in_display_order();
-
+                    let txid = txids[i];
                     let transparent_tx = transparent[i]
                         .clone()
                         .unwrap_or_else(|| TransparentCompactTx::new(vec![], vec![]));

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -11,7 +11,14 @@ use crate::{
             entry::{StoredEntryFixed, StoredEntryVar},
         },
         types::{AddrEventBytes, TransactionHash},
-    }, config::BlockCacheConfig, error::FinalisedStateError, AddrHistRecord, AddrScript, AtomicStatus, BlockHash, BlockHeaderData, ChainBlock, CommitmentTreeData, CompactOrchardAction, CompactSaplingOutput, CompactSaplingSpend, CompactSize, CompactTxData, FixedEncodedLen as _, Height, OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx, TransparentTxList, TxInCompact, TxLocation, TxOutCompact, TxidList, ZainoVersionedSerialise as _
+    },
+    config::BlockCacheConfig,
+    error::FinalisedStateError,
+    AddrHistRecord, AddrScript, AtomicStatus, BlockHash, BlockHeaderData, ChainBlock,
+    CommitmentTreeData, CompactOrchardAction, CompactSaplingOutput, CompactSaplingSpend,
+    CompactSize, CompactTxData, FixedEncodedLen as _, Height, OrchardCompactTx, OrchardTxList,
+    Outpoint, SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx, TransparentTxList,
+    TxInCompact, TxLocation, TxOutCompact, TxidList, ZainoVersionedSerialise as _,
 };
 
 use zebra_chain::parameters::NetworkKind;
@@ -170,7 +177,10 @@ impl BlockCoreExt for DbV1 {
         self.get_block_range_txids(start, end).await
     }
 
-    async fn get_txid(&self, tx_location: TxLocation) -> Result<TransactionHash, FinalisedStateError> {
+    async fn get_txid(
+        &self,
+        tx_location: TxLocation,
+    ) -> Result<TransactionHash, FinalisedStateError> {
         self.get_txid(tx_location).await
     }
 
@@ -963,7 +973,9 @@ impl DbV1 {
                     tokio::task::block_in_place(|| {
                         let prev_output = self.get_previous_output_blocking(prev_outpoint)?;
                         let prev_output_tx_location = self
-                            .find_txid_index_blocking(&TransactionHash::from(*prev_outpoint.prev_txid()))?
+                            .find_txid_index_blocking(&TransactionHash::from(
+                                *prev_outpoint.prev_txid(),
+                            ))?
                             .ok_or_else(|| {
                                 FinalisedStateError::Custom("Previous txid not found".into())
                             })?;
@@ -1358,7 +1370,9 @@ impl DbV1 {
                         let prev_output = self.get_previous_output_blocking(prev_outpoint)?;
 
                         let prev_output_tx_location = self
-                            .find_txid_index_blocking(&TransactionHash::from(*prev_outpoint.prev_txid()))
+                            .find_txid_index_blocking(&TransactionHash::from(
+                                *prev_outpoint.prev_txid(),
+                            ))
                             .map_err(|e| FinalisedStateError::InvalidBlock {
                                 height: block.height().expect("already  checked height is some").0,
                                 hash: *block.hash(),
@@ -1575,7 +1589,10 @@ impl DbV1 {
     }
 
     /// Fetch the block height in the main chain for a given block hash.
-    async fn get_block_height_by_hash(&self, hash: BlockHash) -> Result<Height, FinalisedStateError> {
+    async fn get_block_height_by_hash(
+        &self,
+        hash: BlockHash,
+    ) -> Result<Height, FinalisedStateError> {
         let height = self
             .resolve_validated_hash_or_height(HashOrHeight::Hash(hash.into()))
             .await?;
@@ -1689,7 +1706,10 @@ impl DbV1 {
     /// This uses an optimized lookup without decoding the full TxidList.
     ///
     /// NOTE: This method currently ignores the txid version byte for efficiency.
-    async fn get_txid(&self, tx_location: TxLocation) -> Result<TransactionHash, FinalisedStateError> {
+    async fn get_txid(
+        &self,
+        tx_location: TxLocation,
+    ) -> Result<TransactionHash, FinalisedStateError> {
         tokio::task::block_in_place(|| {
             let txn = self.env.begin_ro_txn()?;
 
@@ -3278,7 +3298,12 @@ impl DbV1 {
         }
 
         // *** Merkle root / Txid validation ***
-        let txids: Vec<[u8; 32]> = txid_list_entry.inner().txids().iter().map(|h| h.0).collect();
+        let txids: Vec<[u8; 32]> = txid_list_entry
+            .inner()
+            .txids()
+            .iter()
+            .map(|h| h.0)
+            .collect();
 
         let header_merkle_root = header_entry.inner().data().merkle_root();
 

--- a/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -10,7 +10,7 @@ use super::{
 
 use crate::{
     chain_index::source::BlockchainSource, config::BlockCacheConfig, error::FinalisedStateError,
-    ChainBlock, ChainWork, Hash, Height,
+    ChainBlock, ChainWork, BlockHash, Height,
 };
 
 use async_trait::async_trait;
@@ -164,7 +164,7 @@ impl<T: BlockchainSource> Migration<T> for Migration0_0_0To1_0_0 {
                                     "block not found at height {height}"
                                 ))
                             })?;
-                        let hash = Hash::from(block.hash().0);
+                        let hash = BlockHash::from(block.hash().0);
 
                         let (sapling_root_data, orchard_root_data) =
                             source.get_commitment_tree_roots(hash).await?;

--- a/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -10,7 +10,7 @@ use super::{
 
 use crate::{
     chain_index::source::BlockchainSource, config::BlockCacheConfig, error::FinalisedStateError,
-    ChainBlock, ChainWork, BlockHash, Height,
+    BlockHash, ChainBlock, ChainWork, Height,
 };
 
 use async_trait::async_trait;

--- a/zaino-state/src/chain_index/finalised_state/reader.rs
+++ b/zaino-state/src/chain_index/finalised_state/reader.rs
@@ -3,7 +3,14 @@
 //! This should be used to fetch chain data in *all* cases.
 
 use crate::{
-    chain_index::{finalised_state::capability::CapabilityRequest, types::{AddrEventBytes, TransactionHash}}, error::FinalisedStateError, AddrScript, BlockHash, BlockHeaderData, ChainBlock, CommitmentTreeData, Height, OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx, TransparentTxList, TxLocation, TxidList
+    chain_index::{
+        finalised_state::capability::CapabilityRequest,
+        types::{AddrEventBytes, TransactionHash},
+    },
+    error::FinalisedStateError,
+    AddrScript, BlockHash, BlockHeaderData, ChainBlock, CommitmentTreeData, Height,
+    OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType,
+    TransparentCompactTx, TransparentTxList, TxLocation, TxidList,
 };
 
 use super::{
@@ -55,12 +62,18 @@ impl DbReader {
     }
 
     /// Fetch the block height in the main chain for a given block hash.
-    pub(crate) async fn get_block_height(&self, hash: BlockHash) -> Result<Height, FinalisedStateError> {
+    pub(crate) async fn get_block_height(
+        &self,
+        hash: BlockHash,
+    ) -> Result<Height, FinalisedStateError> {
         self.inner.get_block_height(hash).await
     }
 
     /// Fetch the block hash in the main chain for a given block height.
-    pub(crate) async fn get_block_hash(&self, height: Height) -> Result<BlockHash, FinalisedStateError> {
+    pub(crate) async fn get_block_hash(
+        &self,
+        height: Height,
+    ) -> Result<BlockHash, FinalisedStateError> {
         self.inner.get_block_hash(height).await
     }
 

--- a/zaino-state/src/chain_index/finalised_state/reader.rs
+++ b/zaino-state/src/chain_index/finalised_state/reader.rs
@@ -3,11 +3,7 @@
 //! This should be used to fetch chain data in *all* cases.
 
 use crate::{
-    chain_index::{finalised_state::capability::CapabilityRequest, types::AddrEventBytes},
-    error::FinalisedStateError,
-    AddrScript, BlockHeaderData, ChainBlock, CommitmentTreeData, BlockHash, Height, OrchardCompactTx,
-    OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx,
-    TransparentTxList, TxLocation, TxidList,
+    chain_index::{finalised_state::capability::CapabilityRequest, types::{AddrEventBytes, TransactionHash}}, error::FinalisedStateError, AddrScript, BlockHash, BlockHeaderData, ChainBlock, CommitmentTreeData, Height, OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx, TransparentTxList, TxLocation, TxidList
 };
 
 use super::{
@@ -73,7 +69,7 @@ impl DbReader {
     /// Fetch the TxLocation for the given txid, transaction data is indexed by TxLocation internally.
     pub(crate) async fn get_tx_location(
         &self,
-        txid: &BlockHash,
+        txid: &TransactionHash,
     ) -> Result<Option<TxLocation>, FinalisedStateError> {
         self.db(CapabilityRequest::BlockCoreExt)?
             .get_tx_location(txid)
@@ -105,7 +101,7 @@ impl DbReader {
     pub(crate) async fn get_txid(
         &self,
         tx_location: TxLocation,
-    ) -> Result<BlockHash, FinalisedStateError> {
+    ) -> Result<TransactionHash, FinalisedStateError> {
         self.db(CapabilityRequest::BlockCoreExt)?
             .get_txid(tx_location)
             .await

--- a/zaino-state/src/chain_index/finalised_state/reader.rs
+++ b/zaino-state/src/chain_index/finalised_state/reader.rs
@@ -5,7 +5,7 @@
 use crate::{
     chain_index::{finalised_state::capability::CapabilityRequest, types::AddrEventBytes},
     error::FinalisedStateError,
-    AddrScript, BlockHeaderData, ChainBlock, CommitmentTreeData, Hash, Height, OrchardCompactTx,
+    AddrScript, BlockHeaderData, ChainBlock, CommitmentTreeData, BlockHash, Height, OrchardCompactTx,
     OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx,
     TransparentTxList, TxLocation, TxidList,
 };
@@ -59,12 +59,12 @@ impl DbReader {
     }
 
     /// Fetch the block height in the main chain for a given block hash.
-    pub(crate) async fn get_block_height(&self, hash: Hash) -> Result<Height, FinalisedStateError> {
+    pub(crate) async fn get_block_height(&self, hash: BlockHash) -> Result<Height, FinalisedStateError> {
         self.inner.get_block_height(hash).await
     }
 
     /// Fetch the block hash in the main chain for a given block height.
-    pub(crate) async fn get_block_hash(&self, height: Height) -> Result<Hash, FinalisedStateError> {
+    pub(crate) async fn get_block_hash(&self, height: Height) -> Result<BlockHash, FinalisedStateError> {
         self.inner.get_block_hash(height).await
     }
 
@@ -73,7 +73,7 @@ impl DbReader {
     /// Fetch the TxLocation for the given txid, transaction data is indexed by TxLocation internally.
     pub(crate) async fn get_tx_location(
         &self,
-        txid: &Hash,
+        txid: &BlockHash,
     ) -> Result<Option<TxLocation>, FinalisedStateError> {
         self.db(CapabilityRequest::BlockCoreExt)?
             .get_tx_location(txid)
@@ -105,7 +105,7 @@ impl DbReader {
     pub(crate) async fn get_txid(
         &self,
         tx_location: TxLocation,
-    ) -> Result<Hash, FinalisedStateError> {
+    ) -> Result<BlockHash, FinalisedStateError> {
         self.db(CapabilityRequest::BlockCoreExt)?
             .get_txid(tx_location)
             .await

--- a/zaino-state/src/chain_index/finalised_state/router.rs
+++ b/zaino-state/src/chain_index/finalised_state/router.rs
@@ -11,7 +11,7 @@ use super::{
 
 use crate::{
     chain_index::finalised_state::capability::CapabilityRequest, error::FinalisedStateError,
-    ChainBlock, BlockHash, Height, StatusType,
+    BlockHash, ChainBlock, Height, StatusType,
 };
 
 use arc_swap::{ArcSwap, ArcSwapOption};

--- a/zaino-state/src/chain_index/finalised_state/router.rs
+++ b/zaino-state/src/chain_index/finalised_state/router.rs
@@ -11,7 +11,7 @@ use super::{
 
 use crate::{
     chain_index::finalised_state::capability::CapabilityRequest, error::FinalisedStateError,
-    ChainBlock, Hash, Height, StatusType,
+    ChainBlock, BlockHash, Height, StatusType,
 };
 
 use arc_swap::{ArcSwap, ArcSwapOption};
@@ -188,13 +188,13 @@ impl DbRead for Router {
         self.backend(CapabilityRequest::ReadCore)?.db_height().await
     }
 
-    async fn get_block_height(&self, hash: Hash) -> Result<Height, FinalisedStateError> {
+    async fn get_block_height(&self, hash: BlockHash) -> Result<Height, FinalisedStateError> {
         self.backend(CapabilityRequest::ReadCore)?
             .get_block_height(hash)
             .await
     }
 
-    async fn get_block_hash(&self, h: Height) -> Result<Hash, FinalisedStateError> {
+    async fn get_block_hash(&self, h: Height) -> Result<BlockHash, FinalisedStateError> {
         self.backend(CapabilityRequest::ReadCore)?
             .get_block_hash(h)
             .await

--- a/zaino-state/src/chain_index/interface.rs
+++ b/zaino-state/src/chain_index/interface.rs
@@ -94,7 +94,7 @@ impl NodeBackedChainIndex {
         //TODO: finalized state, mempool
         snapshot.blocks.values().filter_map(move |block| {
             block.transactions().iter().find_map(|transaction| {
-                if *transaction.txid() == txid {
+                if transaction.txid().0 == txid {
                     Some(block)
                 } else {
                     None

--- a/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/zaino-state/src/chain_index/non_finalised_state.rs
@@ -233,8 +233,13 @@ impl NonFinalizedState {
                     .collect(),
             );
 
-            let txdata =
-                CompactTxData::new(i as u64, trnsctn.hash().0, transparent, sapling, orchard);
+            let txdata = CompactTxData::new(
+                i as u64,
+                trnsctn.hash().into(),
+                transparent,
+                sapling,
+                orchard,
+            );
             transactions.push(txdata);
         }
 
@@ -459,7 +464,7 @@ impl NonFinalizedState {
 
                     let txdata = CompactTxData::new(
                         i as u64,
-                        trnsctn.hash().0,
+                        trnsctn.hash().into(),
                         transparent,
                         sapling,
                         orchard,

--- a/zaino-state/src/chain_index/source.rs
+++ b/zaino-state/src/chain_index/source.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use crate::chain_index::types::Hash;
+use crate::chain_index::types::BlockHash;
 use async_trait::async_trait;
 use futures::future::join;
 use tower::Service;
@@ -26,7 +26,7 @@ pub trait BlockchainSource: Clone + Send + Sync + 'static {
     /// Returns the block commitment tree data by hash or height
     async fn get_commitment_tree_roots(
         &self,
-        id: Hash,
+        id: BlockHash,
     ) -> BlockchainSourceResult<(
         Option<(zebra_chain::sapling::tree::Root, u64)>,
         Option<(zebra_chain::orchard::tree::Root, u64)>,
@@ -100,7 +100,7 @@ impl ValidatorConnector {
 
     pub(super) async fn get_commitment_tree_roots(
         &self,
-        id: Hash,
+        id: BlockHash,
     ) -> BlockchainSourceResult<(
         Option<(zebra_chain::sapling::tree::Root, u64)>,
         Option<(zebra_chain::orchard::tree::Root, u64)>,
@@ -228,7 +228,7 @@ impl BlockchainSource for ValidatorConnector {
 
     async fn get_commitment_tree_roots(
         &self,
-        id: Hash,
+        id: BlockHash,
     ) -> BlockchainSourceResult<(
         Option<(zebra_chain::sapling::tree::Root, u64)>,
         Option<(zebra_chain::orchard::tree::Root, u64)>,
@@ -251,7 +251,7 @@ pub(crate) mod test {
     pub(crate) struct MockchainSource {
         blocks: Vec<Arc<Block>>,
         roots: Vec<(Option<(sapling::Root, u64)>, Option<(orchard::Root, u64)>)>,
-        hashes: Vec<Hash>,
+        hashes: Vec<BlockHash>,
     }
 
     impl MockchainSource {
@@ -261,7 +261,7 @@ pub(crate) mod test {
         pub(crate) fn new(
             blocks: Vec<Arc<Block>>,
             roots: Vec<(Option<(sapling::Root, u64)>, Option<(orchard::Root, u64)>)>,
-            hashes: Vec<Hash>,
+            hashes: Vec<BlockHash>,
         ) -> Self {
             assert!(
                 blocks.len() == roots.len() && roots.len() == hashes.len(),
@@ -325,7 +325,7 @@ pub(crate) mod test {
 
         async fn get_commitment_tree_roots(
             &self,
-            id: Hash,
+            id: BlockHash,
         ) -> BlockchainSourceResult<(Option<(sapling::Root, u64)>, Option<(orchard::Root, u64)>)>
         {
             let index = self.hashes.iter().position(|h| h == &id);

--- a/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -12,6 +12,7 @@ use crate::chain_index::finalised_state::ZainoDB;
 use crate::chain_index::source::test::MockchainSource;
 use crate::chain_index::tests::init_tracing;
 use crate::chain_index::tests::vectors::{build_mockchain_source, load_test_vectors};
+use crate::chain_index::types::TransactionHash;
 use crate::error::FinalisedStateError;
 use crate::{AddrScript, ChainBlock, ChainWork, Height, Outpoint};
 
@@ -899,7 +900,7 @@ async fn check_faucet_spent_map() {
         .zip(faucet_ouptpoints_spent_status.iter())
     {
         let outpoint_tuple = (
-            crate::BlockHash::from(*outpoint.prev_txid()).to_string(),
+            TransactionHash::from(*outpoint.prev_txid()).to_string(),
             outpoint.prev_index(),
         );
         match spender_option {
@@ -1035,7 +1036,7 @@ async fn check_recipient_spent_map() {
         .zip(recipient_ouptpoints_spent_status.iter())
     {
         let outpoint_tuple = (
-            crate::BlockHash::from(*outpoint.prev_txid()).to_string(),
+            TransactionHash::from(*outpoint.prev_txid()).to_string(),
             outpoint.prev_index(),
         );
         match spender_option {

--- a/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -545,7 +545,7 @@ async fn get_faucet_txids() {
         let block_txids: Vec<String> = chain_block
             .transactions()
             .iter()
-            .map(|tx_data| hex::encode(tx_data.txid()))
+            .map(|tx_data| tx_data.txid().to_string())
             .collect();
         let filtered_block_txids: Vec<String> = block_txids
             .into_iter()
@@ -643,7 +643,7 @@ async fn get_recipient_txids() {
         let block_txids: Vec<String> = chain_block
             .transactions()
             .iter()
-            .map(|tx_data| hex::encode(tx_data.txid()))
+            .map(|tx_data| tx_data.txid().to_string())
             .collect();
 
         // Get block txids that are relevant to recipient.
@@ -865,11 +865,11 @@ async fn check_faucet_spent_map() {
         parent_chain_work = *chain_block.index().chainwork();
 
         for tx in chain_block.transactions() {
-            let txid = tx.txid();
+            let txid = tx.txid().0;
             let outputs = tx.transparent().outputs();
             for (vout_idx, output) in outputs.iter().enumerate() {
                 if output.script_hash() == faucet_addr_script.hash() {
-                    let outpoint = Outpoint::new_from_be(txid, vout_idx as u32);
+                    let outpoint = Outpoint::new_from_be(&txid, vout_idx as u32);
 
                     let spender = db_reader.get_outpoint_spender(outpoint).await.unwrap();
 
@@ -1001,11 +1001,11 @@ async fn check_recipient_spent_map() {
         parent_chain_work = *chain_block.index().chainwork();
 
         for tx in chain_block.transactions() {
-            let txid = tx.txid();
+            let txid = tx.txid().0;
             let outputs = tx.transparent().outputs();
             for (vout_idx, output) in outputs.iter().enumerate() {
                 if output.script_hash() == recipient_addr_script.hash() {
-                    let outpoint = Outpoint::new_from_be(txid, vout_idx as u32);
+                    let outpoint = Outpoint::new_from_be(&txid, vout_idx as u32);
 
                     let spender = db_reader.get_outpoint_spender(outpoint).await.unwrap();
 

--- a/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -899,7 +899,7 @@ async fn check_faucet_spent_map() {
         .zip(faucet_ouptpoints_spent_status.iter())
     {
         let outpoint_tuple = (
-            crate::Hash::from(*outpoint.prev_txid()).to_string(),
+            crate::BlockHash::from(*outpoint.prev_txid()).to_string(),
             outpoint.prev_index(),
         );
         match spender_option {
@@ -1035,7 +1035,7 @@ async fn check_recipient_spent_map() {
         .zip(recipient_ouptpoints_spent_status.iter())
     {
         let outpoint_tuple = (
-            crate::Hash::from(*outpoint.prev_txid()).to_string(),
+            crate::BlockHash::from(*outpoint.prev_txid()).to_string(),
             outpoint.prev_index(),
         );
         match spender_option {

--- a/zaino-state/src/chain_index/types.rs
+++ b/zaino-state/src/chain_index/types.rs
@@ -103,14 +103,13 @@ impl From<zebra_chain::block::Hash> for BlockHash {
 
 impl From<BlockHash> for zcash_primitives::block::BlockHash {
     fn from(hash: BlockHash) -> Self {
-        // Convert to display order (big-endian)
-        zcash_primitives::block::BlockHash(hash.bytes_in_display_order())
+        zcash_primitives::block::BlockHash(hash.0)
     }
 }
 
 impl From<zcash_primitives::block::BlockHash> for BlockHash {
     fn from(hash: zcash_primitives::block::BlockHash) -> Self {
-        BlockHash::from_bytes_in_display_order(&hash.0)
+        BlockHash(hash.0)
     }
 }
 
@@ -221,14 +220,13 @@ impl From<zebra_chain::transaction::Hash> for TransactionHash {
 
 impl From<TransactionHash> for zcash_primitives::transaction::TxId {
     fn from(hash: TransactionHash) -> Self {
-        // Convert to display order (big-endian)
-        zcash_primitives::transaction::TxId::from_bytes(hash.bytes_in_display_order())
+        zcash_primitives::transaction::TxId::from_bytes(hash.0)
     }
 }
 
 impl From<zcash_primitives::transaction::TxId> for TransactionHash {
     fn from(hash: zcash_primitives::transaction::TxId) -> Self {
-        TransactionHash::from_bytes_in_display_order(&hash.into())
+        TransactionHash(hash.into())
     }
 }
 

--- a/zaino-state/src/chain_index/types.rs
+++ b/zaino-state/src/chain_index/types.rs
@@ -103,13 +103,14 @@ impl From<zebra_chain::block::Hash> for BlockHash {
 
 impl From<BlockHash> for zcash_primitives::block::BlockHash {
     fn from(hash: BlockHash) -> Self {
-        zcash_primitives::block::BlockHash(hash.0)
+        // Convert to display order (big-endian)
+        zcash_primitives::block::BlockHash(hash.bytes_in_display_order())
     }
 }
 
 impl From<zcash_primitives::block::BlockHash> for BlockHash {
     fn from(hash: zcash_primitives::block::BlockHash) -> Self {
-        BlockHash(hash.0)
+        BlockHash::from_bytes_in_display_order(&hash.0)
     }
 }
 
@@ -220,13 +221,14 @@ impl From<zebra_chain::transaction::Hash> for TransactionHash {
 
 impl From<TransactionHash> for zcash_primitives::transaction::TxId {
     fn from(hash: TransactionHash) -> Self {
-        zcash_primitives::transaction::TxId::from_bytes(hash.0)
+        // Convert to display order (big-endian)
+        zcash_primitives::transaction::TxId::from_bytes(hash.bytes_in_display_order())
     }
 }
 
 impl From<zcash_primitives::transaction::TxId> for TransactionHash {
     fn from(hash: zcash_primitives::transaction::TxId) -> Self {
-        TransactionHash(hash.into())
+        TransactionHash::from_bytes_in_display_order(&hash.into())
     }
 }
 

--- a/zaino-state/src/chain_index/types.rs
+++ b/zaino-state/src/chain_index/types.rs
@@ -541,7 +541,7 @@ impl Outpoint {
 
     /// Build from a *display-order* txid.
     pub fn new_from_be(txid_be: &[u8; 32], index: u32) -> Self {
-        let le = BlockHash::from_bytes_in_display_order(txid_be).0;
+        let le = TransactionHash::from_bytes_in_display_order(txid_be).0;
         Self::new(le, index)
     }
 
@@ -2993,18 +2993,18 @@ impl ZainoVersionedSerialise for BlockHeaderData {
 #[cfg_attr(test, derive(serde::Serialize, serde::Deserialize))]
 pub struct TxidList {
     /// Txids.
-    tx: Vec<BlockHash>,
+    txids: Vec<TransactionHash>,
 }
 
 impl TxidList {
     /// Creates a new `TxidList`.
-    pub fn new(tx: Vec<BlockHash>) -> Self {
-        Self { tx }
+    pub fn new(tx: Vec<TransactionHash>) -> Self {
+        Self { txids: tx }
     }
 
     /// Returns a slice of the contained txids.
-    pub fn tx(&self) -> &[BlockHash] {
-        &self.tx
+    pub fn txids(&self) -> &[TransactionHash] {
+        &self.txids
     }
 }
 
@@ -3012,7 +3012,7 @@ impl ZainoVersionedSerialise for TxidList {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        write_vec(w, &self.tx, |w, h| h.serialize(w))
+        write_vec(w, &self.txids, |w, h| h.serialize(w))
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -3020,7 +3020,7 @@ impl ZainoVersionedSerialise for TxidList {
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
-        let tx = read_vec(r, |r| BlockHash::deserialize(r))?;
+        let tx = read_vec(r, |r| TransactionHash::deserialize(r))?;
         Ok(TxidList::new(tx))
     }
 }

--- a/zaino-state/src/chain_index/types.rs
+++ b/zaino-state/src/chain_index/types.rs
@@ -22,9 +22,9 @@ use super::encoding::{
 /// Block hash (SHA256d hash of the block header).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(test, derive(serde::Serialize, serde::Deserialize))]
-pub struct Hash(pub [u8; 32]);
+pub struct BlockHash(pub [u8; 32]);
 
-impl Hash {
+impl BlockHash {
     /// Return the hash bytes in big-endian byte-order suitable for printing out byte by byte.
     pub fn bytes_in_display_order(&self) -> [u8; 32] {
         let mut reversed_bytes = self.0;
@@ -32,22 +32,22 @@ impl Hash {
         reversed_bytes
     }
 
-    /// Convert bytes in big-endian byte-order into a [`block::Hash`](crate::Hash).
-    pub fn from_bytes_in_display_order(bytes_in_display_order: &[u8; 32]) -> Hash {
+    /// Convert bytes in big-endian byte-order into a [`self::BlockHash`].
+    pub fn from_bytes_in_display_order(bytes_in_display_order: &[u8; 32]) -> BlockHash {
         let mut internal_byte_order = *bytes_in_display_order;
         internal_byte_order.reverse();
 
-        Hash(internal_byte_order)
+        BlockHash(internal_byte_order)
     }
 }
 
-impl fmt::Display for Hash {
+impl fmt::Display for BlockHash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(&self.encode_hex::<String>())
     }
 }
 
-impl ToHex for &Hash {
+impl ToHex for &BlockHash {
     fn encode_hex<T: FromIterator<char>>(&self) -> T {
         self.bytes_in_display_order().encode_hex()
     }
@@ -57,7 +57,7 @@ impl ToHex for &Hash {
     }
 }
 
-impl ToHex for Hash {
+impl ToHex for BlockHash {
     fn encode_hex<T: FromIterator<char>>(&self) -> T {
         (&self).encode_hex()
     }
@@ -67,7 +67,7 @@ impl ToHex for Hash {
     }
 }
 
-impl FromHex for Hash {
+impl FromHex for BlockHash {
     type Error = <[u8; 32] as FromHex>::Error;
 
     fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
@@ -77,44 +77,43 @@ impl FromHex for Hash {
     }
 }
 
-impl From<[u8; 32]> for Hash {
+impl From<[u8; 32]> for BlockHash {
     fn from(bytes: [u8; 32]) -> Self {
-        Hash(bytes)
+        BlockHash(bytes)
     }
 }
 
-impl From<Hash> for [u8; 32] {
-    fn from(hash: Hash) -> Self {
+impl From<BlockHash> for [u8; 32] {
+    fn from(hash: BlockHash) -> Self {
         hash.0
     }
 }
 
-impl From<Hash> for zebra_chain::block::Hash {
-    fn from(h: Hash) -> Self {
-        zebra_chain::block::Hash(h.0)
+impl From<BlockHash> for zebra_chain::block::Hash {
+    fn from(hash: BlockHash) -> Self {
+        zebra_chain::block::Hash(hash.0)
     }
 }
 
-impl From<zebra_chain::block::Hash> for Hash {
-    fn from(h: zebra_chain::block::Hash) -> Self {
-        Hash(h.0)
+impl From<zebra_chain::block::Hash> for BlockHash {
+    fn from(hash: zebra_chain::block::Hash) -> Self {
+        BlockHash(hash.0)
     }
 }
 
-impl From<Hash> for zcash_primitives::block::BlockHash {
-    fn from(h: Hash) -> Self {
-        // Convert to display order (big-endian)
-        zcash_primitives::block::BlockHash(h.bytes_in_display_order())
+impl From<BlockHash> for zcash_primitives::block::BlockHash {
+    fn from(hash: BlockHash) -> Self {
+        zcash_primitives::block::BlockHash(hash.0)
     }
 }
 
-impl From<zcash_primitives::block::BlockHash> for Hash {
-    fn from(h: zcash_primitives::block::BlockHash) -> Self {
-        Hash::from_bytes_in_display_order(&h.0)
+impl From<zcash_primitives::block::BlockHash> for BlockHash {
+    fn from(hash: zcash_primitives::block::BlockHash) -> Self {
+        BlockHash(hash.0)
     }
 }
 
-impl ZainoVersionedSerialise for Hash {
+impl ZainoVersionedSerialise for BlockHash {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -127,12 +126,129 @@ impl ZainoVersionedSerialise for Hash {
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
         let bytes = read_fixed_le::<32, _>(r)?;
-        Ok(Hash(bytes))
+        Ok(BlockHash(bytes))
     }
 }
 
 /// Hash = 32-byte body.
-impl FixedEncodedLen for Hash {
+impl FixedEncodedLen for BlockHash {
+    /// 32 bytes, LE
+    const ENCODED_LEN: usize = 32;
+}
+
+/// Transaction hash.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(test, derive(serde::Serialize, serde::Deserialize))]
+pub struct TransactionHash(pub [u8; 32]);
+
+impl TransactionHash {
+    /// Return the hash bytes in big-endian byte-order suitable for printing out byte by byte.
+    pub fn bytes_in_display_order(&self) -> [u8; 32] {
+        let mut reversed_bytes = self.0;
+        reversed_bytes.reverse();
+        reversed_bytes
+    }
+
+    /// Convert bytes in big-endian byte-order into a [`self::TransactionHash`].
+    pub fn from_bytes_in_display_order(bytes_in_display_order: &[u8; 32]) -> TransactionHash {
+        let mut internal_byte_order = *bytes_in_display_order;
+        internal_byte_order.reverse();
+
+        TransactionHash(internal_byte_order)
+    }
+}
+
+impl fmt::Display for TransactionHash {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.encode_hex::<String>())
+    }
+}
+
+impl ToHex for &TransactionHash {
+    fn encode_hex<T: FromIterator<char>>(&self) -> T {
+        self.bytes_in_display_order().encode_hex()
+    }
+
+    fn encode_hex_upper<T: FromIterator<char>>(&self) -> T {
+        self.bytes_in_display_order().encode_hex_upper()
+    }
+}
+
+impl ToHex for TransactionHash {
+    fn encode_hex<T: FromIterator<char>>(&self) -> T {
+        (&self).encode_hex()
+    }
+
+    fn encode_hex_upper<T: FromIterator<char>>(&self) -> T {
+        (&self).encode_hex_upper()
+    }
+}
+
+impl FromHex for TransactionHash {
+    type Error = <[u8; 32] as FromHex>::Error;
+
+    fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
+        let hash = <[u8; 32]>::from_hex(hex)?;
+
+        Ok(Self::from_bytes_in_display_order(&hash))
+    }
+}
+
+impl From<[u8; 32]> for TransactionHash {
+    fn from(bytes: [u8; 32]) -> Self {
+        TransactionHash(bytes)
+    }
+}
+
+impl From<TransactionHash> for [u8; 32] {
+    fn from(hash: TransactionHash) -> Self {
+        hash.0
+    }
+}
+
+impl From<TransactionHash> for zebra_chain::transaction::Hash {
+    fn from(hash: TransactionHash) -> Self {
+        zebra_chain::transaction::Hash(hash.0)
+    }
+}
+
+impl From<zebra_chain::transaction::Hash> for TransactionHash {
+    fn from(hash: zebra_chain::transaction::Hash) -> Self {
+        TransactionHash(hash.0)
+    }
+}
+
+impl From<TransactionHash> for zcash_primitives::transaction::TxId {
+    fn from(hash: TransactionHash) -> Self {
+        zcash_primitives::transaction::TxId::from_bytes(hash.0)
+    }
+}
+
+impl From<zcash_primitives::transaction::TxId> for TransactionHash {
+    fn from(hash: zcash_primitives::transaction::TxId) -> Self {
+        TransactionHash(hash.into())
+    }
+}
+
+impl ZainoVersionedSerialise for TransactionHash {
+    const VERSION: u8 = version::V1;
+
+    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        write_fixed_le::<32, _>(w, &self.0)
+    }
+
+    fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
+        Self::decode_v1(r)
+    }
+
+    fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
+        let bytes = read_fixed_le::<32, _>(r)?;
+        Ok(TransactionHash(bytes))
+    }
+}
+
+/// Hash = 32-byte body.
+impl FixedEncodedLen for TransactionHash {
     /// 32 bytes, LE
     const ENCODED_LEN: usize = 32;
 }
@@ -425,7 +541,7 @@ impl Outpoint {
 
     /// Build from a *display-order* txid.
     pub fn new_from_be(txid_be: &[u8; 32], index: u32) -> Self {
-        let le = Hash::from_bytes_in_display_order(txid_be).0;
+        let le = BlockHash::from_bytes_in_display_order(txid_be).0;
         Self::new(le, index)
     }
 
@@ -474,9 +590,9 @@ impl FixedEncodedLen for Outpoint {
 #[cfg_attr(test, derive(serde::Serialize, serde::Deserialize))]
 pub struct BlockIndex {
     /// The hash identifying this block uniquely.
-    pub(super) hash: Hash,
+    pub(super) hash: BlockHash,
     /// The hash of this block's parent block (previous block in chain).
-    pub(super) parent_hash: Hash,
+    pub(super) parent_hash: BlockHash,
     /// The cumulative proof-of-work of the blockchain up to this block, used for chain selection.
     pub(super) chainwork: ChainWork,
     /// The height of this block if it's in the current best chain. None if it's part of a fork.
@@ -486,8 +602,8 @@ pub struct BlockIndex {
 impl BlockIndex {
     /// Constructs a new `BlockIndex`.
     pub fn new(
-        hash: Hash,
-        parent_hash: Hash,
+        hash: BlockHash,
+        parent_hash: BlockHash,
         chainwork: ChainWork,
         height: Option<Height>,
     ) -> Self {
@@ -500,12 +616,12 @@ impl BlockIndex {
     }
 
     /// Returns the hash of this block.
-    pub fn hash(&self) -> &Hash {
+    pub fn hash(&self) -> &BlockHash {
         &self.hash
     }
 
     /// Returns the hash of the parent block.
-    pub fn parent_hash(&self) -> &Hash {
+    pub fn parent_hash(&self) -> &BlockHash {
         &self.parent_hash
     }
 
@@ -544,8 +660,8 @@ impl ZainoVersionedSerialise for BlockIndex {
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
         let mut r = r;
-        let hash = Hash::deserialize(&mut r)?;
-        let parent_hash = Hash::deserialize(&mut r)?;
+        let hash = BlockHash::deserialize(&mut r)?;
+        let parent_hash = BlockHash::deserialize(&mut r)?;
         let chainwork = ChainWork::deserialize(&mut r)?;
         let height = read_option(&mut r, |r| Height::deserialize(r))?;
 
@@ -1125,7 +1241,7 @@ impl ChainBlock {
     }
 
     /// Returns the block hash.
-    pub fn hash(&self) -> &Hash {
+    pub fn hash(&self) -> &BlockHash {
         self.index.hash()
     }
 
@@ -1320,8 +1436,8 @@ impl
 
         // --- Final index and block data ---
         let index = BlockIndex::new(
-            Hash::from(hash),
-            Hash::from(parent_hash),
+            BlockHash::from(hash),
+            BlockHash::from(parent_hash),
             chainwork,
             Some(height),
         );
@@ -1483,8 +1599,8 @@ impl
             transactions.push(txdata);
         }
 
-        let hash = Hash::from(block.hash());
-        let parent_hash = Hash::from(block.header.previous_block_hash);
+        let hash = BlockHash::from(block.hash());
+        let parent_hash = BlockHash::from(block.header.previous_block_hash);
 
         let coinbase_tx_height = block
             .coinbase_height()
@@ -2877,17 +2993,17 @@ impl ZainoVersionedSerialise for BlockHeaderData {
 #[cfg_attr(test, derive(serde::Serialize, serde::Deserialize))]
 pub struct TxidList {
     /// Txids.
-    tx: Vec<Hash>,
+    tx: Vec<BlockHash>,
 }
 
 impl TxidList {
     /// Creates a new `TxidList`.
-    pub fn new(tx: Vec<Hash>) -> Self {
+    pub fn new(tx: Vec<BlockHash>) -> Self {
         Self { tx }
     }
 
     /// Returns a slice of the contained txids.
-    pub fn tx(&self) -> &[Hash] {
+    pub fn tx(&self) -> &[BlockHash] {
         &self.tx
     }
 }
@@ -2904,7 +3020,7 @@ impl ZainoVersionedSerialise for TxidList {
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
-        let tx = read_vec(r, |r| Hash::deserialize(r))?;
+        let tx = read_vec(r, |r| BlockHash::deserialize(r))?;
         Ok(TxidList::new(tx))
     }
 }

--- a/zaino-state/src/error.rs
+++ b/zaino-state/src/error.rs
@@ -1,6 +1,6 @@
 //! Holds error types for Zaino-state.
 
-use crate::Hash;
+use crate::BlockHash;
 
 use std::{any::type_name, fmt::Display};
 
@@ -426,7 +426,7 @@ pub enum FinalisedStateError {
     #[error("invalid block @ height {height} (hash {hash}): {reason}")]
     InvalidBlock {
         height: u32,
-        hash: Hash,
+        hash: BlockHash,
         reason: String,
     },
 

--- a/zaino-state/src/lib.rs
+++ b/zaino-state/src/lib.rs
@@ -37,9 +37,9 @@ pub use chain_index::non_finalised_state::{
 };
 // NOTE: Should these be pub at all?
 pub use chain_index::types::{
-    AddrHistRecord, AddrScript, BlockData, BlockHeaderData, BlockIndex, ChainBlock, ChainWork,
-    CommitmentTreeData, CommitmentTreeRoots, CommitmentTreeSizes, CompactOrchardAction,
-    CompactSaplingOutput, CompactSaplingSpend, CompactTxData, Hash, Height, OrchardCompactTx,
+    AddrHistRecord, AddrScript, BlockData, BlockHash, BlockHeaderData, BlockIndex, ChainBlock,
+    ChainWork, CommitmentTreeData, CommitmentTreeRoots, CommitmentTreeSizes, CompactOrchardAction,
+    CompactSaplingOutput, CompactSaplingSpend, CompactTxData, Height, OrchardCompactTx,
     OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList, ScriptType, ShardIndex, ShardRoot,
     TransparentCompactTx, TransparentTxList, TxInCompact, TxLocation, TxOutCompact, TxidList,
 };

--- a/zaino-state/src/local_cache/finalised_state.rs
+++ b/zaino-state/src/local_cache/finalised_state.rs
@@ -103,9 +103,9 @@ pub struct FinalisedState {
     state: Option<ReadStateService>,
     /// LMDB Database Environmant.
     database: Arc<Environment>,
-    /// LMDB Databas containing `<block_height, block_hash>`.
+    /// LMDB Database containing `<block_height, block_hash>`.
     heights_to_hashes: Database,
-    /// LMDB Databas containing `<block_hash, compact_block>`.
+    /// LMDB Database containing `<block_hash, compact_block>`.
     hashes_to_blocks: Database,
     /// Database reader request sender.
     request_sender: tokio::sync::mpsc::Sender<DbRequest>,


### PR DESCRIPTION


## Motivation

ChainBlock currently holds BE txids, but should hold them in LE byte order.

## Solution

Update byte order in ChainBlock.

### Tests

No, uses current tests

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
