### PR TITLE
build(deps)!: remove `zingo-infra-testutils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6124,7 +6124,7 @@ dependencies = [
  "zcash_protocol 0.5.4",
  "zebra-chain 2.0.0",
  "zingo-infra-services",
- "zingo-infra-testutils",
+ "zingo-netutils",
  "zingolib",
 ]
 
@@ -7141,27 +7141,6 @@ dependencies = [
  "zebra-chain 1.0.0-beta.46",
  "zebra-node-services 1.0.0-beta.46",
  "zebra-rpc 1.0.0-beta.46",
-]
-
-[[package]]
-name = "zingo-infra-testutils"
-version = "0.1.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?rev=7509a6d26c6424b2e22585fabd0bb974bff6bf55#7509a6d26c6424b2e22585fabd0bb974bff6bf55"
-dependencies = [
- "http",
- "portpicker",
- "tempfile",
- "testvectors",
- "tokio",
- "tokio-stream",
- "tonic",
- "tracing-subscriber",
- "zcash_client_backend",
- "zcash_primitives 0.22.1",
- "zcash_protocol 0.5.4",
- "zingo-infra-services",
- "zingo-netutils",
- "zingolib",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
     "zaino-state",
     "zaino-fetch",
     "zaino-proto",
-    "zaino-testvectors"
+    "zaino-testvectors",
 ]
 
 # Use the edition 2021 dependency resolver in the workspace, to match the crates
@@ -30,8 +30,8 @@ version = "0.1.2"
 zingolib = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0.0-beta2", features = [
     "test-elevation",
 ] }
+
 testvectors = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0.0-beta2" }
-zingo-infra-testutils = { git = "https://github.com/zingolabs/infrastructure.git", rev = "7509a6d26c6424b2e22585fabd0bb974bff6bf55" }
 zingo-infra-services = { git = "https://github.com/zingolabs/infrastructure.git", rev = "7509a6d26c6424b2e22585fabd0bb974bff6bf55" }
 
 # Librustzcash

--- a/zaino-testutils/Cargo.toml
+++ b/zaino-testutils/Cargo.toml
@@ -23,7 +23,6 @@ zebra-chain = { workspace = true }
 
 # Zingo-infra
 zingo-infra-services = { workspace = true }
-zingo-infra-testutils = { workspace = true }
 
 # ZingoLib
 zingolib = { workspace = true }
@@ -31,7 +30,11 @@ testvectors = { workspace = true }
 
 # Tracing
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["fmt", "env-filter", "time"] }
+tracing-subscriber = { workspace = true, features = [
+    "fmt",
+    "env-filter",
+    "time",
+] }
 tracing-futures = { workspace = true }
 
 # Miscellaneous
@@ -54,3 +57,5 @@ once_cell = { workspace = true }
 proptest = { workspace = true }
 lazy_static = "1.5.0"
 
+[dev-dependencies]
+zingo-netutils = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0.0-beta2" }

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -725,11 +725,19 @@ impl Drop for TestManager {
 #[cfg(test)]
 mod launch_testmanager {
 
+    use zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient;
+    use zingo_netutils::{GetClientError, GrpcConnector, UnderlyingService};
+
     use super::*;
 
-    mod zcashd {
+    /// Builds a client for creating RPC requests to the indexer/light-node
+    async fn build_client(
+        uri: http::Uri,
+    ) -> Result<CompactTxStreamerClient<UnderlyingService>, GetClientError> {
+        GrpcConnector::new(uri).get_client().await
+    }
 
-        use zingo_infra_testutils::client::build_client;
+    mod zcashd {
 
         use super::*;
 
@@ -906,10 +914,10 @@ mod launch_testmanager {
     }
 
     mod zebrad {
+
         use super::*;
 
         mod fetch_service {
-            use zingo_infra_testutils::client::build_client;
 
             use super::*;
 
@@ -1199,7 +1207,6 @@ mod launch_testmanager {
         }
 
         mod state_service {
-            use zingo_infra_testutils::client::build_client;
 
             use super::*;
 


### PR DESCRIPTION
## Motivation

Dependencies are too entangled. We're removing `testutils` from infrastructure, and zaino is currently pulling it as a dependency.

## Solution

Move utilities used by zaino here.

### Tests

Ran with the following versions:

```bash
lightwalletd version:  v0.4.18

Zcash Daemon version v6.3.0-b65b008a7-dirty

zebrad 2.5.0
```

### Remaining Work

https://github.com/zingolabs/infrastructure/pull/109

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
