### PR TITLE
Workspace dependencies do not include zingolib.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,6 @@ version = "0.1.2"
 
 [workspace.dependencies]
 # Zingolabs
-# Should be updated to crates.io releases when available.
-zingolib = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0.0-beta2", features = [
-    "test-elevation",
-] }
 
 testvectors = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0.0-beta2" }
 zingo-infra-services = { git = "https://github.com/zingolabs/infrastructure.git", rev = "7509a6d26c6424b2e22585fabd0bb974bff6bf55" }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -7,6 +7,7 @@ homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 version = { workspace = true }
+publish = false
 
 [dependencies]
 # Test utility

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -18,7 +18,10 @@ zaino-state = { workspace = true, features = ["bench"] }
 zebra-chain.workspace = true
 zebra-state.workspace = true
 zebra-rpc.workspace = true
-zingolib = { workspace = true }
+zingolib = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0.0-beta2", features = [
+    "test-elevation",
+] }
+
 core2 = { workspace = true }
 prost = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }

--- a/zaino-testutils/Cargo.toml
+++ b/zaino-testutils/Cargo.toml
@@ -25,7 +25,9 @@ zebra-chain = { workspace = true }
 zingo-infra-services = { workspace = true }
 
 # ZingoLib
-zingolib = { workspace = true }
+zingolib = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0.0-beta2", features = [
+    "test-elevation",
+] }
 testvectors = { workspace = true }
 
 # Tracing


### PR DESCRIPTION
Move zingolib out of workspace dependency so that it cannot accidentally became a production dependency.

## Motivation

Cleaning the dependency tree as requested by Str4d, pacu, and nuttyc0m. Including Issue 480

## Partial Solution

Zingolib is not a dependency in Zaino whenever it can be avoided. Todayz PR demonstrates that this concern is taken care of, and enforces that it cannot revert.

### Tests

See follow-up work

### Specifications & References

https://hackmd.io/wcqYQAHJRxiaYx60ExIDOQ

### Follow-up Work

Setting up nightly CI cargo hack

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
