### PR TITLE
getter fn for AtomicStatus

### DIFF
--- a/zaino-state/src/status.rs
+++ b/zaino-state/src/status.rs
@@ -34,7 +34,12 @@ impl AtomicStatus {
 
     /// Loads the value held in the AtomicStatus
     pub fn load(&self) -> usize {
-        self.counter.load(Ordering::SeqCst)
+        self.counter().load(Ordering::SeqCst)
+    }
+
+    /// Getter for the counter field
+    pub fn counter(&self) -> &Arc<AtomicUsize> {
+        &self.counter
     }
 
     /// Sets the value held in the AtomicStatus


### PR DESCRIPTION
following #544 

This sets the getter pattern as a impl on AtomicStatus

IIUC, another thing we were interested in looking at here was the elimination of using integers for StatusTypes, if possible. I could add that work on top of this PR or open another.