### PR TITLE
Rm comment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,3 +138,6 @@ zingo-netutils = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0
 [profile.test]
 opt-level = 3
 debug = true
+
+#[workspace.dev-dependencies]
+# zingolib is imported in zaino-testutils!!

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -20,9 +20,6 @@ zaino-state = { workspace = true, features = ["bench"] }
 zebra-chain.workspace = true
 zebra-state.workspace = true
 zebra-rpc.workspace = true
-zingolib = { git = "https://github.com/zingolabs/zingolib.git", tag = "2.0.0-beta2", features = [
-    "test-elevation",
-] }
 
 core2 = { workspace = true }
 prost = { workspace = true }

--- a/zaino-state/src/status.rs
+++ b/zaino-state/src/status.rs
@@ -89,28 +89,6 @@ impl From<StatusType> for usize {
     }
 }
 
-/*
-impl From<AtomicStatus> for StatusType {
-    fn from(status: AtomicStatus) -> Self {
-        //status.load().into()
-        status.load()
-    }
-}
-
-impl From<&AtomicStatus> for StatusType {
-    fn from(status: &AtomicStatus) -> Self {
-        //status.load().into()
-        status.load()
-    }
-}
-
-impl From<StatusType> for u16 {
-    fn from(status: StatusType) -> Self {
-        status as u16
-    }
-}
-*/
-
 impl fmt::Display for StatusType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let status_str = match self {

--- a/zaino-testutils/Cargo.toml
+++ b/zaino-testutils/Cargo.toml
@@ -7,6 +7,7 @@ homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 version = { workspace = true }
+publish = false
 
 [dependencies]
 zaino-state = { workspace = true, features = ["bench"] }


### PR DESCRIPTION
The refurbish StatusType PR commented out this code.   Is this code that's live?   Why is it commented out?   If it's not live, why not remove it?

If it's necessary for correct function, then why didn't a test fail when it was commented out?