### PR TITLE
use derived deser for automatic hex encode/decode, remove hex transfromation from tryfrom

### DIFF
--- a/zaino-fetch/src/jsonrpsee/response.rs
+++ b/zaino-fetch/src/jsonrpsee/response.rs
@@ -1,4 +1,7 @@
-//! Response types for jsonRPC client.
+//! Response types for jsonRPSeeConnector.
+//!
+//! These types are redefined rather than imported from zebra_rpc
+//! to prevent locking consumers into a zebra_rpc version
 
 use std::{convert::Infallible, num::ParseIntError};
 


### PR DESCRIPTION
## Motivation
Fixes #495 

## Solution

We now rely on derived deserialization, which ensures that `zebra_rpc::client::Treestate`s are serialized and deserialized as intended. We also remove the hex-decoding when transforming between GetTreestateResponse types, as that is handled automatically at serialization time. 
