### PR TITLE
Ready tests for ChainIndex

### DIFF
--- a/integration-tests/tests/chain_cache.rs
+++ b/integration-tests/tests/chain_cache.rs
@@ -256,7 +256,7 @@ mod chain_query_interface {
         // this delay had to increase. Maybe we tweak sync loop rerun time?
         test_manager.generate_blocks_with_delay(5).await;
         let snapshot = indexer.snapshot_nonfinalized_state();
-        assert_eq!(snapshot.as_ref().blocks.len(), 7);
+        assert_eq!(snapshot.as_ref().blocks.len(), 8);
         let range = indexer
             .get_block_range(&snapshot, Height::try_from(0).unwrap(), None)
             .unwrap()
@@ -298,7 +298,7 @@ mod chain_query_interface {
         // this delay had to increase. Maybe we tweak sync loop rerun time?
         test_manager.generate_blocks_with_delay(5).await;
         let snapshot = indexer.snapshot_nonfinalized_state();
-        assert_eq!(snapshot.as_ref().blocks.len(), 7);
+        assert_eq!(snapshot.as_ref().blocks.len(), 8);
         for block_hash in snapshot.heights_to_hashes.values() {
             // As all blocks are currently on the main chain,
             // this should be the block provided
@@ -330,7 +330,7 @@ mod chain_query_interface {
         // this delay had to increase. Maybe we tweak sync loop rerun time?
         test_manager.generate_blocks_with_delay(5).await;
         let snapshot = indexer.snapshot_nonfinalized_state();
-        assert_eq!(snapshot.as_ref().blocks.len(), 7);
+        assert_eq!(snapshot.as_ref().blocks.len(), 8);
         for (txid, height) in snapshot.blocks.values().flat_map(|block| {
             block
                 .transactions()
@@ -383,12 +383,12 @@ mod chain_query_interface {
         let snapshot = indexer.snapshot_nonfinalized_state();
         // I don't know where this second block is generated. Somewhere in the
         // guts of create_test_manager_and_chain_index
-        assert_eq!(snapshot.as_ref().blocks.len(), 2);
+        assert_eq!(snapshot.as_ref().blocks.len(), 3);
 
         // this delay had to increase. Maybe we tweak sync loop rerun time?
         test_manager.generate_blocks_with_delay(5).await;
         let snapshot = indexer.snapshot_nonfinalized_state();
-        assert_eq!(snapshot.as_ref().blocks.len(), 7);
+        assert_eq!(snapshot.as_ref().blocks.len(), 8);
         for (txid, height, block_hash) in snapshot.blocks.values().flat_map(|block| {
             block
                 .transactions()

--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -576,7 +576,7 @@ async fn fetch_service_get_latest_block(validator: &ValidatorKind) {
         hash: json_service_blockchain_info.best_block_hash.0.to_vec(),
     });
 
-    assert_eq!(fetch_service_get_latest_block.height, 2);
+    assert_eq!(fetch_service_get_latest_block.height, 3);
     assert_eq!(
         fetch_service_get_latest_block,
         json_service_get_latest_block
@@ -647,7 +647,7 @@ async fn fetch_service_get_best_blockhash(validator: &ValidatorKind) {
 
     let inspected_block: GetBlock = fetch_service_subscriber
         // Some(verbosity) : 1 for JSON Object, 2 for tx data as JSON instead of hex
-        .z_get_block("6".to_string(), Some(1))
+        .z_get_block("7".to_string(), Some(1))
         .await
         .unwrap();
 
@@ -675,7 +675,7 @@ async fn fetch_service_get_block_count(validator: &ValidatorKind) {
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
     let block_id = BlockId {
-        height: 6,
+        height: 7,
         hash: Vec::new(),
     };
 

--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -1358,12 +1358,12 @@ mod zcashd {
 
         use super::*;
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn regtest_no_cache() {
             launch_fetch_service(&ValidatorKind::Zcashd, None).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         #[ignore = "We no longer use chain caches. See zcashd::launch::regtest_no_cache."]
         pub(crate) async fn regtest_with_cache() {
             launch_fetch_service(
@@ -1378,7 +1378,7 @@ mod zcashd {
 
         use super::*;
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn validate_address() {
             fetch_service_validate_address(&ValidatorKind::Zcashd).await;
         }
@@ -1388,27 +1388,27 @@ mod zcashd {
 
         use super::*;
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn address_balance() {
             fetch_service_get_address_balance(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_raw() {
             fetch_service_get_block_raw(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_object() {
             fetch_service_get_block_object(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn raw_mempool() {
             fetch_service_get_raw_mempool(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn mempool_info() {
             test_get_mempool_info(&ValidatorKind::Zcashd).await;
         }
@@ -1417,128 +1417,128 @@ mod zcashd {
 
             use super::*;
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn get_treestate() {
                 fetch_service_z_get_treestate(&ValidatorKind::Zcashd).await;
             }
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn subtrees_by_index() {
                 fetch_service_z_get_subtrees_by_index(&ValidatorKind::Zcashd).await;
             }
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn raw_transaction() {
             fetch_service_get_raw_transaction(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn address_tx_ids() {
             fetch_service_get_address_tx_ids(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn address_utxos() {
             fetch_service_get_address_utxos(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn latest_block() {
             fetch_service_get_latest_block(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block() {
             fetch_service_get_block(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn difficulty() {
             assert_fetch_service_difficulty_matches_rpc(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn best_blockhash() {
             fetch_service_get_best_blockhash(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_count() {
             fetch_service_get_block_count(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_nullifiers() {
             fetch_service_get_block_nullifiers(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_range() {
             fetch_service_get_block_range(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_range_nullifiers() {
             fetch_service_get_block_range_nullifiers(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn transaction_mined() {
             fetch_service_get_transaction_mined(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn transaction_mempool() {
             fetch_service_get_transaction_mempool(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_txids() {
             fetch_service_get_taddress_txids(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_balance() {
             fetch_service_get_taddress_balance(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn mempool_tx() {
             fetch_service_get_mempool_tx(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn mempool_stream() {
             fetch_service_get_mempool_stream(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn tree_state() {
             fetch_service_get_tree_state(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn latest_tree_state() {
             fetch_service_get_latest_tree_state(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn subtree_roots() {
             fetch_service_get_subtree_roots(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_utxos() {
             fetch_service_get_taddress_utxos(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_utxos_stream() {
             fetch_service_get_taddress_utxos_stream(&ValidatorKind::Zcashd).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn lightd_info() {
             fetch_service_get_lightd_info(&ValidatorKind::Zcashd).await;
         }
@@ -1553,12 +1553,12 @@ mod zebrad {
 
         use super::*;
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn regtest_no_cache() {
             launch_fetch_service(&ValidatorKind::Zebrad, None).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         #[ignore = "We no longer use chain caches. See zebrad::launch::regtest_no_cache."]
         pub(crate) async fn regtest_with_cache() {
             launch_fetch_service(
@@ -1573,7 +1573,7 @@ mod zebrad {
 
         use super::*;
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn validate_address() {
             fetch_service_validate_address(&ValidatorKind::Zebrad).await;
         }
@@ -1583,27 +1583,27 @@ mod zebrad {
 
         use super::*;
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn address_balance() {
             fetch_service_get_address_balance(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_raw() {
             fetch_service_get_block_raw(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_object() {
             fetch_service_get_block_object(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn raw_mempool() {
             fetch_service_get_raw_mempool(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn mempool_info() {
             test_get_mempool_info(&ValidatorKind::Zebrad).await;
         }
@@ -1612,128 +1612,128 @@ mod zebrad {
 
             use super::*;
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn treestate() {
                 fetch_service_z_get_treestate(&ValidatorKind::Zebrad).await;
             }
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn subtrees_by_index() {
                 fetch_service_z_get_subtrees_by_index(&ValidatorKind::Zebrad).await;
             }
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn raw_transaction() {
             fetch_service_get_raw_transaction(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn address_tx_ids() {
             fetch_service_get_address_tx_ids(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn address_utxos() {
             fetch_service_get_address_utxos(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn latest_block() {
             fetch_service_get_latest_block(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block() {
             fetch_service_get_block(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn difficulty() {
             assert_fetch_service_difficulty_matches_rpc(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn best_blockhash() {
             fetch_service_get_best_blockhash(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_count() {
             fetch_service_get_block_count(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_nullifiers() {
             fetch_service_get_block_nullifiers(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_range() {
             fetch_service_get_block_range(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_range_nullifiers() {
             fetch_service_get_block_range_nullifiers(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn transaction_mined() {
             fetch_service_get_transaction_mined(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn transaction_mempool() {
             fetch_service_get_transaction_mempool(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_txids() {
             fetch_service_get_taddress_txids(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_balance() {
             fetch_service_get_taddress_balance(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn mempool_tx() {
             fetch_service_get_mempool_tx(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn mempool_stream() {
             fetch_service_get_mempool_stream(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn tree_state() {
             fetch_service_get_tree_state(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn latest_tree_state() {
             fetch_service_get_latest_tree_state(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn subtree_roots() {
             fetch_service_get_subtree_roots(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_utxos() {
             fetch_service_get_taddress_utxos(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_utxos_stream() {
             fetch_service_get_taddress_utxos_stream(&ValidatorKind::Zebrad).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn lightd_info() {
             fetch_service_get_lightd_info(&ValidatorKind::Zebrad).await;
         }

--- a/integration-tests/tests/json_server.rs
+++ b/integration-tests/tests/json_server.rs
@@ -670,27 +670,27 @@ mod zcashd {
     pub(crate) mod zcash_indexer {
         use super::*;
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn check_info_no_cookie() {
             launch_json_server_check_info(false).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn check_info_with_cookie() {
             launch_json_server_check_info(false).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn z_get_address_balance() {
             z_get_address_balance_inner().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_best_blockhash() {
             get_best_blockhash_inner().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_block_count() {
             get_block_count_inner().await;
         }
@@ -699,7 +699,7 @@ mod zcashd {
         ///
         /// This tests generates blocks and checks that the difficulty is the same between zcashd and zaino
         /// after each block is generated.
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_difficulty() {
             let (
                 mut test_manager,
@@ -723,47 +723,47 @@ mod zcashd {
             test_manager.close().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn validate_address() {
             validate_address_inner().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn z_get_block() {
             z_get_block_inner().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_raw_mempool() {
             get_raw_mempool_inner().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_mempool_info() {
             get_mempool_info_inner().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn z_get_treestate() {
             z_get_treestate_inner().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn z_get_subtrees_by_index() {
             z_get_subtrees_by_index_inner().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_raw_transaction() {
             get_raw_transaction_inner().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_address_tx_ids() {
             get_address_tx_ids_inner().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn z_get_address_utxos() {
             z_get_address_utxos_inner().await;
         }

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -1682,7 +1682,7 @@ mod zebrad {
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
             let block = BlockId {
-                height: 102,
+                height: 103,
                 hash: vec![],
             };
             let state_service_block_by_height = state_service_subscriber

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -1043,12 +1043,12 @@ mod zebrad {
         use super::*;
         use zaino_testutils::ZEBRAD_CHAIN_CACHE_DIR;
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn regtest_no_cache() {
             state_service_check_info(&ValidatorKind::Zebrad, None, NetworkKind::Regtest).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn state_service_chaintip_update_subscriber() {
             let (
                 test_manager,
@@ -1081,7 +1081,7 @@ mod zebrad {
             }
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         #[ignore = "We no longer use chain caches. See zcashd::check_info::regtest_no_cache."]
         async fn regtest_with_cache() {
             state_service_check_info(
@@ -1093,7 +1093,7 @@ mod zebrad {
         }
 
         #[ignore = "requires fully synced testnet."]
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn testnet() {
             state_service_check_info(
                 &ValidatorKind::Zebrad,
@@ -1108,40 +1108,40 @@ mod zebrad {
 
         use super::*;
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn address_utxos() {
             state_service_get_address_utxos(&ValidatorKind::Zebrad).await;
         }
 
         #[ignore = "requires fully synced testnet."]
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn address_utxos_testnet() {
             state_service_get_address_utxos_testnet().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn address_tx_ids_regtest() {
             state_service_get_address_tx_ids(&ValidatorKind::Zebrad).await;
         }
 
         #[ignore = "requires fully synced testnet."]
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn address_tx_ids_testnet() {
             state_service_get_address_tx_ids_testnet().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn raw_transaction_regtest() {
             state_service_get_raw_transaction(&ValidatorKind::Zebrad).await;
         }
 
         #[ignore = "requires fully synced testnet."]
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn raw_transaction_testnet() {
             state_service_get_raw_transaction_testnet().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn best_blockhash() {
             let (
                 test_manager,
@@ -1167,7 +1167,7 @@ mod zebrad {
             assert_eq!(fetch_service_bbh, state_service_bbh);
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn block_count() {
             let (
                 mut test_manager,
@@ -1195,7 +1195,7 @@ mod zebrad {
             test_manager.close().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn difficulty() {
             let (
                 mut test_manager,
@@ -1239,36 +1239,36 @@ mod zebrad {
         mod z {
             use super::*;
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn subtrees_by_index_regtest() {
                 state_service_z_get_subtrees_by_index(&ValidatorKind::Zebrad).await;
             }
 
             #[ignore = "requires fully synced testnet."]
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn subtrees_by_index_testnet() {
                 state_service_z_get_subtrees_by_index_testnet().await;
             }
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn treestate_regtest() {
                 state_service_z_get_treestate(&ValidatorKind::Zebrad).await;
             }
 
             #[ignore = "requires fully synced testnet."]
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn treestate_testnet() {
                 state_service_z_get_treestate_testnet().await;
             }
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn raw_mempool_regtest() {
             state_service_get_raw_mempool(&ValidatorKind::Zebrad).await;
         }
 
         /// `getmempoolinfo` computed from local Broadcast state
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_mempool_info() {
             let (
                 mut test_manager,
@@ -1343,19 +1343,19 @@ mod zebrad {
         }
 
         #[ignore = "requires fully synced testnet."]
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn raw_mempool_testnet() {
             state_service_get_raw_mempool_testnet().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn block_object_regtest() {
             state_service_get_block_object(&ValidatorKind::Zebrad, None, NetworkKind::Regtest)
                 .await;
         }
 
         #[ignore = "requires fully synced testnet."]
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn block_object_testnet() {
             state_service_get_block_object(
                 &ValidatorKind::Zebrad,
@@ -1365,13 +1365,13 @@ mod zebrad {
             .await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn block_raw_regtest() {
             state_service_get_block_raw(&ValidatorKind::Zebrad, None, NetworkKind::Regtest).await;
         }
 
         #[ignore = "requires fully synced testnet."]
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn block_raw_testnet() {
             state_service_get_block_raw(
                 &ValidatorKind::Zebrad,
@@ -1381,13 +1381,13 @@ mod zebrad {
             .await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn address_balance_regtest() {
             state_service_get_address_balance(&ValidatorKind::Zebrad).await;
         }
 
         #[ignore = "requires fully synced testnet."]
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn address_balance_testnet() {
             state_service_get_address_balance_testnet().await;
         }
@@ -1401,7 +1401,7 @@ mod zebrad {
         use zebra_rpc::methods::GetAddressTxIdsRequest;
 
         use super::*;
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_latest_block() {
             let (
                 test_manager,
@@ -1427,7 +1427,7 @@ mod zebrad {
             assert_eq!(fetch_service_block, state_service_block);
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_block() {
             let (
                 test_manager,
@@ -1473,7 +1473,8 @@ mod zebrad {
             assert_eq!(fetch_service_block_by_hash, state_service_block_by_hash);
             assert_eq!(state_service_block_by_hash, state_service_block_by_height)
         }
-        #[tokio::test]
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_tree_state() {
             let (
                 test_manager,
@@ -1509,7 +1510,8 @@ mod zebrad {
                 state_service_treestate_by_height
             );
         }
-        #[tokio::test]
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_subtree_roots() {
             let (
                 test_manager,
@@ -1552,7 +1554,8 @@ mod zebrad {
                 state_service_sapling_subtree_roots
             );
         }
-        #[tokio::test]
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_latest_tree_state() {
             let (
                 test_manager,
@@ -1644,15 +1647,17 @@ mod zebrad {
             }
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_block_range_full() {
             get_block_range_helper(false).await;
         }
-        #[tokio::test]
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_block_range_nullifiers() {
             get_block_range_helper(true).await;
         }
-        #[tokio::test]
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_transaction() {
             let (
                 mut test_manager,
@@ -1707,7 +1712,7 @@ mod zebrad {
             assert_eq!(fetch_service_raw_transaction, state_service_raw_transaction);
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_taddress_txids() {
             let (
                 mut test_manager,
@@ -1746,7 +1751,7 @@ mod zebrad {
             assert_eq!(fetch_service_taddress_txids, state_service_taddress_txids);
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_address_utxos_stream() {
             let (
                 mut test_manager,
@@ -1805,7 +1810,8 @@ mod zebrad {
                     .as_ref()
             );
         }
-        #[tokio::test]
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_address_utxos() {
             let (
                 mut test_manager,
@@ -1859,7 +1865,8 @@ mod zebrad {
                     .as_ref()
             );
         }
-        #[tokio::test]
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn get_taddress_balance() {
             let (
                 mut test_manager,

--- a/integration-tests/tests/test_vectors.rs
+++ b/integration-tests/tests/test_vectors.rs
@@ -134,7 +134,7 @@ async fn create_test_manager_and_services(
     (test_manager, state_service, state_subscriber)
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "Not a test! Used to build test vector data for zaino_state::chain_index unit tests."]
 async fn create_200_block_regtest_chain_vectors() {
     let (mut test_manager, _state_service, state_service_subscriber) =
@@ -840,7 +840,7 @@ pub fn read_vectors_from_file<P: AsRef<Path>>(
     Ok((full_data, faucet, recipient))
 }
 
-#[tokio::test]
+#[tokio::tes(flavor = "multi_thread", worker_threads = 2)t]
 async fn pre_v4_txs_parsing() -> anyhow::Result<()> {
     let test_vectors = get_test_vectors();
 

--- a/integration-tests/tests/wallet_to_validator.rs
+++ b/integration-tests/tests/wallet_to_validator.rs
@@ -540,7 +540,7 @@ async fn monitor_unverified_mempool_for_validator(
 mod zcashd {
     use super::*;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn connect_to_node_get_info() {
         connect_to_node_get_info_for_validator(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
     }
@@ -548,33 +548,33 @@ mod zcashd {
     mod sent_to {
         use super::*;
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn orchard() {
             send_to_orchard(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn sapling() {
             send_to_sapling(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn transparent() {
             send_to_transparent(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn all() {
             send_to_all(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn shield() {
         shield_for_validator(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn monitor_unverified_mempool() {
         monitor_unverified_mempool_for_validator(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
     }
@@ -586,7 +586,7 @@ mod zebrad {
     mod fetch_service {
         use super::*;
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn connect_to_node_get_info() {
             connect_to_node_get_info_for_validator(&ValidatorKind::Zebrad, &BackendType::Fetch)
                 .await;
@@ -594,33 +594,33 @@ mod zebrad {
         mod send_to {
             use super::*;
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn sapling() {
                 send_to_sapling(&ValidatorKind::Zebrad, &BackendType::Fetch).await;
             }
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn orchard() {
                 send_to_orchard(&ValidatorKind::Zebrad, &BackendType::Fetch).await;
             }
 
             /// Bug documented in https://github.com/zingolabs/zaino/issues/145.
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn transparent() {
                 send_to_transparent(&ValidatorKind::Zebrad, &BackendType::Fetch).await;
             }
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn all() {
                 send_to_all(&ValidatorKind::Zebrad, &BackendType::Fetch).await;
             }
         }
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn shield() {
             shield_for_validator(&ValidatorKind::Zebrad, &BackendType::Fetch).await;
         }
         /// Bug documented in https://github.com/zingolabs/zaino/issues/144.
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn monitor_unverified_mempool() {
             monitor_unverified_mempool_for_validator(&ValidatorKind::Zebrad, &BackendType::Fetch)
                 .await;
@@ -630,7 +630,7 @@ mod zebrad {
     mod state_service {
         use super::*;
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn connect_to_node_get_info() {
             connect_to_node_get_info_for_validator(&ValidatorKind::Zebrad, &BackendType::State)
                 .await;
@@ -638,33 +638,33 @@ mod zebrad {
         mod send_to {
             use super::*;
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn sapling() {
                 send_to_sapling(&ValidatorKind::Zebrad, &BackendType::State).await;
             }
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn orchard() {
                 send_to_orchard(&ValidatorKind::Zebrad, &BackendType::State).await;
             }
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn transparent() {
                 send_to_transparent(&ValidatorKind::Zebrad, &BackendType::State).await;
             }
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn all() {
                 send_to_all(&ValidatorKind::Zebrad, &BackendType::State).await;
             }
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn shield() {
             shield_for_validator(&ValidatorKind::Zebrad, &BackendType::State).await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn monitor_unverified_mempool() {
             monitor_unverified_mempool_for_validator(&ValidatorKind::Zebrad, &BackendType::State)
                 .await;

--- a/zaino-common/src/network.rs
+++ b/zaino-common/src/network.rs
@@ -83,9 +83,9 @@ impl Default for ActivationHeights {
             blossom: Some(1),
             heartwood: Some(1),
             canopy: Some(1),
-            nu5: Some(1),
-            nu6: Some(1),
-            nu6_1: Some(1),
+            nu5: Some(2),
+            nu6: Some(2),
+            nu6_1: Some(1000),
             nu7: None,
         }
     }

--- a/zaino-state/src/chain_index/tests.rs
+++ b/zaino-state/src/chain_index/tests.rs
@@ -161,6 +161,10 @@ mod mockchain_tests {
                 branch_id,
                 if height == 0 {
                     None
+                } else if height == 1 {
+                    zebra_chain::parameters::NetworkUpgrade::Canopy
+                        .branch_id()
+                        .map(u32::from)
                 } else {
                     zebra_chain::parameters::NetworkUpgrade::Nu6
                         .branch_id()

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -39,8 +39,8 @@ pub const ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS: ActivationHeights = ActivationHeigh
     blossom: Some(1),
     heartwood: Some(1),
     canopy: Some(1),
-    nu5: Some(1),
-    nu6: Some(1),
+    nu5: Some(2),
+    nu6: Some(2),
     nu6_1: Some(1000),
     nu7: None,
 };
@@ -548,7 +548,7 @@ impl TestManager {
             None
         };
 
-        Ok(Self {
+        let test_manager = Self {
             local_net,
             data_dir,
             network: network_kind,
@@ -559,7 +559,13 @@ impl TestManager {
             zaino_grpc_listen_address,
             json_server_cookie_dir: zaino_json_server_cookie_dir,
             clients,
-        })
+        };
+
+        // Generate an extra block to turn on NU5 and NU6,
+        // as they currently must be turned on at block height = 2.
+        test_manager.generate_blocks_with_delay(1).await;
+
+        Ok(test_manager)
     }
 
     /// Helper function to support default test case.
@@ -641,7 +647,7 @@ mod launch_testmanager {
 
         use super::*;
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn basic() {
             let mut test_manager = TestManager::launch_with_default_activation_heights(
                 &ValidatorKind::Zcashd,
@@ -658,13 +664,13 @@ mod launch_testmanager {
             .await
             .unwrap();
             assert_eq!(
-                1,
+                2,
                 u32::from(test_manager.local_net.get_chain_height().await)
             );
             test_manager.close().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn generate_blocks() {
             let mut test_manager = TestManager::launch_with_default_activation_heights(
                 &ValidatorKind::Zcashd,
@@ -681,19 +687,19 @@ mod launch_testmanager {
             .await
             .unwrap();
             assert_eq!(
-                1,
+                2,
                 u32::from(test_manager.local_net.get_chain_height().await)
             );
             test_manager.local_net.generate_blocks(1).await.unwrap();
             assert_eq!(
-                2,
+                3,
                 u32::from(test_manager.local_net.get_chain_height().await)
             );
             test_manager.close().await;
         }
 
         #[ignore = "chain cache needs development"]
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn with_chain() {
             let mut test_manager = TestManager::launch_with_default_activation_heights(
                 &ValidatorKind::Zcashd,
@@ -716,7 +722,7 @@ mod launch_testmanager {
             test_manager.close().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn zaino() {
             let mut test_manager = TestManager::launch_with_default_activation_heights(
                 &ValidatorKind::Zcashd,
@@ -743,7 +749,7 @@ mod launch_testmanager {
             test_manager.close().await;
         }
 
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn zaino_clients() {
             let mut test_manager = TestManager::launch_with_default_activation_heights(
                 &ValidatorKind::Zcashd,
@@ -771,7 +777,7 @@ mod launch_testmanager {
         /// This test shows currently we do not receive mining rewards from Zebra unless we mine 100 blocks at a time.
         /// This is not the case with Zcashd and should not be the case here.
         /// Even if rewards need 100 confirmations these blocks should not have to be mined at the same time.
-        #[tokio::test]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn zaino_clients_receive_mining_reward() {
             let mut test_manager = TestManager::launch_with_default_activation_heights(
                 &ValidatorKind::Zcashd,
@@ -821,7 +827,7 @@ mod launch_testmanager {
 
             use super::*;
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn basic() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,
@@ -838,13 +844,13 @@ mod launch_testmanager {
                 .await
                 .unwrap();
                 assert_eq!(
-                    1,
+                    2,
                     u32::from(test_manager.local_net.get_chain_height().await)
                 );
                 test_manager.close().await;
             }
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn generate_blocks() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,
@@ -861,19 +867,19 @@ mod launch_testmanager {
                 .await
                 .unwrap();
                 assert_eq!(
-                    1,
+                    2,
                     u32::from(test_manager.local_net.get_chain_height().await)
                 );
                 test_manager.local_net.generate_blocks(1).await.unwrap();
                 assert_eq!(
-                    2,
+                    3,
                     u32::from(test_manager.local_net.get_chain_height().await)
                 );
                 test_manager.close().await;
             }
 
             #[ignore = "chain cache needs development"]
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn with_chain() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,
@@ -896,7 +902,7 @@ mod launch_testmanager {
                 test_manager.close().await;
             }
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,
@@ -923,7 +929,7 @@ mod launch_testmanager {
                 test_manager.close().await;
             }
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,
@@ -951,7 +957,7 @@ mod launch_testmanager {
             /// This test shows currently we do not receive mining rewards from Zebra unless we mine 100 blocks at a time.
             /// This is not the case with Zcashd and should not be the case here.
             /// Even if rewards need 100 confirmations these blocks should not have to be mined at the same time.
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients_receive_mining_reward() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,
@@ -998,7 +1004,7 @@ mod launch_testmanager {
                 test_manager.close().await;
             }
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients_receive_mining_reward_and_send() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,
@@ -1100,7 +1106,7 @@ mod launch_testmanager {
             }
 
             #[ignore = "requires fully synced testnet."]
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_testnet() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,
@@ -1132,7 +1138,7 @@ mod launch_testmanager {
 
             use super::*;
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn basic() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,
@@ -1149,13 +1155,13 @@ mod launch_testmanager {
                 .await
                 .unwrap();
                 assert_eq!(
-                    1,
+                    2,
                     u32::from(test_manager.local_net.get_chain_height().await)
                 );
                 test_manager.close().await;
             }
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn generate_blocks() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,
@@ -1172,19 +1178,19 @@ mod launch_testmanager {
                 .await
                 .unwrap();
                 assert_eq!(
-                    1,
+                    2,
                     u32::from(test_manager.local_net.get_chain_height().await)
                 );
                 test_manager.generate_blocks_with_delay(1).await;
                 assert_eq!(
-                    2,
+                    3,
                     u32::from(test_manager.local_net.get_chain_height().await)
                 );
                 test_manager.close().await;
             }
 
             #[ignore = "chain cache needs development"]
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn with_chain() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,
@@ -1207,7 +1213,7 @@ mod launch_testmanager {
                 test_manager.close().await;
             }
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,
@@ -1234,7 +1240,7 @@ mod launch_testmanager {
                 test_manager.close().await;
             }
 
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,
@@ -1262,8 +1268,7 @@ mod launch_testmanager {
             /// This test shows currently we do not receive mining rewards from Zebra unless we mine 100 blocks at a time.
             /// This is not the case with Zcashd and should not be the case here.
             /// Even if rewards need 100 confirmations these blocks should not have to be mined at the same time.
-            #[ignore = "Bug in zingolib 1.0 sync, reinstate on zinglib 2.0 upgrade."]
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients_receive_mining_reward() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,
@@ -1311,8 +1316,7 @@ mod launch_testmanager {
                 test_manager.close().await;
             }
 
-            #[ignore = "Bug in zingolib 1.0 sync, reinstate on zinglib 2.0 upgrade."]
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients_receive_mining_reward_and_send() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,
@@ -1412,7 +1416,7 @@ mod launch_testmanager {
             }
 
             #[ignore = "requires fully synced testnet."]
-            #[tokio::test]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_testnet() {
                 let mut test_manager = TestManager::launch_with_default_activation_heights(
                     &ValidatorKind::Zebrad,


### PR DESCRIPTION
Prepare tests for chain index integration.

## Motivation

Several changes to tests are required for chain index integration, these changes should be made first so we know any failure introduced in the switchover are from the chain index code and not from test changes.

## Solution

- Update default regtest activation heights and fix tests for changes.
-  Add `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]` to tests that _will_ require it after update.


### Tests

Updates tests in place

### Specifications & References



### Follow-up Work

- #596

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
