### PR TITLE
run autoinherit and machete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,16 +973,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
-dependencies = [
- "nix 0.30.1",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,23 +2196,18 @@ dependencies = [
  "anyhow",
  "core2 0.4.0",
  "futures",
- "hex",
  "prost",
  "serde_json",
  "tempfile",
  "tokio",
- "tracing-subscriber",
- "url",
  "zaino-common",
  "zaino-fetch",
  "zaino-proto",
  "zaino-state",
  "zaino-testutils",
- "zcash_primitives 0.24.0",
  "zebra-chain 2.0.0",
  "zebra-rpc 2.0.1",
  "zebra-state 2.0.0",
- "zingolib",
 ]
 
 [[package]]
@@ -2427,29 +2412,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c644f4623d1c55eb60a9dac35e0858a59f982fb87db6ce34c872372b0a5b728f"
 dependencies = [
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "lazy-regex"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126"
-dependencies = [
- "lazy-regex-proc_macros",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "lazy-regex-proc_macros"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -2754,18 +2716,6 @@ name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.9.4",
  "cfg-if",
@@ -5973,7 +5923,6 @@ name = "zaino-common"
 version = "0.1.2"
 dependencies = [
  "serde",
- "thiserror 1.0.69",
  "zebra-chain 2.0.0",
  "zingo-infra-services",
 ]
@@ -6001,10 +5950,8 @@ dependencies = [
  "url",
  "zaino-proto",
  "zaino-testvectors",
- "zcash_protocol 0.6.1",
  "zebra-chain 2.0.0",
  "zebra-rpc 2.0.1",
- "zebra-state 2.0.0",
 ]
 
 [[package]]
@@ -6021,14 +5968,8 @@ dependencies = [
 name = "zaino-serve"
 version = "0.1.2"
 dependencies = [
- "async-stream",
- "crossbeam-channel",
  "futures",
- "hex",
- "http",
  "jsonrpsee",
- "lazy-regex",
- "prost",
  "thiserror 1.0.69",
  "tokio",
  "tonic",
@@ -6040,7 +5981,6 @@ dependencies = [
  "zaino-state",
  "zebra-chain 2.0.0",
  "zebra-rpc 2.0.1",
- "zebra-state 2.0.0",
 ]
 
 [[package]]
@@ -6051,19 +5991,13 @@ dependencies = [
  "async-trait",
  "bitflags 2.9.4",
  "blake2",
- "bs58",
- "byteorder",
  "cargo-lock",
  "chrono",
  "core2 0.4.0",
  "dashmap",
- "derive_more",
  "futures",
  "hex",
- "http",
  "indexmap 2.11.0",
- "jsonrpsee-core",
- "lazy-regex",
  "lmdb",
  "lmdb-sys",
  "nonempty",
@@ -6082,7 +6016,6 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
- "url",
  "whoami",
  "zaino-common",
  "zaino-fetch",
@@ -6102,26 +6035,19 @@ dependencies = [
 name = "zaino-testutils"
 version = "0.1.2"
 dependencies = [
- "ctrlc",
  "http",
- "lazy_static",
  "once_cell",
  "portpicker",
- "proptest",
  "tempfile",
  "testvectors",
  "tokio",
  "tonic",
- "tracing",
- "tracing-futures",
  "tracing-subscriber",
  "zaino-common",
  "zaino-state",
  "zaino-testvectors",
- "zainod",
  "zcash_client_backend",
- "zcash_protocol 0.5.4",
- "zebra-chain 2.0.0",
+ "zcash_protocol 0.6.1",
  "zingo-infra-services",
  "zingo-netutils",
  "zingolib",
@@ -6139,7 +6065,6 @@ name = "zainod"
 version = "0.1.2"
 dependencies = [
  "clap",
- "ctrlc",
  "figment",
  "http",
  "serde",
@@ -6147,7 +6072,6 @@ dependencies = [
  "tokio",
  "toml 0.5.11",
  "tracing",
- "tracing-futures",
  "tracing-subscriber",
  "zaino-common",
  "zaino-fetch",
@@ -6869,7 +6793,7 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-proc-macros",
  "jsonrpsee-types",
- "nix 0.29.0",
+ "nix",
  "rand 0.8.5",
  "semver",
  "serde",
@@ -6907,7 +6831,7 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-proc-macros",
  "jsonrpsee-types",
- "nix 0.29.0",
+ "nix",
  "prost",
  "rand 0.8.5",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,13 @@ proptest = "~1.2"
 
 # Patch for vulnerable dependency
 slab = "0.4.11"
+anyhow = "1.0"
+arc-swap = "1.7.1"
+cargo-lock = "10.1.0"
+derive_more = "2.0.1"
+lazy_static = "1.5.0"
+zcash_client_backend = "0.18.0"
+zingo-netutils = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0.0-beta2" }
 
 [profile.test]
 opt-level = 3

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -18,23 +18,14 @@ zaino-state = { workspace = true, features = ["bench"] }
 zebra-chain.workspace = true
 zebra-state.workspace = true
 zebra-rpc.workspace = true
-zingolib = { workspace = true }
 core2 = { workspace = true }
 prost = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 futures.workspace = true
-zcash_primitives = { workspace = true }
-hex = { workspace = true, features = ["serde"] }
 tempfile.workspace = true
 
 # Runtime
 tokio = { workspace = true }
 
-# Logging
-tracing-subscriber = { workspace = true }
-
-# Url
-url = { workspace = true }
-
 [dev-dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }

--- a/zaino-common/Cargo.toml
+++ b/zaino-common/Cargo.toml
@@ -17,6 +17,3 @@ zingo-infra-services = { workspace = true }
 
 # Serialization
 serde = { workspace = true, features = ["derive"] }
-
-# Error handling
-thiserror = { workspace = true }

--- a/zaino-fetch/Cargo.toml
+++ b/zaino-fetch/Cargo.toml
@@ -11,13 +11,9 @@ version = { workspace = true }
 [dependencies]
 zaino-proto = { workspace = true }
 
-# Librustzcash
-zcash_protocol = { workspace = true }
-
 # Zebra
 zebra-chain = { workspace = true }
 zebra-rpc = { workspace = true }
-zebra-state = { workspace = true }
 
 # Tracing
 tracing = { workspace = true }
@@ -40,7 +36,7 @@ base64 = { workspace = true }
 byteorder = { workspace = true }
 sha2 = { workspace = true }
 jsonrpsee-types = { workspace = true }
-derive_more = { version = "2.0.1", features = ["from"] }
+derive_more = { workspace = true, features = ["from"] }
 
 [dev-dependencies]
-zaino-testvectors = { path = "../zaino-testvectors" }
+zaino-testvectors = { workspace = true }

--- a/zaino-serve/Cargo.toml
+++ b/zaino-serve/Cargo.toml
@@ -18,7 +18,6 @@ zaino-state = { workspace = true }
 
 # Zebra
 zebra-chain = { workspace = true }
-zebra-state = { workspace = true }
 zebra-rpc = { workspace = true }
 
 # Tracing
@@ -27,16 +26,8 @@ tracing = { workspace = true }
 # Miscellaneous Workspace
 tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true, features = ["tls"] }
-http = { workspace = true }
 thiserror = { workspace = true }
-
-# Miscellaneous Crate
-prost = { workspace = true }
-hex = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
-async-stream = { workspace = true }
-crossbeam-channel = { workspace = true }
-lazy-regex = { workspace = true }
 jsonrpsee = { workspace = true, features = ["server", "macros"] }
 tower = { workspace = true }
 

--- a/zaino-state/Cargo.toml
+++ b/zaino-state/Cargo.toml
@@ -13,7 +13,7 @@ version = { workspace = true }
 bench = []
 
 [dependencies]
-zaino-common = { path = "../zaino-common" }
+zaino-common = { workspace = true }
 zaino-fetch = { workspace = true }
 zaino-proto = { workspace = true }
 
@@ -39,31 +39,24 @@ tower = { workspace = true, features = ["buffer", "util"] }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 indexmap = { workspace = true }
-url = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 tokio-stream = { workspace = true }
 futures = { workspace = true }
 tonic = { workspace = true }
-http = { workspace = true }
-lazy-regex = { workspace = true }
 dashmap = { workspace = true }
 lmdb = { workspace = true }
 lmdb-sys = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
-jsonrpsee-core = { workspace = true }
 prost = { workspace = true }
 primitive-types = { workspace = true }
 blake2 = { workspace = true }
 sha2 = { workspace = true }
-byteorder = { workspace = true }
 core2 = { workspace = true }
-bs58 = { workspace = true }
-nonempty = "0.11.0"
-arc-swap = "1.7.1"
+nonempty = { workspace = true }
+arc-swap = { workspace = true }
 reqwest.workspace = true
 bitflags = { workspace = true }
-derive_more = { version = "2.0.1", features = ["from"] }
 
 [dev-dependencies]
 zingo-infra-services = { workspace = true }
@@ -73,4 +66,4 @@ once_cell = { workspace = true }
 
 [build-dependencies]
 whoami = { workspace = true }
-cargo-lock = "10.1.0"
+cargo-lock = { workspace = true }

--- a/zaino-testutils/Cargo.toml
+++ b/zaino-testutils/Cargo.toml
@@ -9,17 +9,13 @@ license = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
-zainod = { workspace = true }
 zaino-state = { workspace = true, features = ["bench"] }
 zaino-testvectors.workspace = true
 zaino-common.workspace = true
 
 # Librustzcash
-zcash_protocol = "0.5.4"
-zcash_client_backend = { version = "0.18.0", features = ["lightwalletd-tonic"] }
-
-# Zebra
-zebra-chain = { workspace = true }
+zcash_protocol = { workspace = true }
+zcash_client_backend = { workspace = true, features = ["lightwalletd-tonic"] }
 
 # Zingo-infra
 zingo-infra-services = { workspace = true }
@@ -27,35 +23,19 @@ zingo-infra-services = { workspace = true }
 # ZingoLib
 zingolib = { workspace = true }
 testvectors = { workspace = true }
-
-# Tracing
-tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = [
     "fmt",
     "env-filter",
     "time",
 ] }
-tracing-futures = { workspace = true }
 
 # Miscellaneous
 tokio = { workspace = true }
 tonic = { workspace = true }
 http = { workspace = true }
-ctrlc = { workspace = true }
 tempfile = { workspace = true }
 portpicker = { workspace = true }
 once_cell = { workspace = true }
 
-# We don't need this as a direct dependency.
-# Rather, we need to pin this version of proptest.
-# if we don't, cargo update will update to the semver-compatible
-# version 1.7, which depends on rand-0.9.1.
-# This causes compiler errors in incrementalmerkletree, due a conflict
-# with its rand version of 0.8.5.
-# TODO: Investigate whether proptest has violated semver guarentees with
-# its rand version update.
-proptest = { workspace = true }
-lazy_static = "1.5.0"
-
 [dev-dependencies]
-zingo-netutils = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0.0-beta2" }
+zingo-netutils = { workspace = true }

--- a/zaino-testvectors/Cargo.toml
+++ b/zaino-testvectors/Cargo.toml
@@ -9,5 +9,5 @@ license = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
-lazy_static = "1.5.0"
+lazy_static = { workspace = true }
 

--- a/zainod/Cargo.toml
+++ b/zainod/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 no_tls_use_unencrypted_traffic = []
 
 [dependencies]
-zaino-common = { path = "../zaino-common" }
+zaino-common = { workspace = true }
 zaino-fetch = { workspace = true }
 zaino-state = { workspace = true }
 zaino-serve = { workspace = true }
@@ -39,7 +39,6 @@ clap = { workspace = true, features = ["derive"] }
 # Tracing
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter", "time"] }
-tracing-futures = { workspace = true }
 
 # Network / RPC
 http = { workspace = true }
@@ -47,7 +46,6 @@ serde = { workspace = true, features = ["derive"] }
 
 # Utility
 thiserror = { workspace = true }
-ctrlc = { workspace = true }
 
 # Formats
 toml = { workspace = true }


### PR DESCRIPTION
## Motivation

Having multiple versions of the same crate in a single workspace is a significant source if bugs.   Moreover by unifying dependency policy to a single source of truth we reduce the possibility of version skew.

In this case I discovered that there were 2 versions of zcash_protocol specified one in the workspace, and another in zaino-testutils!!

## Solution

Use the **cargo autoinherit** tool.

This unifies polciy into the workspace level crate.

### Tests

If the current set on dev pass, that's sufficient for this dependency related PR.

### Follow-up Work

Once dependencies are unified it will be easier to know that updates in a single place have the same effect across the workspace.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ x ] The PR name is suitable for the release notes.
- [ x ] The solution is tested.
- [ x ] The documentation is up to date.
