### PR TITLE
bench was ambiguously readable as "benchmark"

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -18,7 +18,7 @@ zaino-testutils = { workspace = true }
 zaino-fetch = { workspace = true }
 zaino-proto.workspace = true
 zaino-common.workspace = true
-zaino-state = { workspace = true, features = ["workbench"] }
+zaino-state = { workspace = true, features = ["test_dependencies"] }
 zebra-chain.workspace = true
 zebra-state.workspace = true
 zebra-rpc.workspace = true

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -18,7 +18,7 @@ zaino-testutils = { workspace = true }
 zaino-fetch = { workspace = true }
 zaino-proto.workspace = true
 zaino-common.workspace = true
-zaino-state = { workspace = true, features = ["bench"] }
+zaino-state = { workspace = true, features = ["workbench"] }
 zebra-chain.workspace = true
 zebra-state.workspace = true
 zebra-rpc.workspace = true

--- a/integration-tests/tests/chain_cache.rs
+++ b/integration-tests/tests/chain_cache.rs
@@ -60,7 +60,7 @@ mod chain_query_interface {
             types::{BestChainLocation, TransactionHash},
             NodeBackedChainIndex, NodeBackedChainIndexSubscriber,
         },
-        workbench::{
+        test_dependencies::{
             chain_index::{self, ChainIndex},
             BlockCacheConfig,
         },

--- a/integration-tests/tests/chain_cache.rs
+++ b/integration-tests/tests/chain_cache.rs
@@ -55,14 +55,14 @@ mod chain_query_interface {
         network::ActivationHeights, CacheConfig, DatabaseConfig, ServiceConfig, StorageConfig,
     };
     use zaino_state::{
-        bench::{
-            chain_index::{self, ChainIndex},
-            BlockCacheConfig,
-        },
         chain_index::{
             source::ValidatorConnector,
             types::{BestChainLocation, TransactionHash},
             NodeBackedChainIndex, NodeBackedChainIndexSubscriber,
+        },
+        workbench::{
+            chain_index::{self, ChainIndex},
+            BlockCacheConfig,
         },
         Height, StateService, StateServiceConfig, ZcashService as _,
     };

--- a/integration-tests/tests/local_cache.rs
+++ b/integration-tests/tests/local_cache.rs
@@ -1,7 +1,7 @@
 use zaino_common::{network::ActivationHeights, DatabaseConfig, StorageConfig};
 use zaino_fetch::jsonrpsee::connector::{test_node_and_return_url, JsonRpSeeConnector};
 use zaino_state::{
-    workbench::{BlockCache, BlockCacheConfig, BlockCacheSubscriber},
+    test_dependencies::{BlockCache, BlockCacheConfig, BlockCacheSubscriber},
     BackendType,
 };
 use zaino_testutils::{TestManager, ValidatorKind};

--- a/integration-tests/tests/local_cache.rs
+++ b/integration-tests/tests/local_cache.rs
@@ -1,7 +1,7 @@
 use zaino_common::{network::ActivationHeights, DatabaseConfig, StorageConfig};
 use zaino_fetch::jsonrpsee::connector::{test_node_and_return_url, JsonRpSeeConnector};
 use zaino_state::{
-    bench::{BlockCache, BlockCacheConfig, BlockCacheSubscriber},
+    workbench::{BlockCache, BlockCacheConfig, BlockCacheSubscriber},
     BackendType,
 };
 use zaino_testutils::{TestManager, ValidatorKind};

--- a/zaino-state/Cargo.toml
+++ b/zaino-state/Cargo.toml
@@ -9,7 +9,7 @@ license = { workspace = true }
 version = { workspace = true }
 
 [features]
-# (Work)bench - Exposes internal functionality for testing.
+# test_dependencies - Exposes internal functionality for testing.
 test_dependencies = []
 
 [dependencies]

--- a/zaino-state/Cargo.toml
+++ b/zaino-state/Cargo.toml
@@ -10,7 +10,7 @@ version = { workspace = true }
 
 [features]
 # (Work)bench - Exposes internal functionality for testing.
-workbench = []
+test_dependencies = []
 
 [dependencies]
 zaino-common = { workspace = true }

--- a/zaino-state/Cargo.toml
+++ b/zaino-state/Cargo.toml
@@ -10,7 +10,7 @@ version = { workspace = true }
 
 [features]
 # (Work)bench - Exposes internal functionality for testing.
-bench = []
+workbench = []
 
 [dependencies]
 zaino-common = { workspace = true }

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -145,7 +145,7 @@ impl StateService {
         .await
     }
 
-    #[cfg(feature = "workbench")]
+    #[cfg(feature = "test_dependencies")]
     /// Helper for tests
     pub fn read_state_service(&self) -> &ReadStateService {
         &self.read_state_service

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -145,7 +145,7 @@ impl StateService {
         .await
     }
 
-    #[cfg(feature = "bench")]
+    #[cfg(feature = "workbench")]
     /// Helper for tests
     pub fn read_state_service(&self) -> &ReadStateService {
         &self.read_state_service

--- a/zaino-state/src/lib.rs
+++ b/zaino-state/src/lib.rs
@@ -56,7 +56,7 @@ pub use chain_index::mempool::{MempoolKey, MempoolValue};
 
 #[cfg(feature = "test_dependencies")]
 /// allow public access to additional APIs, for testing
-pub mod test_depenedencies {
+pub mod test_dependencies {
     /// Testing export of chain_index
     pub mod chain_index {
         pub use crate::chain_index::*;

--- a/zaino-state/src/lib.rs
+++ b/zaino-state/src/lib.rs
@@ -54,9 +54,9 @@ pub(crate) mod local_cache;
 
 pub use chain_index::mempool::{MempoolKey, MempoolValue};
 
-#[cfg(feature = "bench")]
+#[cfg(feature = "workbench")]
 /// allow public access to additional APIs, for testing
-pub mod bench {
+pub mod workbench {
     /// Testing export of chain_index
     pub mod chain_index {
         pub use crate::chain_index::*;

--- a/zaino-state/src/lib.rs
+++ b/zaino-state/src/lib.rs
@@ -54,9 +54,9 @@ pub(crate) mod local_cache;
 
 pub use chain_index::mempool::{MempoolKey, MempoolValue};
 
-#[cfg(feature = "workbench")]
+#[cfg(feature = "test_dependencies")]
 /// allow public access to additional APIs, for testing
-pub mod workbench {
+pub mod test_depenedencies {
     /// Testing export of chain_index
     pub mod chain_index {
         pub use crate::chain_index::*;

--- a/zaino-state/src/local_cache/finalised_state.rs
+++ b/zaino-state/src/local_cache/finalised_state.rs
@@ -680,7 +680,7 @@ impl Drop for FinalisedState {
     }
 }
 
-/// A subscriber to a [`crate::workbench::chain_index::non_finalised_state::NonFinalizedState`].
+/// A subscriber to a [`crate::test_dependencies::chain_index::non_finalised_state::NonFinalizedState`].
 #[derive(Debug, Clone)]
 pub struct FinalisedStateSubscriber {
     request_sender: tokio::sync::mpsc::Sender<DbRequest>,

--- a/zaino-state/src/local_cache/finalised_state.rs
+++ b/zaino-state/src/local_cache/finalised_state.rs
@@ -680,7 +680,7 @@ impl Drop for FinalisedState {
     }
 }
 
-/// A subscriber to a [`crate::bench::chain_index::non_finalised_state::NonFinalizedState`].
+/// A subscriber to a [`crate::workbench::chain_index::non_finalised_state::NonFinalizedState`].
 #[derive(Debug, Clone)]
 pub struct FinalisedStateSubscriber {
     request_sender: tokio::sync::mpsc::Sender<DbRequest>,

--- a/zaino-testutils/Cargo.toml
+++ b/zaino-testutils/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 # Zaino
-zaino-state = { workspace = true, features = ["bench"] }
+zaino-state = { workspace = true, features = ["workbench"] }
 zaino-testvectors.workspace = true
 zaino-common.workspace = true
 zainod = { workspace = true }

--- a/zaino-testutils/Cargo.toml
+++ b/zaino-testutils/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 # Zaino
-zaino-state = { workspace = true, features = ["workbench"] }
+zaino-state = { workspace = true, features = ["test_dependencies"] }
 zaino-testvectors.workspace = true
 zaino-common.workspace = true
 zainod = { workspace = true }


### PR DESCRIPTION
(cherry picked from commit 19497d03fbcfdea6ef2d53464e2b83dca75f4af6)

