### PR TITLE
height is not currently a correct indicator of whether the BlockIndex's block is on the best chain

### DIFF
--- a/zaino-state/src/chain_index/types.rs
+++ b/zaino-state/src/chain_index/types.rs
@@ -637,11 +637,6 @@ impl BlockIndex {
     pub fn height(&self) -> Option<Height> {
         self.height
     }
-
-    /// Returns true if this block is part of the best chain.
-    pub fn is_on_best_chain(&self) -> bool {
-        self.height.is_some()
-    }
 }
 
 impl ZainoVersionedSerialise for BlockIndex {
@@ -1251,11 +1246,6 @@ impl IndexedBlock {
     /// Returns the block height if available.
     pub fn height(&self) -> Option<Height> {
         self.index.height()
-    }
-
-    /// Returns true if this block is part of the best chain.
-    pub fn is_on_best_chain(&self) -> bool {
-        self.index.is_on_best_chain()
     }
 
     /// Returns the cumulative chainwork.


### PR DESCRIPTION
## Motivation

Height of the IndexedBlock is not an indicator of presence on the best chain. There may be more to this...but this is an unused function that can be cleanly removed.



### Follow-up Work

It's possible height is being relied on somewhere where it shouldn't be. 

