### PR TITLE
Claude assisted markup of flakey test, ignored in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
             target/debug/deps
 
       - name: Build and archive tests
-        run: cargo nextest archive --verbose --workspace --all-features --archive-file nextest-archive.tar.zst
+        run: cargo nextest archive --verbose --workspace --all-features --features integration-tests/ci_exclude --archive-file nextest-archive.tar.zst
 
       - name: Save cargo dependencies
         if: steps.restore-cargo.outputs.cache-hit != 'true'
@@ -175,7 +175,7 @@ jobs:
         env:
           TEST_BINARIES_DIR: ${{ github.workspace }}/test_binaries/bins
         run: |
-          cargo nextest run --verbose --profile ci --retries 2 --no-tests warn --archive-file nextest-archive.tar.zst \
+          cargo nextest run --verbose --profile ci --no-tests warn --archive-file nextest-archive.tar.zst \
             --workspace-remap ./ --filterset "binary_id(${{ matrix.partition }})" ${{ env.NEXTEST-FLAGS }}
 
       - name: Test Summary

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -10,6 +10,10 @@ edition = { workspace = true }
 license = { workspace = true }
 version = { workspace = true }
 
+[features]
+# ci_exclude - When enabled, excludes certain slow tests from running (used in CI)
+ci_exclude = []
+
 [dev-dependencies]
 anyhow = { workspace = true }
 

--- a/integration-tests/tests/chain_cache.rs
+++ b/integration-tests/tests/chain_cache.rs
@@ -375,6 +375,7 @@ mod chain_query_interface {
         get_transaction_status(&ValidatorKind::Zebrad).await
     }
 
+    #[cfg_attr(feature = "ci_exclude", ignore)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn get_transaction_status_zcashd() {
         get_transaction_status(&ValidatorKind::Zcashd).await

--- a/integration-tests/tests/chain_cache.rs
+++ b/integration-tests/tests/chain_cache.rs
@@ -244,6 +244,7 @@ mod chain_query_interface {
         get_block_range(&ValidatorKind::Zebrad).await
     }
 
+    #[cfg_attr(feature = "ci_exclude", ignore)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn get_block_range_zcashd() {
         get_block_range(&ValidatorKind::Zcashd).await
@@ -286,6 +287,7 @@ mod chain_query_interface {
         find_fork_point(&ValidatorKind::Zebrad).await
     }
 
+    #[cfg_attr(feature = "ci_exclude", ignore)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn find_fork_point_zcashd() {
         find_fork_point(&ValidatorKind::Zcashd).await
@@ -318,6 +320,7 @@ mod chain_query_interface {
         get_raw_transaction(&ValidatorKind::Zebrad).await
     }
 
+    #[cfg_attr(feature = "ci_exclude", ignore)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn get_raw_transaction_zcashd() {
         get_raw_transaction(&ValidatorKind::Zcashd).await
@@ -412,6 +415,7 @@ mod chain_query_interface {
         sync_large_chain(&ValidatorKind::Zebrad).await
     }
 
+    #[cfg_attr(feature = "ci_exclude", ignore)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn sync_large_chain_zcashd() {
         sync_large_chain(&ValidatorKind::Zcashd).await

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -1119,6 +1119,7 @@ mod zebrad {
             state_service_get_address_utxos_testnet().await;
         }
 
+        #[cfg_attr(feature = "ci_exclude", ignore)]
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn address_tx_ids_regtest() {
             state_service_get_address_tx_ids(&ValidatorKind::Zebrad).await;
@@ -1130,6 +1131,7 @@ mod zebrad {
             state_service_get_address_tx_ids_testnet().await;
         }
 
+        #[cfg_attr(feature = "ci_exclude", ignore)]
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn raw_transaction_regtest() {
             state_service_get_raw_transaction(&ValidatorKind::Zebrad).await;
@@ -1359,6 +1361,7 @@ mod zebrad {
             }
         }
 
+        #[cfg_attr(feature = "ci_exclude", ignore)]
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn raw_mempool_regtest() {
             state_service_get_raw_mempool(&ValidatorKind::Zebrad).await;
@@ -1478,6 +1481,7 @@ mod zebrad {
             .await;
         }
 
+        #[cfg_attr(feature = "ci_exclude", ignore)]
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn address_balance_regtest() {
             state_service_get_address_balance(&ValidatorKind::Zebrad).await;


### PR DESCRIPTION
  Summary

  1. Feature Flag Added (integration-tests/Cargo.toml:13-15)

  [features]
  # ci_exclude - When enabled, excludes certain slow tests from running (used in CI)
  ci_exclude = []

  2. Tests Excluded from CI (8 total)

  Chain Cache tests (integration-tests/tests/chain_cache.rs):
  - get_block_range_zcashd - line 247-250
  - find_fork_point_zcashd - line 290-293
  - get_raw_transaction_zcashd - line 323-326
  - sync_large_chain_zcashd - line 418-421

  State Service tests (integration-tests/tests/state_service.rs):
  - address_tx_ids_regtest - line 1122-1125
  - raw_transaction_regtest - line 1134-1137
  - raw_mempool_regtest - line 1364-1367
  - address_balance_regtest - line 1484-1487

  All have #[cfg_attr(feature = "ci_exclude", ignore)] attribute.

  3. CI Configuration Updated (.github/workflows/ci.yml)

  - Line 65: Build with --features integration-tests/ci_exclude flag (tests will be ignored in CI)
  - Line 178: Removed --retries 2 flag (tests succeed or fail on one try)

  4. Behavior

  - CI runs: Tests are excluded (ignored)
  - Local runs: Tests are included by default (run cargo test or cargo nextest run normally)
  - All tests: No retries - they succeed or fail on the first attempt