### PR TITLE
feat(rpc): add `getblockheader` endpoint

### DIFF
--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -700,6 +700,54 @@ async fn fetch_service_get_block(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
+async fn fetch_service_get_block_header(validator: &ValidatorKind) {
+    let (test_manager, _fetch_service, fetch_service_subscriber) =
+        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+
+    const BLOCK_LIMIT: u32 = 10;
+
+    for i in 0..BLOCK_LIMIT {
+        test_manager.local_net.generate_blocks(1).await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+        let block = fetch_service_subscriber
+            .z_get_block(i.to_string(), Some(1))
+            .await
+            .unwrap();
+
+        let block_hash = match block {
+            GetBlock::Object(block) => block.hash(),
+            GetBlock::Raw(_) => panic!("Expected block object"),
+        };
+
+        let fetch_service_get_block_header = fetch_service_subscriber
+            .get_block_header(block_hash.to_string(), false)
+            .await
+            .unwrap();
+
+        let jsonrpc_client = JsonRpSeeConnector::new_with_basic_auth(
+            test_node_and_return_url(
+                test_manager.zebrad_rpc_listen_address,
+                false,
+                None,
+                Some("xxxxxx".to_string()),
+                Some("xxxxxx".to_string()),
+            )
+            .await
+            .unwrap(),
+            "xxxxxx".to_string(),
+            "xxxxxx".to_string(),
+        )
+        .unwrap();
+
+        let rpc_block_header_response = jsonrpc_client
+            .get_block_header(block_hash.to_string(), false)
+            .await
+            .unwrap();
+        assert_eq!(fetch_service_get_block_header, rpc_block_header_response);
+    }
+}
+
 async fn fetch_service_get_best_blockhash(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
         create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
@@ -1544,6 +1592,11 @@ mod zcashd {
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        pub(crate) async fn block_header() {
+            fetch_service_get_block_header(&ValidatorKind::Zcashd).await;
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn difficulty() {
             assert_fetch_service_difficulty_matches_rpc(&ValidatorKind::Zcashd).await;
         }
@@ -1751,6 +1804,11 @@ mod zebrad {
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block() {
             fetch_service_get_block(&ValidatorKind::Zebrad).await;
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        pub(crate) async fn block_header() {
+            fetch_service_get_block_header(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -715,7 +715,7 @@ async fn fetch_service_get_block(validator: &ValidatorKind) {
 
 async fn fetch_service_get_block_header(validator: &ValidatorKind) {
     let (test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service(validator, None, true, true, true).await;
 
     const BLOCK_LIMIT: u32 = 10;
 
@@ -740,8 +740,7 @@ async fn fetch_service_get_block_header(validator: &ValidatorKind) {
 
         let jsonrpc_client = JsonRpSeeConnector::new_with_basic_auth(
             test_node_and_return_url(
-                test_manager.zebrad_rpc_listen_address,
-                false,
+                test_manager.full_node_rpc_listen_address,
                 None,
                 Some("xxxxxx".to_string()),
                 Some("xxxxxx".to_string()),

--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -760,12 +760,12 @@ async fn fetch_service_get_block_header(validator: &ValidatorKind) {
             .unwrap();
 
         let fetch_service_get_block_header_verbose = fetch_service_subscriber
-            .get_block_header(block_hash.to_string(), false)
+            .get_block_header(block_hash.to_string(), true)
             .await
             .unwrap();
 
         let rpc_block_header_response_verbose = jsonrpc_client
-            .get_block_header(block_hash.to_string(), false)
+            .get_block_header(block_hash.to_string(), true)
             .await
             .unwrap();
 

--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -758,7 +758,22 @@ async fn fetch_service_get_block_header(validator: &ValidatorKind) {
             .get_block_header(block_hash.to_string(), false)
             .await
             .unwrap();
+
+        let fetch_service_get_block_header_verbose = fetch_service_subscriber
+            .get_block_header(block_hash.to_string(), false)
+            .await
+            .unwrap();
+
+        let rpc_block_header_response_verbose = jsonrpc_client
+            .get_block_header(block_hash.to_string(), false)
+            .await
+            .unwrap();
+
         assert_eq!(fetch_service_get_block_header, rpc_block_header_response);
+        assert_eq!(
+            fetch_service_get_block_header_verbose,
+            rpc_block_header_response_verbose
+        );
     }
 }
 

--- a/integration-tests/tests/json_server.rs
+++ b/integration-tests/tests/json_server.rs
@@ -796,7 +796,7 @@ mod zcashd {
                 zcashd_subscriber,
                 _zaino_service,
                 zaino_subscriber,
-            ) = create_test_manager_and_fetch_services(false, false).await;
+            ) = create_test_manager_and_fetch_services(false).await;
 
             const BLOCK_LIMIT: u32 = 10;
 

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -1495,7 +1495,7 @@ mod zebrad {
         use zaino_proto::proto::service::{
             AddressList, BlockId, BlockRange, GetAddressUtxosArg, GetSubtreeRootsArg, TxFilter,
         };
-        use zebra_rpc::methods::GetAddressTxIdsRequest;
+        use zebra_rpc::methods::{GetAddressTxIdsRequest, GetBlock};
 
         use super::*;
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1569,6 +1569,55 @@ mod zebrad {
                 .unwrap());
             assert_eq!(fetch_service_block_by_hash, state_service_block_by_hash);
             assert_eq!(state_service_block_by_hash, state_service_block_by_height)
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn get_block_header() {
+            let (
+                test_manager,
+                _fetch_service,
+                fetch_service_subscriber,
+                _state_service,
+                state_service_subscriber,
+            ) = create_test_manager_and_services(
+                &ValidatorKind::Zebrad,
+                None,
+                false,
+                false,
+                Some(NetworkKind::Regtest),
+            )
+            .await;
+
+            const BLOCK_LIMIT: u32 = 10;
+
+            for i in 0..BLOCK_LIMIT {
+                test_manager.local_net.generate_blocks(1).await.unwrap();
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+                let block = fetch_service_subscriber
+                    .z_get_block(i.to_string(), Some(1))
+                    .await
+                    .unwrap();
+
+                let block_hash = match block {
+                    GetBlock::Object(block) => block.hash(),
+                    GetBlock::Raw(_) => panic!("Expected block object"),
+                };
+
+                let fetch_service_get_block_header = fetch_service_subscriber
+                    .get_block_header(block_hash.to_string(), false)
+                    .await
+                    .unwrap();
+
+                let state_service_block_header_response = state_service_subscriber
+                    .get_block_header(block_hash.to_string(), false)
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    fetch_service_get_block_header,
+                    state_service_block_header_response
+                );
+            }
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/zaino-fetch/src/jsonrpsee/connector.rs
+++ b/zaino-fetch/src/jsonrpsee/connector.rs
@@ -25,12 +25,12 @@ use zebra_rpc::client::ValidateAddressResponse;
 use crate::jsonrpsee::{
     error::{JsonRpcError, TransportError},
     response::{
-        block_subsidy::GetBlockSubsidy, peer_info::GetPeerInfo, GetBalanceError,
-        GetBalanceResponse, GetBlockCountResponse, GetBlockError, GetBlockHash, GetBlockResponse,
-        GetBlockchainInfoResponse, GetInfoResponse, GetMempoolInfoResponse, GetSubtreesError,
-        GetSubtreesResponse, GetTransactionResponse, GetTreestateError, GetTreestateResponse,
-        GetUtxosError, GetUtxosResponse, SendTransactionError, SendTransactionResponse, TxidsError,
-        TxidsResponse,
+        block_header::GetBlockHeader, block_subsidy::GetBlockSubsidy, peer_info::GetPeerInfo,
+        GetBalanceError, GetBalanceResponse, GetBlockCountResponse, GetBlockError, GetBlockHash,
+        GetBlockResponse, GetBlockchainInfoResponse, GetInfoResponse, GetMempoolInfoResponse,
+        GetSubtreesError, GetSubtreesResponse, GetTransactionResponse, GetTreestateError,
+        GetTreestateResponse, GetUtxosError, GetUtxosResponse, SendTransactionError,
+        SendTransactionResponse, TxidsError, TxidsResponse,
     },
 };
 
@@ -544,6 +544,19 @@ impl JsonRpSeeConnector {
                 .await
                 .map(GetBlockResponse::Object)
         }
+    }
+
+    // TODO: handle error cases
+    pub async fn get_block_header(
+        &self,
+        hash: String,
+        verbose: bool,
+    ) -> Result<GetBlockHeader, RpcRequestError<Infallible>> {
+        let params = [
+            serde_json::to_value(hash).unwrap(),
+            serde_json::to_value(verbose).unwrap(),
+        ];
+        self.send_request("getblockheader", params).await
     }
 
     /// Returns the hash of the best block (tip) of the longest chain.

--- a/zaino-fetch/src/jsonrpsee/connector.rs
+++ b/zaino-fetch/src/jsonrpsee/connector.rs
@@ -548,8 +548,8 @@ impl JsonRpSeeConnector {
         }
     }
 
-    /// If verbose is false, returns a string that is serialized, hex-encoded data for blockheader 'hash'.
-    /// If verbose is true, returns an Object with information about blockheader <hash>.
+    /// If verbose is false, returns a string that is serialized, hex-encoded data for blockheader `hash`.
+    /// If verbose is true, returns an Object with information about blockheader `hash`.
     ///
     /// # Parameters
     ///

--- a/zaino-fetch/src/jsonrpsee/response.rs
+++ b/zaino-fetch/src/jsonrpsee/response.rs
@@ -3,8 +3,9 @@
 //! These types are redefined rather than imported from zebra_rpc
 //! to prevent locking consumers into a zebra_rpc version
 
+pub mod block_header;
 pub mod block_subsidy;
-mod common;
+pub mod common;
 pub mod peer_info;
 
 use std::{convert::Infallible, num::ParseIntError};

--- a/zaino-fetch/src/jsonrpsee/response/block_header.rs
+++ b/zaino-fetch/src/jsonrpsee/response/block_header.rs
@@ -1,0 +1,100 @@
+//! Types associated with the `getblockheader` RPC request.
+
+use std::{collections::BTreeMap, convert::Infallible};
+
+use serde::{Deserialize, Serialize};
+use zebra_rpc::client::BlockHeaderObject;
+
+use crate::jsonrpsee::connector::ResponseToError;
+
+type z = BlockHeaderObject;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum GetBlockHeader {
+    Verbose(VerboseBlockHeader),
+    Compact(String),
+    Unknown(serde_json::Value),
+}
+
+/// Verbose response to a `getblockheader` RPC request.
+///
+/// See the notes for the `get_block_header` method.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct VerboseBlockHeader {
+    /// The hash of the requested block.
+    pub hash: String,
+
+    /// The number of confirmations of this block in the best chain,
+    /// or -1 if it is not in the best chain.
+    pub confirmations: i64,
+
+    /// The height of the requested block.
+    pub height: u32,
+
+    /// The version field of the requested block.
+    pub version: u32,
+
+    /// The merkle root of the requesteed block.
+    #[serde(rename = "merkleroot")]
+    pub merkle_root: String,
+
+    /// The blockcommitments field of the requested block. Its interpretation changes
+    /// depending on the network and height.
+    #[serde(
+        rename = "blockcommitments",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub block_commitments: Option<String>,
+
+    /// The root of the Sapling commitment tree after applying this block.
+    #[serde(rename = "finalsaplingroot")]
+    pub final_sapling_root: String,
+
+    /// The block time of the requested block header in non-leap seconds since Jan 1 1970 GMT.
+    pub time: i64,
+
+    /// The nonce of the requested block header.
+    pub nonce: String,
+
+    /// The Equihash solution in the requested block header.
+    pub solution: String,
+
+    /// The difficulty threshold of the requested block header displayed in compact form.
+    pub bits: String,
+
+    /// Floating point number that represents the difficulty limit for this block as a multiple
+    /// of the minimum difficulty for the network.
+    pub difficulty: f64,
+
+    /// Cumulative chain work for this block (hex).
+    ///
+    /// Present in zcashd, omitted by Zebra.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chainwork: Option<String>,
+
+    /// The previous block hash of the requested block header.
+    #[serde(
+        rename = "previousblockhash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub previous_block_hash: Option<String>,
+
+    /// The next block hash after the requested block header.
+    #[serde(
+        rename = "nextblockhash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub next_block_hash: Option<String>,
+
+    /// Catch-all for any extra/undocumented fields.
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_json::Value>,
+}
+
+impl ResponseToError for GetBlockHeader {
+    type RpcError = Infallible;
+}

--- a/zaino-fetch/src/jsonrpsee/response/block_header.rs
+++ b/zaino-fetch/src/jsonrpsee/response/block_header.rs
@@ -59,6 +59,8 @@ pub struct VerboseBlockHeader {
 
     /// The blockcommitments field of the requested block. Its interpretation changes
     /// depending on the network and height.
+    ///
+    /// This field is only present in Zebra. It was added [here](https://github.com/ZcashFoundation/zebra/pull/9217).
     #[serde(
         with = "opthex",
         rename = "blockcommitments",
@@ -71,15 +73,6 @@ pub struct VerboseBlockHeader {
     #[serde(with = "opthex", rename = "finalsaplingroot")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub final_sapling_root: Option<[u8; 32]>,
-
-    /// The root of the Orchard commitment tree after applying this block.
-    #[serde(
-        with = "opthex",
-        rename = "finalorchardroot",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    final_orchard_root: Option<[u8; 32]>,
 
     /// The block time of the requested block header in non-leap seconds since Jan 1 1970 GMT.
     pub time: i64,
@@ -177,7 +170,6 @@ mod tests {
           "merkleroot": "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f",
           "blockcommitments": "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f",
           "finalsaplingroot": "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f",
-          "finalorchardroot": "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f",
           "time": 1699999999,
           "nonce": "33nonce",
           "solution": "44solution",
@@ -284,13 +276,6 @@ mod tests {
                     .unwrap()
                 );
 
-                assert_eq!(
-                    block_header.final_orchard_root.unwrap(),
-                    <[u8; 32]>::from_hex(
-                        "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f"
-                    )
-                    .unwrap()
-                );
                 assert_eq!(block_header.time, 1_699_999_999);
                 assert_eq!(block_header.nonce, "33nonce");
                 assert_eq!(block_header.solution, "44solution");
@@ -386,7 +371,6 @@ mod tests {
           "version": 4,
           "merkleroot": "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f",
           "finalsaplingroot": "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f",
-          "finalorchardroot": "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f",
           "time": 1477641369,
           "nonce": "nonce",
           "solution": "solution",

--- a/zaino-fetch/src/jsonrpsee/response/block_header.rs
+++ b/zaino-fetch/src/jsonrpsee/response/block_header.rs
@@ -1,6 +1,6 @@
 //! Types associated with the `getblockheader` RPC request.
 
-use std::{collections::BTreeMap, convert::Infallible};
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 

--- a/zaino-fetch/src/jsonrpsee/response/block_header.rs
+++ b/zaino-fetch/src/jsonrpsee/response/block_header.rs
@@ -3,11 +3,8 @@
 use std::{collections::BTreeMap, convert::Infallible};
 
 use serde::{Deserialize, Serialize};
-use zebra_rpc::client::BlockHeaderObject;
 
 use crate::jsonrpsee::connector::ResponseToError;
-
-type z = BlockHeaderObject;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -97,4 +94,210 @@ pub struct VerboseBlockHeader {
 
 impl ResponseToError for GetBlockHeader {
     type RpcError = Infallible;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Value};
+
+    /// Zcashd verbose response.
+    fn zcashd_verbose_json() -> &'static str {
+        r#"{
+          "hash": "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f",
+          "confirmations": 10,
+          "height": 123456,
+          "version": 4,
+          "merkleroot": "aa11merkle",
+          "finalsaplingroot": "bb22sapling",
+          "time": 1700000000,
+          "nonce": "11nonce",
+          "solution": "22solution",
+          "bits": "1d00ffff",
+          "difficulty": 123456.789,
+          "chainwork": "0000000000000000000000000000000000000000000000000000000000001234",
+          "previousblockhash": "prevhash0001",
+          "nextblockhash": "nexthash0001",
+          "mediantime": 1700000500,
+          "nTx": 12
+        }"#
+    }
+
+    // Zebra verbose response
+    fn zebra_verbose_json() -> &'static str {
+        r#"{
+          "hash": "00000000001b76b932f31289beccd3988d098ec3c8c6e4a0c7bcaf52e9bdead1",
+          "confirmations": 3,
+          "height": 42,
+          "version": 5,
+          "merkleroot": "bb33merkle",
+          "blockcommitments": "cc44blockcommitments",
+          "finalsaplingroot": "dd55sapling",
+          "time": 1699999999,
+          "nonce": "33nonce",
+          "solution": "44solution",
+          "bits": "1c654321",
+          "difficulty": 7890.123,
+          "previousblockhash": "prevhash0042"
+        }"#
+    }
+
+    #[test]
+    fn deserialize_verbose_zcashd_includes_chainwork_and_extra() {
+        let block_header: GetBlockHeader = serde_json::from_str(zcashd_verbose_json()).unwrap();
+        match block_header {
+            GetBlockHeader::Verbose(v) => {
+                assert_eq!(
+                    v.hash,
+                    "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f"
+                );
+                assert_eq!(v.confirmations, 10);
+                assert_eq!(v.height, 123_456);
+                assert_eq!(v.version, 4);
+                assert_eq!(v.merkle_root, "aa11merkle");
+                assert_eq!(v.final_sapling_root, "bb22sapling");
+                assert_eq!(v.time, 1_700_000_000);
+                assert_eq!(v.nonce, "11nonce");
+                assert_eq!(v.solution, "22solution");
+                assert_eq!(v.bits, "1d00ffff");
+                assert!((v.difficulty - 123_456.789).abs() < f64::EPSILON);
+
+                assert_eq!(
+                    v.chainwork.as_deref(),
+                    Some("0000000000000000000000000000000000000000000000000000000000001234")
+                );
+
+                assert_eq!(v.previous_block_hash.as_deref(), Some("prevhash0001"));
+                assert_eq!(v.next_block_hash.as_deref(), Some("nexthash0001"));
+
+                // Extras
+                assert_eq!(v.extra.get("mediantime"), Some(&json!(1_700_000_500)));
+                assert_eq!(v.extra.get("nTx"), Some(&json!(12)));
+            }
+            _ => panic!("expected Verbose variant"),
+        }
+    }
+
+    #[test]
+    fn deserialize_verbose_zebra_includes_blockcommitments_and_omits_chainwork() {
+        let block_header: GetBlockHeader = serde_json::from_str(zebra_verbose_json()).unwrap();
+        match block_header {
+            GetBlockHeader::Verbose(v) => {
+                assert_eq!(
+                    v.hash,
+                    "00000000001b76b932f31289beccd3988d098ec3c8c6e4a0c7bcaf52e9bdead1"
+                );
+                assert_eq!(v.confirmations, 3);
+                assert_eq!(v.height, 42);
+                assert_eq!(v.version, 5);
+                assert_eq!(v.merkle_root, "bb33merkle");
+
+                assert_eq!(v.block_commitments.as_deref(), Some("cc44blockcommitments"));
+
+                assert_eq!(v.final_sapling_root, "dd55sapling");
+                assert_eq!(v.time, 1_699_999_999);
+                assert_eq!(v.nonce, "33nonce");
+                assert_eq!(v.solution, "44solution");
+                assert_eq!(v.bits, "1c654321");
+                assert!((v.difficulty - 7890.123).abs() < f64::EPSILON);
+
+                assert!(v.chainwork.is_none());
+
+                // Zebra always sets previous
+                assert_eq!(v.previous_block_hash.as_deref(), Some("prevhash0042"));
+                assert!(v.next_block_hash.is_none());
+
+                // No extras
+                assert!(v.extra.is_empty());
+            }
+            _ => panic!("expected Verbose variant"),
+        }
+    }
+
+    #[test]
+    fn compact_header_is_hex_string() {
+        let s = r#""040102deadbeef""#;
+        let block_header: GetBlockHeader = serde_json::from_str(s).unwrap();
+        match block_header.clone() {
+            GetBlockHeader::Compact(hex) => assert_eq!(hex, "040102deadbeef"),
+            _ => panic!("expected Compact variant"),
+        }
+
+        // Roundtrip
+        let out = serde_json::to_string(&block_header).unwrap();
+        assert_eq!(out, s);
+    }
+
+    #[test]
+    fn unknown_shape_falls_back_to_unknown_variant() {
+        let weird = r#"{ "weird": 1, "unexpected": ["a","b","c"] }"#;
+        let block_header: GetBlockHeader = serde_json::from_str(weird).unwrap();
+        match block_header {
+            GetBlockHeader::Unknown(v) => {
+                assert_eq!(v["weird"], json!(1));
+                assert_eq!(v["unexpected"], json!(["a", "b", "c"]));
+            }
+            _ => panic!("expected Unknown variant"),
+        }
+    }
+
+    #[test]
+    fn zebra_roundtrip_does_not_inject_chainwork_field() {
+        let block_header: GetBlockHeader = serde_json::from_str(zebra_verbose_json()).unwrap();
+        let header_value: Value = serde_json::to_value(&block_header).unwrap();
+
+        let header_object = header_value
+            .as_object()
+            .expect("verbose should serialize to object");
+        assert!(!header_object.contains_key("chainwork"));
+
+        assert_eq!(
+            header_object.get("blockcommitments"),
+            Some(&json!("cc44blockcommitments"))
+        );
+    }
+
+    #[test]
+    fn zcashd_roundtrip_preserves_chainwork_and_extras() {
+        let block_header: GetBlockHeader = serde_json::from_str(zcashd_verbose_json()).unwrap();
+        let header_value: Value = serde_json::to_value(&block_header).unwrap();
+        let header_object = header_value.as_object().unwrap();
+
+        assert_eq!(
+            header_object.get("chainwork"),
+            Some(&json!(
+                "0000000000000000000000000000000000000000000000000000000000001234"
+            ))
+        );
+
+        assert_eq!(header_object.get("mediantime"), Some(&json!(1_700_000_500)));
+        assert_eq!(header_object.get("nTx"), Some(&json!(12)));
+    }
+
+    #[test]
+    fn previous_and_next_optional_edges() {
+        // Simulate genesis
+        let genesis_like = r#"{
+          "hash": "genesis-hash",
+          "confirmations": 1,
+          "height": 0,
+          "version": 4,
+          "merkleroot": "root",
+          "finalsaplingroot": "saproot",
+          "time": 1477641369,
+          "nonce": "nonce",
+          "solution": "solution",
+          "bits": "1d00ffff",
+          "difficulty": 1.0
+        }"#;
+
+        let block_header: GetBlockHeader = serde_json::from_str(genesis_like).unwrap();
+        match block_header {
+            GetBlockHeader::Verbose(v) => {
+                assert!(v.previous_block_hash.is_none());
+                assert!(v.next_block_hash.is_none());
+            }
+            _ => panic!("expected Verbose variant"),
+        }
+    }
 }

--- a/zaino-fetch/src/jsonrpsee/response/block_header.rs
+++ b/zaino-fetch/src/jsonrpsee/response/block_header.rs
@@ -155,15 +155,15 @@ mod tests {
           "confirmations": 3,
           "height": 42,
           "version": 5,
-          "merkleroot": "bb33merkle",
-          "blockcommitments": "cc44blockcommitments",
-          "finalsaplingroot": "dd55sapling",
+          "merkleroot": "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f",
+          "blockcommitments": "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f",
+          "finalsaplingroot": "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f",
           "time": 1699999999,
           "nonce": "33nonce",
           "solution": "44solution",
           "bits": "1c654321",
           "difficulty": 7890.123,
-          "previousblockhash": "prevhash0042"
+          "previousblockhash": "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f"
         }"#
     }
 
@@ -235,21 +235,20 @@ mod tests {
 
     #[test]
     fn deserialize_verbose_zebra_includes_blockcommitments_and_omits_chainwork() {
-        let block_header: GetBlockHeader = serde_json::from_str(zebra_verbose_json()).unwrap();
-        match block_header {
-            GetBlockHeader::Verbose(v) => {
+        match serde_json::from_str::<VerboseBlockHeader>(zebra_verbose_json()) {
+            Ok(block_header) => {
                 assert_eq!(
-                    v.hash,
+                    block_header.hash,
                     block::Hash::from_str(
                         "00000000001b76b932f31289beccd3988d098ec3c8c6e4a0c7bcaf52e9bdead1"
                     )
                     .unwrap()
                 );
-                assert_eq!(v.confirmations, 3);
-                assert_eq!(v.height, 42);
-                assert_eq!(v.version, 5);
+                assert_eq!(block_header.confirmations, 3);
+                assert_eq!(block_header.height, 42);
+                assert_eq!(block_header.version, 5);
                 assert_eq!(
-                    v.merkle_root,
+                    block_header.merkle_root,
                     block::merkle::Root::from_hex(
                         "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f"
                     )
@@ -257,30 +256,46 @@ mod tests {
                 );
 
                 assert_eq!(
-                    v.block_commitments.unwrap(),
-                    "cc44blockcommitments".as_bytes()
+                    block_header.block_commitments.unwrap(),
+                    <[u8; 32]>::from_hex(
+                        "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f"
+                    )
+                    .unwrap()
                 );
 
                 assert_eq!(
-                    v.final_sapling_root.unwrap(),
-                    "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f".as_bytes()
+                    block_header.final_sapling_root.unwrap(),
+                    <[u8; 32]>::from_hex(
+                        "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f"
+                    )
+                    .unwrap()
                 );
-                assert_eq!(v.time, 1_699_999_999);
-                assert_eq!(v.nonce, "33nonce");
-                assert_eq!(v.solution, "44solution");
-                assert_eq!(v.bits, "1c654321");
-                assert!((v.difficulty - 7890.123).abs() < f64::EPSILON);
+                assert_eq!(block_header.time, 1_699_999_999);
+                assert_eq!(block_header.nonce, "33nonce");
+                assert_eq!(block_header.solution, "44solution");
+                assert_eq!(block_header.bits, "1c654321");
+                assert!((block_header.difficulty - 7890.123).abs() < f64::EPSILON);
 
-                assert!(v.chainwork.is_none());
+                assert!(block_header.chainwork.is_none());
 
                 // Zebra always sets previous
-                assert_eq!(v.previous_block_hash.as_deref(), Some("prevhash0042"));
-                assert!(v.next_block_hash.is_none());
+                assert_eq!(
+                    block_header.previous_block_hash.as_deref(),
+                    Some("000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f")
+                );
+                assert!(block_header.next_block_hash.is_none());
 
                 // No extras
-                assert!(v.extra.is_empty());
+                assert!(block_header.extra.is_empty());
             }
-            _ => panic!("expected Verbose variant"),
+            Err(e) => {
+                panic!(
+                    "VerboseBlockHeader failed at {}:{} — {}",
+                    e.line(),
+                    e.column(),
+                    e
+                );
+            }
         }
     }
 
@@ -323,7 +338,9 @@ mod tests {
 
         assert_eq!(
             header_object.get("blockcommitments"),
-            Some(&json!("cc44blockcommitments"))
+            Some(&json!(
+                "000000000053d2771290ff1b57181bd067ae0e55a367ba8ddee2d961ea27a14f"
+            ))
         );
     }
 

--- a/zaino-fetch/src/jsonrpsee/response/block_header.rs
+++ b/zaino-fetch/src/jsonrpsee/response/block_header.rs
@@ -9,6 +9,7 @@ use zebra_rpc::methods::opthex;
 use crate::jsonrpsee::connector::{ResponseToError, RpcError};
 
 /// Response to a `getblockheader` RPC request.
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum GetBlockHeader {

--- a/zaino-fetch/src/jsonrpsee/response/common.rs
+++ b/zaino-fetch/src/jsonrpsee/response/common.rs
@@ -1,13 +1,17 @@
+//! Common types used across jsonrpsee responses
+
 pub mod amount;
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+/// The identifier for a Zcash node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct NodeId(pub i64);
 
+/// The height of a Zcash block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct BlockHeight(pub u32);
@@ -18,6 +22,7 @@ impl From<u32> for BlockHeight {
     }
 }
 
+/// The height of a Zcash block, or None if unknown.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MaybeHeight(pub Option<BlockHeight>);
 
@@ -46,10 +51,13 @@ impl<'de> Deserialize<'de> for MaybeHeight {
     }
 }
 
+/// Unix timestamp.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct UnixTime(pub i64);
+
 impl UnixTime {
+    /// Converts to a [`SystemTime`].
     pub fn as_system_time(self) -> SystemTime {
         if self.0 >= 0 {
             UNIX_EPOCH + Duration::from_secs(self.0 as u64)
@@ -59,23 +67,29 @@ impl UnixTime {
     }
 }
 
+/// Duration in seconds.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct SecondsF64(pub f64);
+
 impl SecondsF64 {
+    /// Converts to a [`Duration`].
     pub fn as_duration(self) -> Duration {
         Duration::from_secs_f64(self.0)
     }
 }
 
+/// Protocol version.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct ProtocolVersion(pub i64);
 
+/// A byte array.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Bytes(pub u64);
 
+/// Time offset in seconds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct TimeOffsetSeconds(pub i64);

--- a/zaino-fetch/src/jsonrpsee/response/common/amount.rs
+++ b/zaino-fetch/src/jsonrpsee/response/common/amount.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+/// Zatoshis per ZEC.
 pub const ZATS_PER_ZEC: u64 = 100_000_000;
 /// Represents an amount in Zatoshis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
@@ -41,6 +42,7 @@ impl<'de> Deserialize<'de> for Zatoshis {
 pub struct ZecAmount(u64);
 
 impl ZecAmount {
+    /// Returns the amount in zatoshis.
     pub fn as_zatoshis(self) -> u64 {
         self.0
     }

--- a/zaino-serve/src/rpc/jsonrpc/service.rs
+++ b/zaino-serve/src/rpc/jsonrpc/service.rs
@@ -228,6 +228,8 @@ pub trait ZcashIndexerRpc {
     /// - verbose: (boolean, optional, default=true) true for a json object, false for the hex encoded data
     ///
     /// zcashd reference: [`getblockheader`](https://zcash.github.io/rpc/getblockheader.html)
+    /// zcashd implementation [here](https://github.com/zcash/zcash/blob/16ac743764a513e41dafb2cd79c2417c5bb41e81/src/rpc/blockchain.cpp#L668)
+    ///
     /// method: post
     /// tags: blockchain
     #[method(name = "getblockheader")]

--- a/zaino-serve/src/rpc/jsonrpc/service.rs
+++ b/zaino-serve/src/rpc/jsonrpc/service.rs
@@ -212,6 +212,17 @@ pub trait ZcashIndexerRpc {
         verbosity: Option<u8>,
     ) -> Result<GetBlock, ErrorObjectOwned>;
 
+    /// If verbose is false, returns a string that is serialized, hex-encoded data for blockheader 'hash'.
+    /// If verbose is true, returns an Object with information about blockheader <hash>.
+    ///
+    /// # Parameters
+    ///
+    /// - hash: (string, required) The block hash
+    /// - verbose: (boolean, optional, default=true) true for a json object, false for the hex encoded data
+    ///
+    /// zcashd reference: [`getblockheader`](https://zcash.github.io/rpc/getblockheader.html)
+    /// method: post
+    /// tags: blockchain
     #[method(name = "getblockheader")]
     async fn get_block_header(
         &self,

--- a/zaino-serve/src/rpc/jsonrpc/service.rs
+++ b/zaino-serve/src/rpc/jsonrpc/service.rs
@@ -212,8 +212,8 @@ pub trait ZcashIndexerRpc {
         verbosity: Option<u8>,
     ) -> Result<GetBlock, ErrorObjectOwned>;
 
-    /// If verbose is false, returns a string that is serialized, hex-encoded data for blockheader 'hash'.
-    /// If verbose is true, returns an Object with information about blockheader <hash>.
+    /// If verbose is false, returns a string that is serialized, hex-encoded data for blockheader `hash`.
+    /// If verbose is true, returns an Object with information about blockheader `hash`.
     ///
     /// # Parameters
     ///

--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -23,9 +23,8 @@ use zaino_fetch::{
     jsonrpsee::{
         connector::{JsonRpSeeConnector, RpcError},
         response::{
-            block_subsidy::GetBlockSubsidy,
-            peer_info::GetPeerInfo,
-            {GetMempoolInfoResponse, GetNetworkSolPsResponse},
+            block_header::GetBlockHeader, block_subsidy::GetBlockSubsidy, peer_info::GetPeerInfo,
+            GetMempoolInfoResponse, GetNetworkSolPsResponse,
         },
     },
 };
@@ -370,6 +369,14 @@ impl ZcashIndexer for FetchServiceSubscriber {
             .get_block(hash_or_height, verbosity)
             .await?
             .try_into()?)
+    }
+
+    async fn get_block_header(
+        &self,
+        hash: String,
+        verbose: bool,
+    ) -> Result<GetBlockHeader, Self::Error> {
+        Ok(self.fetcher.get_block_header(hash, verbose).await?.into())
     }
 
     /// Returns the hash of the best block (tip) of the longest chain.

--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -376,7 +376,7 @@ impl ZcashIndexer for FetchServiceSubscriber {
         hash: String,
         verbose: bool,
     ) -> Result<GetBlockHeader, Self::Error> {
-        Ok(self.fetcher.get_block_header(hash, verbose).await?.into())
+        Ok(self.fetcher.get_block_header(hash, verbose).await?)
     }
 
     /// Returns the hash of the best block (tip) of the longest chain.

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -27,8 +27,8 @@ use zaino_fetch::{
     jsonrpsee::{
         connector::{JsonRpSeeConnector, RpcError},
         response::{
-            block_subsidy::GetBlockSubsidy, peer_info::GetPeerInfo, GetMempoolInfoResponse,
-            GetNetworkSolPsResponse, GetSubtreesResponse,
+            block_header::GetBlockHeader, block_subsidy::GetBlockSubsidy, peer_info::GetPeerInfo,
+            GetMempoolInfoResponse, GetNetworkSolPsResponse, GetSubtreesResponse,
         },
     },
 };
@@ -56,10 +56,10 @@ use zebra_rpc::{
     },
     methods::{
         chain_tip_difficulty, AddressBalance, AddressStrings, ConsensusBranchIdHex,
-        GetAddressTxIdsRequest, GetAddressUtxos, GetBlock, GetBlockHash, GetBlockHeader,
-        GetBlockHeaderObject, GetBlockTransaction, GetBlockTrees, GetBlockchainInfoResponse,
-        GetInfo, GetRawTransaction, NetworkUpgradeInfo, NetworkUpgradeStatus, SentTransactionHash,
-        TipConsensusBranch,
+        GetAddressTxIdsRequest, GetAddressUtxos, GetBlock, GetBlockHash,
+        GetBlockHeader as GetBlockHeaderZebra, GetBlockHeaderObject, GetBlockTransaction,
+        GetBlockTrees, GetBlockchainInfoResponse, GetInfo, GetRawTransaction, NetworkUpgradeInfo,
+        NetworkUpgradeStatus, SentTransactionHash, TipConsensusBranch,
     },
     server::error::LegacyCode,
     sync::init_read_state_with_syncer,
@@ -390,12 +390,12 @@ impl StateServiceSubscriber {
     ///
     /// This rpc is used by get_block(verbose), there is currently no
     /// plan to offer this RPC publicly.
-    async fn get_block_header(
+    async fn get_block_header_inner(
         state: &ReadStateService,
         network: &Network,
         hash_or_height: HashOrHeight,
         verbose: Option<bool>,
-    ) -> Result<GetBlockHeader, StateServiceError> {
+    ) -> Result<GetBlockHeaderZebra, StateServiceError> {
         let mut state = state.clone();
         let verbose = verbose.unwrap_or(true);
         let network = network.clone();
@@ -426,7 +426,7 @@ impl StateServiceSubscriber {
         };
 
         let response = if !verbose {
-            GetBlockHeader::Raw(HexData(header.zcash_serialize_to_vec()?))
+            GetBlockHeaderZebra::Raw(HexData(header.zcash_serialize_to_vec()?))
         } else {
             let zebra_state::ReadResponse::SaplingTree(sapling_tree) = state
                 .ready()
@@ -505,7 +505,7 @@ impl StateServiceSubscriber {
                 next_block_hash,
             );
 
-            GetBlockHeader::Object(Box::new(block_header))
+            GetBlockHeaderZebra::Object(Box::new(block_header))
         };
 
         Ok(response)
@@ -733,7 +733,7 @@ impl StateServiceSubscriber {
                 let (fullblock, orchard_tree_response, header, block_info) = futures::join!(
                     blockandsize_future,
                     orchard_future,
-                    StateServiceSubscriber::get_block_header(
+                    StateServiceSubscriber::get_block_header_inner(
                         &state_3,
                         network,
                         hash_or_height,
@@ -743,10 +743,10 @@ impl StateServiceSubscriber {
                 );
 
                 let header_obj = match header? {
-                    GetBlockHeader::Raw(_hex_data) => unreachable!(
+                    GetBlockHeaderZebra::Raw(_hex_data) => unreachable!(
                         "`true` was passed to get_block_header, an object should be returned"
                     ),
-                    GetBlockHeader::Object(get_block_header_object) => get_block_header_object,
+                    GetBlockHeaderZebra::Object(get_block_header_object) => get_block_header_object,
                 };
 
                 let (transactions_response, size, block_info): (Vec<GetBlockTransaction>, _, _) =
@@ -1083,6 +1083,17 @@ impl ZcashIndexer for StateServiceSubscriber {
             .await
             .map(SentTransactionHash::from)
             .map_err(Into::into)
+    }
+
+    async fn get_block_header(
+        &self,
+        hash: String,
+        verbose: bool,
+    ) -> Result<GetBlockHeader, Self::Error> {
+        self.rpc_client
+            .get_block_header(hash, verbose)
+            .await
+            .map_err(|e| StateServiceError::Custom(e.to_string()))
     }
 
     async fn z_get_block(

--- a/zaino-state/src/indexer.rs
+++ b/zaino-state/src/indexer.rs
@@ -250,6 +250,17 @@ pub trait ZcashIndexer: Send + Sync + 'static {
         raw_transaction_hex: String,
     ) -> Result<SentTransactionHash, Self::Error>;
 
+    /// If verbose is false, returns a string that is serialized, hex-encoded data for blockheader 'hash'.
+    /// If verbose is true, returns an Object with information about blockheader <hash>.
+    ///
+    /// # Parameters
+    ///
+    /// - hash: (string, required) The block hash
+    /// - verbose: (boolean, optional, default=true) true for a json object, false for the hex encoded data
+    ///
+    /// zcashd reference: [`getblockheader`](https://zcash.github.io/rpc/getblockheader.html)
+    /// method: post
+    /// tags: blockchain
     async fn get_block_header(
         &self,
         hash: String,

--- a/zaino-state/src/indexer.rs
+++ b/zaino-state/src/indexer.rs
@@ -250,8 +250,8 @@ pub trait ZcashIndexer: Send + Sync + 'static {
         raw_transaction_hex: String,
     ) -> Result<SentTransactionHash, Self::Error>;
 
-    /// If verbose is false, returns a string that is serialized, hex-encoded data for blockheader 'hash'.
-    /// If verbose is true, returns an Object with information about blockheader <hash>.
+    /// If verbose is false, returns a string that is serialized, hex-encoded data for blockheader `hash`.
+    /// If verbose is true, returns an Object with information about blockheader `hash`.
     ///
     /// # Parameters
     ///

--- a/zaino-state/src/indexer.rs
+++ b/zaino-state/src/indexer.rs
@@ -5,9 +5,8 @@ use async_trait::async_trait;
 use tokio::{sync::mpsc, time::timeout};
 use tracing::warn;
 use zaino_fetch::jsonrpsee::response::{
-    block_subsidy::GetBlockSubsidy,
-    peer_info::GetPeerInfo,
-    {GetMempoolInfoResponse, GetNetworkSolPsResponse},
+    block_header::GetBlockHeader, block_subsidy::GetBlockSubsidy, peer_info::GetPeerInfo,
+    GetMempoolInfoResponse, GetNetworkSolPsResponse,
 };
 use zaino_proto::proto::{
     compact_formats::CompactBlock,
@@ -250,6 +249,12 @@ pub trait ZcashIndexer: Send + Sync + 'static {
         &self,
         raw_transaction_hex: String,
     ) -> Result<SentTransactionHash, Self::Error>;
+
+    async fn get_block_header(
+        &self,
+        hash: String,
+        verbose: bool,
+    ) -> Result<GetBlockHeader, Self::Error>;
 
     /// Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
     /// If the block is not in Zebra's state, returns


### PR DESCRIPTION
On top of #595, supersedes #473.

## Motivation

#203.

## Solution

Implement `getblockheader`.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
