### PR TITLE
Update get transaction

### DIFF
--- a/zaino-state/src/chain_index.rs
+++ b/zaino-state/src/chain_index.rs
@@ -23,6 +23,7 @@ use source::{BlockchainSource, ValidatorConnector};
 use tokio_stream::StreamExt;
 use tracing::info;
 use types::ChainBlock;
+use zebra_chain::parameters::ConsensusBranchId;
 pub use zebra_chain::parameters::Network as ZebraNetwork;
 use zebra_chain::serialization::ZcashSerialize;
 use zebra_state::HashOrHeight;
@@ -193,12 +194,13 @@ pub trait ChainIndex {
         block_hash: &types::BlockHash,
     ) -> Result<Option<(types::BlockHash, types::Height)>, Self::Error>;
 
-    /// given a transaction id, returns the transaction
+    /// given a transaction id, returns the transaction, along with
+    /// its consensus branch ID if available
     fn get_raw_transaction(
         &self,
         snapshot: &Self::Snapshot,
         txid: &types::TransactionHash,
-    ) -> impl std::future::Future<Output = Result<Option<Vec<u8>>, Self::Error>>;
+    ) -> impl std::future::Future<Output = Result<Option<(Vec<u8>, Option<u32>)>, Self::Error>>;
 
     /// Given a transaction ID, returns all known hashes and heights of blocks
     /// containing that transaction. Height is None for blocks not on the best chain.
@@ -661,19 +663,34 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
         }
     }
 
-    /// given a transaction id, returns the transaction
     async fn get_raw_transaction(
         &self,
         snapshot: &Self::Snapshot,
         txid: &types::TransactionHash,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
+    ) -> Result<Option<(Vec<u8>, Option<u32>)>, Self::Error> {
         if let Some(mempool_tx) = self
             .mempool
             .get_transaction(&mempool::MempoolKey(txid.to_string()))
             .await
         {
             let bytes = mempool_tx.0.as_ref().as_ref().to_vec();
-            return Ok(Some(bytes));
+            let mempool_height = snapshot
+                .blocks
+                .iter()
+                .find(|(hash, _block)| **hash == self.mempool.mempool_chain_tip())
+                .map(|(_hash, block)| block.height())
+                .flatten();
+            let mempool_branch_id = mempool_height
+                .map(|height| {
+                    ConsensusBranchId::current(
+                        &self.non_finalized_state.network,
+                        zebra_chain::block::Height::from(height + 1),
+                    )
+                    .map(u32::from)
+                })
+                .flatten();
+
+            return Ok(Some((bytes, mempool_branch_id)));
         }
 
         let Some(block) = self
@@ -698,6 +715,14 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
             .await
             .map_err(ChainIndexError::backing_validator)?
             .ok_or_else(|| ChainIndexError::database_hole(block.index().hash()))?;
+        let block_consensus_branch_id = full_block
+            .coinbase_height()
+            .map(|height| {
+                ConsensusBranchId::current(&self.non_finalized_state.network, dbg!(height))
+                    .map(u32::from)
+            })
+            .flatten();
+        dbg!(block_consensus_branch_id);
         full_block
             .transactions
             .iter()
@@ -708,6 +733,7 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
             .map(ZcashSerialize::zcash_serialize_to_vec)
             .ok_or_else(|| ChainIndexError::database_hole(block.index().hash()))?
             .map_err(ChainIndexError::backing_validator)
+            .map(|transaction| (transaction, block_consensus_branch_id))
             .map(Some)
     }
 

--- a/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/zaino-state/src/chain_index/non_finalised_state.rs
@@ -28,7 +28,7 @@ pub struct NonFinalizedState<Source: BlockchainSource> {
     /// without interfering with readers, who will hold a stale copy
     current: ArcSwap<NonfinalizedBlockCacheSnapshot>,
     /// Used mostly to determine activation heights
-    network: Network,
+    pub(crate) network: Network,
     /// Listener used to detect non-best-chain blocks, if available
     #[allow(clippy::type_complexity)]
     nfs_change_listener: Option<

--- a/zaino-state/src/chain_index/tests.rs
+++ b/zaino-state/src/chain_index/tests.rs
@@ -136,10 +136,13 @@ mod mockchain_tests {
         let (blocks, _indexer, index_reader, _mockchain) =
             load_test_vectors_and_sync_chain_index(false).await;
         let nonfinalized_snapshot = index_reader.snapshot_nonfinalized_state();
-        for expected_transaction in blocks
-            .into_iter()
-            .flat_map(|block| block.3.transactions.into_iter())
-        {
+        for (expected_transaction, height) in blocks.into_iter().flat_map(|block| {
+            block
+                .3
+                .transactions
+                .into_iter()
+                .map(move |transaction| (transaction, block.0))
+        }) {
             let (transaction, branch_id) = index_reader
                 .get_raw_transaction(
                     &nonfinalized_snapshot,
@@ -154,9 +157,13 @@ mod mockchain_tests {
             assert_eq!(expected_transaction.as_ref(), &zaino_transaction);
             assert_eq!(
                 branch_id,
-                zebra_chain::parameters::NetworkUpgrade::Nu6
-                    .branch_id()
-                    .map(u32::from)
+                if height == 0 {
+                    None
+                } else {
+                    zebra_chain::parameters::NetworkUpgrade::Nu6
+                        .branch_id()
+                        .map(u32::from)
+                }
             );
         }
     }

--- a/zaino-state/src/chain_index/tests.rs
+++ b/zaino-state/src/chain_index/tests.rs
@@ -140,17 +140,24 @@ mod mockchain_tests {
             .into_iter()
             .flat_map(|block| block.3.transactions.into_iter())
         {
-            let zaino_transaction = index_reader
+            let (transaction, branch_id) = index_reader
                 .get_raw_transaction(
                     &nonfinalized_snapshot,
                     &TransactionHash::from(expected_transaction.hash()),
                 )
                 .await
                 .unwrap()
-                .unwrap()
+                .unwrap();
+            let zaino_transaction = transaction
                 .zcash_deserialize_into::<zebra_chain::transaction::Transaction>()
                 .unwrap();
-            assert_eq!(expected_transaction.as_ref(), &zaino_transaction)
+            assert_eq!(expected_transaction.as_ref(), &zaino_transaction);
+            assert_eq!(
+                branch_id,
+                zebra_chain::parameters::NetworkUpgrade::Nu6
+                    .branch_id()
+                    .map(u32::from)
+            );
         }
     }
 
@@ -235,17 +242,24 @@ mod mockchain_tests {
 
         let nonfinalized_snapshot = index_reader.snapshot_nonfinalized_state();
         for expected_transaction in mempool_transactions.into_iter() {
-            let zaino_transaction = index_reader
+            let (transaction, branch_id) = index_reader
                 .get_raw_transaction(
                     &nonfinalized_snapshot,
                     &TransactionHash::from(expected_transaction.hash()),
                 )
                 .await
                 .unwrap()
-                .unwrap()
+                .unwrap();
+            let zaino_transaction = transaction
                 .zcash_deserialize_into::<zebra_chain::transaction::Transaction>()
                 .unwrap();
-            assert_eq!(expected_transaction.as_ref(), &zaino_transaction)
+            assert_eq!(expected_transaction.as_ref(), &zaino_transaction);
+            assert_eq!(
+                branch_id,
+                zebra_chain::parameters::NetworkUpgrade::Nu6
+                    .branch_id()
+                    .map(u32::from)
+            );
         }
     }
 


### PR DESCRIPTION


## Motivation

Fixes #520 

## Solution

Adds an optional consensus branch id u32 as a return type to get_raw_transaction. 

### Tests

Updated get_raw_transaction tests to assert we return the latest consensus branch ID, except the genesis block (which has no ID).


### PR Checklist

<!-- Check as many boxes as possible. -->

- [*] The PR name is suitable for the release notes.
- [*] The solution is tested.
- [*] The documentation is up to date.
