### PR TITLE
Fix `FetchServiceSubscriber::get_latest_block`

### DIFF
--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -578,12 +578,11 @@ impl LightWalletIndexer for FetchServiceSubscriber {
     /// Return the height of the tip of the best chain
     async fn get_latest_block(&self) -> Result<BlockId, Self::Error> {
         let latest_height = self.block_cache.get_chain_height().await?;
-        let mut latest_hash = self
+        let latest_hash = self
             .block_cache
             .get_compact_block(latest_height.0.to_string())
             .await?
             .hash;
-        latest_hash.reverse();
 
         Ok(BlockId {
             height: latest_height.0 as u64,


### PR DESCRIPTION
This likely doesn't solve the underlying problem, but fixes the immediate issue sufficiently for Zallet to be functional again.

Part of zingolabs/zaino#521.

<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

## Solution

<!-- Describe the changes in the PR. -->

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
