### PR TITLE
add type module rules

### DIFF
--- a/zaino-state/src/chain_index/types.rs
+++ b/zaino-state/src/chain_index/types.rs
@@ -1,6 +1,6 @@
 //! Type definitions for the chain index.
 //!
-//! MODULE RULES: This rules must **always** be followed with no exeptions.
+//! MODULE RULES: These rules must **always** be followed with no exeptions.
 //! - structs in this module must never use external types as fields directly,
 //!   instead fundamental data should be saved into the struct, and from / into
 //!   (or appropriate getters / setters) should be implemented.

--- a/zaino-state/src/chain_index/types.rs
+++ b/zaino-state/src/chain_index/types.rs
@@ -1,5 +1,16 @@
 //! Type definitions for the chain index.
 //!
+//! MODULE RULES: This rules must **always** be followed with no exeptions.
+//! - structs in this module must never use external types as fields directly,
+//!   instead fundamental data should be saved into the struct, and from / into
+//!   (or appropriate getters / setters) should be implemented.
+//!
+//! - structs in this module must implement ZainoVersionedSerialize and abide by
+//!   the stringent version rules outlined in that trait.
+//!
+//! - structs in this module must never be changed without implementing a new version
+//!   and implementing the necessary ZainoDB updates and migrations.
+//!
 //! This module is currently in transition from a large monolithic file to well-organized
 //! submodules. The organized types have been moved to focused modules:
 //!


### PR DESCRIPTION
Type mod rules

## Motivation

Currently the module rules are not clearly defined, breaking these rule will break zainoDB so we must add these rules before any more changes happen.

## Solution

Add doc comment.

### Tests


### Specifications & References


### Follow-up Work


### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
