### PR TITLE
Fix get latest block

### DIFF
--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -5,8 +5,8 @@ use zaino_proto::proto::service::{
     TransparentAddressBlockFilter, TxFilter,
 };
 use zaino_state::{
-    BackendType, BlockHash, FetchService, FetchServiceConfig, FetchServiceSubscriber,
-    LightWalletIndexer, StatusType, ZcashIndexer, ZcashService as _,
+    BackendType, FetchService, FetchServiceConfig, FetchServiceSubscriber, LightWalletIndexer,
+    StatusType, ZcashIndexer, ZcashService as _,
 };
 use zaino_testutils::Validator as _;
 use zaino_testutils::{TestManager, ValidatorKind};

--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -569,11 +569,7 @@ async fn fetch_service_get_latest_block(validator: &ValidatorKind) {
 
     let json_service_get_latest_block = dbg!(BlockId {
         height: json_service_blockchain_info.blocks.0 as u64,
-        hash: BlockHash::from_bytes_in_display_order(
-            &json_service_blockchain_info.best_block_hash.0
-        )
-        .0
-        .to_vec(),
+        hash: json_service_blockchain_info.best_block_hash.0.to_vec(),
     });
 
     assert_eq!(fetch_service_get_latest_block.height, 2);

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -1070,11 +1070,7 @@ mod zebrad {
             for _ in 0..5 {
                 test_manager.generate_blocks_with_delay(1).await;
                 assert_eq!(
-                    chaintip_subscriber
-                        .next_tip_hash()
-                        .await
-                        .unwrap()
-                        .bytes_in_display_order(),
+                    chaintip_subscriber.next_tip_hash().await.unwrap().0,
                     <[u8; 32]>::try_from(
                         state_service_subscriber
                             .get_latest_block()

--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -578,12 +578,11 @@ impl LightWalletIndexer for FetchServiceSubscriber {
     /// Return the height of the tip of the best chain
     async fn get_latest_block(&self) -> Result<BlockId, Self::Error> {
         let latest_height = self.block_cache.get_chain_height().await?;
-        let mut latest_hash = self
+        let latest_hash = self
             .block_cache
             .get_compact_block(latest_height.0.to_string())
             .await?
             .hash;
-        latest_hash.reverse();
 
         Ok(BlockId {
             height: latest_height.0 as u64,

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -1516,9 +1516,7 @@ impl LightWalletIndexer for StateServiceSubscriber {
         )?;
         Ok(BlockId {
             height: chain_height.as_usize() as u64,
-            hash: BlockHash::from_bytes_in_display_order(&chain_hash.0)
-                .0
-                .to_vec(),
+            hash: chain_hash.0.to_vec(),
         })
     }
 

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -17,7 +17,7 @@ use crate::{
         UtxoReplyStream,
     },
     utils::{blockid_to_hashorheight, get_build_info, ServiceMetadata},
-    BlockHash, MempoolKey,
+    MempoolKey,
 };
 
 use nonempty::NonEmpty;


### PR DESCRIPTION
Fixes get_latest_lock

## Motivation

get_latest_block returns block hash bytes in the wrong order.

Closes #521

## Solution

Update FetchService, StateService and tests

### Tests


### Specifications & References


### Follow-up Work


### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
