### PR TITLE
Enhance codependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,3 +138,6 @@ zingo-netutils = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0
 [profile.test]
 opt-level = 3
 debug = true
+
+#[workspace.dev-dependencies]
+# zingolib is imported in zaino-testutils!!

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -20,9 +20,6 @@ zaino-state = { workspace = true, features = ["bench"] }
 zebra-chain.workspace = true
 zebra-state.workspace = true
 zebra-rpc.workspace = true
-zingolib = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0.0-beta2", features = [
-    "test-elevation",
-] }
 
 core2 = { workspace = true }
 prost = { workspace = true }

--- a/zaino-testutils/Cargo.toml
+++ b/zaino-testutils/Cargo.toml
@@ -7,6 +7,7 @@ homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 version = { workspace = true }
+publish = false
 
 [dependencies]
 zaino-state = { workspace = true, features = ["bench"] }


### PR DESCRIPTION
## Motivation

The remove codepencies feature had costs and benefits.

One cost is that a viewer of the Workspace Manifest would not realize that zingolib is used in test members, another is that it was possible to skew the versions of zingolib between the tightly couples non-published integration-tests and zaino-testutils packages.

## Solution

Couple zaino-testutil and integration-tests to a single version of zingolib with a re-export.
Add a comment to the workspace Manifest warning readers that zingolib is around.

### Tests

Yes.

### Specifications & References

This work builds on https://github.com/zingolabs/zaino/pull/551 which references relevant context.

### Follow-up Work

We're updating zingolib, and will likely make it easier to depend on it less, here.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ x ] The PR name is suitable for the release notes.
- [ x ] The solution is tested.
- [ x ] The documentation is up to date.
