### PR TITLE
stop importing BlockCacheConfig via bench to allow for compilation without bench feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,7 +2208,6 @@ dependencies = [
  "zebra-chain 2.0.0",
  "zebra-rpc 2.0.1",
  "zebra-state 2.0.0",
- "zingolib",
 ]
 
 [[package]]

--- a/zaino-state/src/chain_index/tests.rs
+++ b/zaino-state/src/chain_index/tests.rs
@@ -26,7 +26,6 @@ mod mockchain_tests {
     use zebra_chain::serialization::ZcashDeserializeInto;
 
     use crate::{
-        bench::BlockCacheConfig,
         chain_index::{
             source::test::MockchainSource,
             tests::vectors::{
@@ -35,7 +34,7 @@ mod mockchain_tests {
             types::{BestChainLocation, TransactionHash},
             ChainIndex, NodeBackedChainIndex, NodeBackedChainIndexSubscriber,
         },
-        IndexedBlock,
+        BlockCacheConfig, IndexedBlock,
     };
 
     async fn load_test_vectors_and_sync_chain_index(

--- a/zaino-state/src/chain_index/tests/finalised_state/migrations.rs
+++ b/zaino-state/src/chain_index/tests/finalised_state/migrations.rs
@@ -5,13 +5,12 @@ use tempfile::TempDir;
 use zaino_common::network::ActivationHeights;
 use zaino_common::{DatabaseConfig, Network, StorageConfig};
 
-use crate::bench::BlockCacheConfig;
 use crate::chain_index::finalised_state::capability::{DbCore as _, DbWrite as _};
 use crate::chain_index::finalised_state::db::DbBackend;
 use crate::chain_index::finalised_state::ZainoDB;
 use crate::chain_index::tests::init_tracing;
 use crate::chain_index::tests::vectors::{build_mockchain_source, load_test_vectors};
-use crate::{ChainWork, IndexedBlock};
+use crate::{BlockCacheConfig, ChainWork, IndexedBlock};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn v0_to_v1_full() {

--- a/zaino-state/src/chain_index/tests/finalised_state/v0.rs
+++ b/zaino-state/src/chain_index/tests/finalised_state/v0.rs
@@ -8,14 +8,13 @@ use zaino_common::{DatabaseConfig, Network, StorageConfig};
 use zaino_proto::proto::compact_formats::CompactBlock;
 use zebra_rpc::methods::GetAddressUtxos;
 
-use crate::bench::BlockCacheConfig;
 use crate::chain_index::finalised_state::reader::DbReader;
 use crate::chain_index::finalised_state::ZainoDB;
 use crate::chain_index::source::test::MockchainSource;
 use crate::chain_index::tests::init_tracing;
 use crate::chain_index::tests::vectors::{build_mockchain_source, load_test_vectors};
 use crate::error::FinalisedStateError;
-use crate::{ChainWork, Height, IndexedBlock};
+use crate::{BlockCacheConfig, ChainWork, Height, IndexedBlock};
 
 pub(crate) async fn spawn_v0_zaino_db(
     source: MockchainSource,

--- a/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -8,7 +8,6 @@ use zaino_common::{DatabaseConfig, Network, StorageConfig};
 use zaino_proto::proto::compact_formats::CompactBlock;
 use zebra_rpc::methods::GetAddressUtxos;
 
-use crate::bench::BlockCacheConfig;
 use crate::chain_index::finalised_state::reader::DbReader;
 use crate::chain_index::finalised_state::ZainoDB;
 use crate::chain_index::source::test::MockchainSource;
@@ -16,7 +15,7 @@ use crate::chain_index::tests::init_tracing;
 use crate::chain_index::tests::vectors::{build_mockchain_source, load_test_vectors};
 use crate::chain_index::types::TransactionHash;
 use crate::error::FinalisedStateError;
-use crate::{AddrScript, ChainWork, Height, IndexedBlock, Outpoint};
+use crate::{AddrScript, BlockCacheConfig, ChainWork, Height, IndexedBlock, Outpoint};
 
 pub(crate) async fn spawn_v1_zaino_db(
     source: MockchainSource,


### PR DESCRIPTION
This should be able to supersede #564 