### PR TITLE
chore(`integration-tests`): mark as private

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "integration-tests"
 description = "Crate containing Zaino's integration-tests."
+publish = false
+
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
## Motivation

Explicitly mark crates that are not supposed to be released as private.

## Solution

A `publish = false` should do. This also hooks up with future CI checks when we do releases.

