### PR TITLE
run cargo autoinherit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,13 @@ proptest = "~1.2"
 
 # Patch for vulnerable dependency
 slab = "0.4.11"
+anyhow = "1.0"
+arc-swap = "1.7.1"
+cargo-lock = "10.1.0"
+derive_more = "2.0.1"
+lazy_static = "1.5.0"
+zcash_client_backend = "0.18.0"
+zingo-netutils = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0.0-beta2" }
 
 [profile.test]
 opt-level = 3

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -37,4 +37,4 @@ tracing-subscriber = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }

--- a/zaino-fetch/Cargo.toml
+++ b/zaino-fetch/Cargo.toml
@@ -40,7 +40,7 @@ base64 = { workspace = true }
 byteorder = { workspace = true }
 sha2 = { workspace = true }
 jsonrpsee-types = { workspace = true }
-derive_more = { version = "2.0.1", features = ["from"] }
+derive_more = { workspace = true, features = ["from"] }
 
 [dev-dependencies]
-zaino-testvectors = { path = "../zaino-testvectors" }
+zaino-testvectors = { workspace = true }

--- a/zaino-state/Cargo.toml
+++ b/zaino-state/Cargo.toml
@@ -13,7 +13,7 @@ version = { workspace = true }
 bench = []
 
 [dependencies]
-zaino-common = { path = "../zaino-common" }
+zaino-common = { workspace = true }
 zaino-fetch = { workspace = true }
 zaino-proto = { workspace = true }
 
@@ -59,11 +59,11 @@ sha2 = { workspace = true }
 byteorder = { workspace = true }
 core2 = { workspace = true }
 bs58 = { workspace = true }
-nonempty = "0.11.0"
-arc-swap = "1.7.1"
+nonempty = { workspace = true }
+arc-swap = { workspace = true }
 reqwest.workspace = true
 bitflags = { workspace = true }
-derive_more = { version = "2.0.1", features = ["from"] }
+derive_more = { workspace = true, features = ["from"] }
 
 [dev-dependencies]
 zingo-infra-services = { workspace = true }
@@ -73,4 +73,4 @@ once_cell = { workspace = true }
 
 [build-dependencies]
 whoami = { workspace = true }
-cargo-lock = "10.1.0"
+cargo-lock = { workspace = true }

--- a/zaino-testutils/Cargo.toml
+++ b/zaino-testutils/Cargo.toml
@@ -16,7 +16,7 @@ zaino-common.workspace = true
 
 # Librustzcash
 zcash_protocol = "0.5.4"
-zcash_client_backend = { version = "0.18.0", features = ["lightwalletd-tonic"] }
+zcash_client_backend = { workspace = true, features = ["lightwalletd-tonic"] }
 
 # Zebra
 zebra-chain = { workspace = true }
@@ -55,7 +55,7 @@ once_cell = { workspace = true }
 # TODO: Investigate whether proptest has violated semver guarentees with
 # its rand version update.
 proptest = { workspace = true }
-lazy_static = "1.5.0"
+lazy_static = { workspace = true }
 
 [dev-dependencies]
-zingo-netutils = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0.0-beta2" }
+zingo-netutils = { workspace = true }

--- a/zaino-testvectors/Cargo.toml
+++ b/zaino-testvectors/Cargo.toml
@@ -9,5 +9,5 @@ license = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
-lazy_static = "1.5.0"
+lazy_static = { workspace = true }
 

--- a/zainod/Cargo.toml
+++ b/zainod/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 no_tls_use_unencrypted_traffic = []
 
 [dependencies]
-zaino-common = { path = "../zaino-common" }
+zaino-common = { workspace = true }
 zaino-fetch = { workspace = true }
 zaino-state = { workspace = true }
 zaino-serve = { workspace = true }


### PR DESCRIPTION
## Motivation

Migrating version policies to a single location, workspace-Cargo.toml, allows readers to consult and modify a single source of truth with respect to those policies.

This enhances readability.

All tests and local linters run and pass.