### PR TITLE
Rename ZainoVersionedSerialise to ZainoVersionSerde

### DIFF
--- a/zaino-state/src/chain_index/encoding.rs
+++ b/zaino-state/src/chain_index/encoding.rs
@@ -35,7 +35,7 @@ pub mod version {
 ///
 /// ### Initial release (`VERSION = 1`)
 /// 1. `pub struct TxV1 { … }`   // layout frozen forever
-/// 2. `impl ZainoVersionedSerialise for TxV1`
+/// 2. `impl ZainoVersionedSerde for TxV1`
 ///    * `const VERSION = 1`
 ///    * `encode_body` – **v1** layout
 ///    * `decode_v1` – parses **v1** bytes
@@ -44,7 +44,7 @@ pub mod version {
 /// ### Bump to v2
 /// 1. `pub struct TxV2 { … }`   // new “current” layout
 /// 2. `impl From<TxV1> for TxV2` // loss-less upgrade path
-/// 3. `impl ZainoVersionedSerialise for TxV2`
+/// 3. `impl ZainoVersionedSerde for TxV2`
 ///    * `const VERSION = 2`
 ///    * `encode_body` – **v2** layout
 ///    * `decode_v1` – `TxV1::decode_latest(r).map(Self::from)`
@@ -67,7 +67,7 @@ pub mod version {
 ///
 /// Historical helpers (`decode_v1`, `decode_v2`, …) must be implemented
 /// for compatibility with historical versions
-pub trait ZainoVersionedSerialise: Sized {
+pub trait ZainoVersionedSerde: Sized {
     /// Tag this build writes.
     const VERSION: u8;
 

--- a/zaino-state/src/chain_index/finalised_state/capability.rs
+++ b/zaino-state/src/chain_index/finalised_state/capability.rs
@@ -9,7 +9,7 @@ use crate::{
     AddrScript, BlockHash, BlockHeaderData, CommitmentTreeData, FixedEncodedLen, Height,
     IndexedBlock, OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList,
     StatusType, TransparentCompactTx, TransparentTxList, TxLocation, TxidList,
-    ZainoVersionedSerialise,
+    ZainoVersionedSerde,
 };
 
 use async_trait::async_trait;
@@ -165,7 +165,7 @@ impl DbMetadata {
     }
 }
 
-impl ZainoVersionedSerialise for DbMetadata {
+impl ZainoVersionedSerde for DbMetadata {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -278,7 +278,7 @@ impl DbVersion {
     }
 }
 
-impl ZainoVersionedSerialise for DbVersion {
+impl ZainoVersionedSerde for DbVersion {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -346,7 +346,7 @@ impl fmt::Display for MigrationStatus {
     }
 }
 
-impl ZainoVersionedSerialise for MigrationStatus {
+impl ZainoVersionedSerde for MigrationStatus {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {

--- a/zaino-state/src/chain_index/finalised_state/capability.rs
+++ b/zaino-state/src/chain_index/finalised_state/capability.rs
@@ -8,8 +8,7 @@ use crate::{
     read_fixed_le, read_u32_le, read_u8, version, write_fixed_le, write_u32_le, write_u8,
     AddrScript, BlockHash, BlockHeaderData, CommitmentTreeData, FixedEncodedLen, Height,
     IndexedBlock, OrchardCompactTx, OrchardTxList, Outpoint, SaplingCompactTx, SaplingTxList,
-    StatusType, TransparentCompactTx, TransparentTxList, TxLocation, TxidList,
-    ZainoVersionedSerde,
+    StatusType, TransparentCompactTx, TransparentTxList, TxLocation, TxidList, ZainoVersionedSerde,
 };
 
 use async_trait::async_trait;

--- a/zaino-state/src/chain_index/finalised_state/db/v0.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v0.rs
@@ -2,7 +2,7 @@
 //!
 //! WARNING: This is a legacy development database and should not be used in production environments.
 //!
-//! NOTE: This database version was implemented before zaino's `ZainoVersionedSerded` was defined,
+//! NOTE: This database version was implemented before zaino's `ZainoVersionedSerde` was defined,
 //! for this reason ZainoDB-V0 does not use the standard serialisation schema used elswhere in Zaino.
 
 use crate::{

--- a/zaino-state/src/chain_index/finalised_state/db/v0.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v0.rs
@@ -2,7 +2,7 @@
 //!
 //! WARNING: This is a legacy development database and should not be used in production environments.
 //!
-//! NOTE: This database version was implemented before zaino's `ZainoVersionedSerialised` was defined,
+//! NOTE: This database version was implemented before zaino's `ZainoVersionedSerded` was defined,
 //! for this reason ZainoDB-V0 does not use the standard serialisation schema used elswhere in Zaino.
 
 use crate::{

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -18,7 +18,7 @@ use crate::{
     CompactOrchardAction, CompactSaplingOutput, CompactSaplingSpend, CompactSize, CompactTxData,
     FixedEncodedLen as _, Height, IndexedBlock, OrchardCompactTx, OrchardTxList, Outpoint,
     SaplingCompactTx, SaplingTxList, StatusType, TransparentCompactTx, TransparentTxList,
-    TxInCompact, TxLocation, TxOutCompact, TxidList, ZainoVersionedSerialise as _,
+    TxInCompact, TxLocation, TxOutCompact, TxidList, ZainoVersionedSerde as _,
 };
 
 use zebra_chain::parameters::NetworkKind;

--- a/zaino-state/src/chain_index/finalised_state/entry.rs
+++ b/zaino-state/src/chain_index/finalised_state/entry.rs
@@ -1,7 +1,7 @@
 //! DB stored data wrappers structs.
 
 use crate::{
-    read_fixed_le, version, write_fixed_le, CompactSize, FixedEncodedLen, ZainoVersionedSerialise,
+    read_fixed_le, version, write_fixed_le, CompactSize, FixedEncodedLen, ZainoVersionedSerde,
 };
 
 use blake2::{
@@ -20,14 +20,14 @@ use core2::io::{self, Read, Write};
 /// │ StoredEntry version  │  Record version  │             Body              │ B2B256 hash     │
 /// └──────────────────────┴──────────────────┴───────────────────────────────┴─────────────────┘
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct StoredEntryFixed<T: ZainoVersionedSerialise + FixedEncodedLen> {
+pub(crate) struct StoredEntryFixed<T: ZainoVersionedSerde + FixedEncodedLen> {
     /// Inner record
     pub(crate) item: T,
     /// Entry checksum
     pub(crate) checksum: [u8; 32],
 }
 
-impl<T: ZainoVersionedSerialise + FixedEncodedLen> StoredEntryFixed<T> {
+impl<T: ZainoVersionedSerde + FixedEncodedLen> StoredEntryFixed<T> {
     /// Create a new entry, hashing `key || encoded_item`.
     pub(crate) fn new<K: AsRef<[u8]>>(key: K, item: T) -> Self {
         let body = {
@@ -68,7 +68,7 @@ impl<T: ZainoVersionedSerialise + FixedEncodedLen> StoredEntryFixed<T> {
     }
 }
 
-impl<T: ZainoVersionedSerialise + FixedEncodedLen> ZainoVersionedSerialise for StoredEntryFixed<T> {
+impl<T: ZainoVersionedSerde + FixedEncodedLen> ZainoVersionedSerde for StoredEntryFixed<T> {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -90,7 +90,7 @@ impl<T: ZainoVersionedSerialise + FixedEncodedLen> ZainoVersionedSerialise for S
     }
 }
 
-impl<T: ZainoVersionedSerialise + FixedEncodedLen> FixedEncodedLen for StoredEntryFixed<T> {
+impl<T: ZainoVersionedSerde + FixedEncodedLen> FixedEncodedLen for StoredEntryFixed<T> {
     const ENCODED_LEN: usize = T::VERSIONED_LEN + 32;
 }
 
@@ -101,14 +101,14 @@ impl<T: ZainoVersionedSerialise + FixedEncodedLen> FixedEncodedLen for StoredEnt
 /// │ StoredEntry version │ (length of item.serialize()) │ Record version │        Body        │    Hash    │
 /// └─────────────────────┴──────────────────────────────┴────────────────┴────────────────────┴────────────┘
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct StoredEntryVar<T: ZainoVersionedSerialise> {
+pub(crate) struct StoredEntryVar<T: ZainoVersionedSerde> {
     /// Inner record
     pub(crate) item: T,
     /// Entry checksum
     pub(crate) checksum: [u8; 32],
 }
 
-impl<T: ZainoVersionedSerialise> StoredEntryVar<T> {
+impl<T: ZainoVersionedSerde> StoredEntryVar<T> {
     /// Create a new entry, hashing `encoded_key || encoded_item`.
     pub(crate) fn new<K: AsRef<[u8]>>(key: K, item: T) -> Self {
         let body = {
@@ -146,7 +146,7 @@ impl<T: ZainoVersionedSerialise> StoredEntryVar<T> {
     }
 }
 
-impl<T: ZainoVersionedSerialise> ZainoVersionedSerialise for StoredEntryVar<T> {
+impl<T: ZainoVersionedSerde> ZainoVersionedSerde for StoredEntryVar<T> {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {

--- a/zaino-state/src/chain_index/types.rs
+++ b/zaino-state/src/chain_index/types.rs
@@ -3,7 +3,7 @@
 //! This module provides types for blockchain indexing, organized into two main categories:
 //!
 //! ## Database Types
-//! Types that implement `ZainoVersionedSerialise` for database persistence.
+//! Types that implement `ZainoVersionedSerde` for database persistence.
 //! These types follow strict versioning rules and require migrations for any changes.
 //!
 //! Currently organized in `db/legacy.rs` (pending refactoring into focused modules):
@@ -22,13 +22,13 @@
 //! ## Module Organization Rules
 //!
 //! **Database Types (`db` module):**
-//! 1. Must implement `ZainoVersionedSerialise`
+//! 1. Must implement `ZainoVersionedSerde`
 //! 2. Never use external types as fields directly - store fundamental data
 //! 3. Never change without implementing a new version and database migration
 //! 4. Follow stringent versioning rules for backward compatibility
 //!
 //! **Helper Types (`helpers` module):**
-//! 1. Do NOT implement `ZainoVersionedSerialise`
+//! 1. Do NOT implement `ZainoVersionedSerde`
 //! 2. Used for in-memory operations, conversions, and coordination
 //! 3. Can be changed more freely as they're not persisted
 

--- a/zaino-state/src/chain_index/types/db.rs
+++ b/zaino-state/src/chain_index/types/db.rs
@@ -1,6 +1,6 @@
 //! Database-serializable types for the chain index.
 //!
-//! This module contains all types that implement `ZainoVersionedSerialise` and are used
+//! This module contains all types that implement `ZainoVersionedSerde` and are used
 //! for database persistence. These types follow strict versioning rules to maintain
 //! backward compatibility across database schema changes.
 //!
@@ -10,7 +10,7 @@
 //!    - Store fundamental data in the struct
 //!    - Implement `From`/`Into` or getters/setters for external type conversions
 //!
-//! 2. **Must implement ZainoVersionedSerialise**
+//! 2. **Must implement ZainoVersionedSerde**
 //!    - Follow stringent versioning rules outlined in the trait
 //!    - Ensure backward compatibility
 //!

--- a/zaino-state/src/chain_index/types/db/address.rs
+++ b/zaino-state/src/chain_index/types/db/address.rs
@@ -1,6 +1,6 @@
 //! Address-related database-serializable types.
 //!
-//! Contains types for address and UTXO data that implement `ZainoVersionedSerialise`:
+//! Contains types for address and UTXO data that implement `ZainoVersionedSerde`:
 //! - AddrScript
 //! - Outpoint
 //! - AddrHistRecord

--- a/zaino-state/src/chain_index/types/db/block.rs
+++ b/zaino-state/src/chain_index/types/db/block.rs
@@ -1,6 +1,6 @@
 //! Block-related database-serializable types.
 //!
-//! Contains types for block data that implement `ZainoVersionedSerialise`:
+//! Contains types for block data that implement `ZainoVersionedSerde`:
 //! - BlockHash
 //! - BlockIndex
 //! - BlockData

--- a/zaino-state/src/chain_index/types/db/commitment.rs
+++ b/zaino-state/src/chain_index/types/db/commitment.rs
@@ -10,7 +10,7 @@ use core2::io::{self, Read, Write};
 
 use crate::chain_index::encoding::{
     read_fixed_le, read_u32_le, version, write_fixed_le, write_u32_le, FixedEncodedLen,
-    ZainoVersionedSerialise,
+    ZainoVersionedSerde,
 };
 
 /// Holds commitment tree metadata (roots and sizes) for a block.
@@ -38,7 +38,7 @@ impl CommitmentTreeData {
     }
 }
 
-impl ZainoVersionedSerialise for CommitmentTreeData {
+impl ZainoVersionedSerde for CommitmentTreeData {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -94,7 +94,7 @@ impl CommitmentTreeRoots {
     }
 }
 
-impl ZainoVersionedSerialise for CommitmentTreeRoots {
+impl ZainoVersionedSerde for CommitmentTreeRoots {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -148,7 +148,7 @@ impl CommitmentTreeSizes {
     }
 }
 
-impl ZainoVersionedSerialise for CommitmentTreeSizes {
+impl ZainoVersionedSerde for CommitmentTreeSizes {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {

--- a/zaino-state/src/chain_index/types/db/legacy.rs
+++ b/zaino-state/src/chain_index/types/db/legacy.rs
@@ -37,7 +37,7 @@ use std::{fmt, io::Cursor};
 use crate::chain_index::encoding::{
     read_fixed_le, read_i64_le, read_option, read_u16_be, read_u32_be, read_u32_le, read_u64_le,
     read_vec, version, write_fixed_le, write_i64_le, write_option, write_u16_be, write_u32_be,
-    write_u32_le, write_u64_le, write_vec, FixedEncodedLen, ZainoVersionedSerialise,
+    write_u32_le, write_u64_le, write_vec, FixedEncodedLen, ZainoVersionedSerde,
 };
 
 use super::commitment::{CommitmentTreeData, CommitmentTreeRoots, CommitmentTreeSizes};
@@ -142,7 +142,7 @@ impl From<zcash_primitives::block::BlockHash> for BlockHash {
     }
 }
 
-impl ZainoVersionedSerialise for BlockHash {
+impl ZainoVersionedSerde for BlockHash {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -259,7 +259,7 @@ impl From<zcash_primitives::transaction::TxId> for TransactionHash {
     }
 }
 
-impl ZainoVersionedSerialise for TransactionHash {
+impl ZainoVersionedSerde for TransactionHash {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -371,7 +371,7 @@ impl TryFrom<zcash_protocol::consensus::BlockHeight> for Height {
     }
 }
 
-impl ZainoVersionedSerialise for Height {
+impl ZainoVersionedSerde for Height {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -403,7 +403,7 @@ impl FixedEncodedLen for Height {
 #[cfg_attr(test, derive(serde::Serialize, serde::Deserialize))]
 pub struct ShardIndex(pub u32);
 
-impl ZainoVersionedSerialise for ShardIndex {
+impl ZainoVersionedSerde for ShardIndex {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -523,7 +523,7 @@ impl From<AddrScript> for [u8; 21] {
     }
 }
 
-impl ZainoVersionedSerialise for AddrScript {
+impl ZainoVersionedSerde for AddrScript {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -588,7 +588,7 @@ impl Outpoint {
     }
 }
 
-impl ZainoVersionedSerialise for Outpoint {
+impl ZainoVersionedSerde for Outpoint {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -668,7 +668,7 @@ impl BlockIndex {
     }
 }
 
-impl ZainoVersionedSerialise for BlockIndex {
+impl ZainoVersionedSerde for BlockIndex {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -748,7 +748,7 @@ impl fmt::Display for ChainWork {
     }
 }
 
-impl ZainoVersionedSerialise for ChainWork {
+impl ZainoVersionedSerde for ChainWork {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -914,7 +914,7 @@ impl BlockData {
     }
 }
 
-impl ZainoVersionedSerialise for BlockData {
+impl ZainoVersionedSerde for BlockData {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -1023,7 +1023,7 @@ impl<'a> TryFrom<&'a [u8]> for EquihashSolution {
     }
 }
 
-impl ZainoVersionedSerialise for EquihashSolution {
+impl ZainoVersionedSerde for EquihashSolution {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -1182,7 +1182,7 @@ impl IndexedBlock {
     }
 }
 
-impl ZainoVersionedSerialise for IndexedBlock {
+impl ZainoVersionedSerde for IndexedBlock {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, mut w: &mut W) -> io::Result<()> {
@@ -1583,7 +1583,7 @@ impl TryFrom<(u64, zaino_fetch::chain::transaction::FullTransaction)> for Compac
     }
 }
 
-impl ZainoVersionedSerialise for CompactTxData {
+impl ZainoVersionedSerde for CompactTxData {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, mut w: &mut W) -> io::Result<()> {
@@ -1628,7 +1628,7 @@ pub struct TransparentCompactTx {
     vout: Vec<TxOutCompact>,
 }
 
-impl ZainoVersionedSerialise for TransparentCompactTx {
+impl ZainoVersionedSerde for TransparentCompactTx {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -1713,7 +1713,7 @@ impl TxInCompact {
     }
 }
 
-impl ZainoVersionedSerialise for TxInCompact {
+impl ZainoVersionedSerde for TxInCompact {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -1776,7 +1776,7 @@ impl ScriptType {
     }
 }
 
-impl ZainoVersionedSerialise for ScriptType {
+impl ZainoVersionedSerde for ScriptType {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -1927,7 +1927,7 @@ impl<T: AsRef<[u8]>> TryFrom<(u64, T)> for TxOutCompact {
     }
 }
 
-impl ZainoVersionedSerialise for TxOutCompact {
+impl ZainoVersionedSerde for TxOutCompact {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -2001,7 +2001,7 @@ impl SaplingCompactTx {
     }
 }
 
-impl ZainoVersionedSerialise for SaplingCompactTx {
+impl ZainoVersionedSerde for SaplingCompactTx {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -2054,7 +2054,7 @@ impl CompactSaplingSpend {
     }
 }
 
-impl ZainoVersionedSerialise for CompactSaplingSpend {
+impl ZainoVersionedSerde for CompactSaplingSpend {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -2124,7 +2124,7 @@ impl CompactSaplingOutput {
     }
 }
 
-impl ZainoVersionedSerialise for CompactSaplingOutput {
+impl ZainoVersionedSerde for CompactSaplingOutput {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -2180,7 +2180,7 @@ impl OrchardCompactTx {
     }
 }
 
-impl ZainoVersionedSerialise for OrchardCompactTx {
+impl ZainoVersionedSerde for OrchardCompactTx {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -2266,7 +2266,7 @@ impl CompactOrchardAction {
     }
 }
 
-impl ZainoVersionedSerialise for CompactOrchardAction {
+impl ZainoVersionedSerde for CompactOrchardAction {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -2327,7 +2327,7 @@ impl TxLocation {
     }
 }
 
-impl ZainoVersionedSerialise for TxLocation {
+impl ZainoVersionedSerde for TxLocation {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -2421,7 +2421,7 @@ impl AddrHistRecord {
     }
 }
 
-impl ZainoVersionedSerialise for AddrHistRecord {
+impl ZainoVersionedSerde for AddrHistRecord {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -2523,7 +2523,7 @@ impl AddrEventBytes {
     }
 }
 
-impl ZainoVersionedSerialise for AddrEventBytes {
+impl ZainoVersionedSerde for AddrEventBytes {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -2592,7 +2592,7 @@ impl ShardRoot {
     }
 }
 
-impl ZainoVersionedSerialise for ShardRoot {
+impl ZainoVersionedSerde for ShardRoot {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -2651,7 +2651,7 @@ impl BlockHeaderData {
     }
 }
 
-impl ZainoVersionedSerialise for BlockHeaderData {
+impl ZainoVersionedSerde for BlockHeaderData {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -2690,7 +2690,7 @@ impl TxidList {
     }
 }
 
-impl ZainoVersionedSerialise for TxidList {
+impl ZainoVersionedSerde for TxidList {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -2715,7 +2715,7 @@ impl ZainoVersionedSerialise for TxidList {
 /// This ensures 1-to-1 indexing with `TxidList`: element *i* matches txid *i*.
 /// `None` keeps the index when the tx lacks this pool.
 ///
-/// **Serialization layout for `TransparentTxList` (implements `ZainoVersionedSerialise`)**
+/// **Serialization layout for `TransparentTxList` (implements `ZainoVersionedSerde`)**
 ///
 /// ┌──────────── byte 0 ─────────────┬────────── CompactSize ─────────────┬──────────── entries ───────────────┐
 /// │ TransparentTxList version tag   │ num_txs (CompactSize) = N          │ [`Option<TransparentCompactTx>`; N]│
@@ -2761,7 +2761,7 @@ impl TransparentTxList {
     }
 }
 
-impl ZainoVersionedSerialise for TransparentTxList {
+impl ZainoVersionedSerde for TransparentTxList {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -2790,7 +2790,7 @@ impl ZainoVersionedSerialise for TransparentTxList {
 /// This ensures 1-to-1 indexing with `TxidList`: element *i* matches txid *i*.
 /// `None` keeps the index when the tx lacks this pool.
 ///
-/// **Serialization layout for `SaplingTxList` (implements `ZainoVersionedSerialise`)**
+/// **Serialization layout for `SaplingTxList` (implements `ZainoVersionedSerde`)**
 ///
 /// ┌──────────── byte 0 ─────────────┬────────── CompactSize ─────────────┬──────────── entries ───────────────┐
 /// │ SaplingTxList version tag = 1   │ num_txs (CompactSize) = N          │ [`Option<SaplingCompactTx>`; N]    │
@@ -2840,7 +2840,7 @@ impl SaplingTxList {
     }
 }
 
-impl ZainoVersionedSerialise for SaplingTxList {
+impl ZainoVersionedSerde for SaplingTxList {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
@@ -2867,7 +2867,7 @@ impl ZainoVersionedSerialise for SaplingTxList {
 /// This ensures 1-to-1 indexing with `TxidList`: element *i* matches txid *i*.
 /// `None` keeps the index when the tx lacks this pool.
 ///
-/// **Serialization layout for `OrchardTxList` (implements `ZainoVersionedSerialise`)**
+/// **Serialization layout for `OrchardTxList` (implements `ZainoVersionedSerde`)**
 ///
 /// ┌──────────── byte 0 ─────────────┬────────── CompactSize ─────────────┬──────────── entries ───────────────┐
 /// │ OrchardTxList version tag = 1   │ num_txs (CompactSize) = N          │ [`Option<OrchardCompactTx>`; N]    │
@@ -2911,7 +2911,7 @@ impl OrchardTxList {
     }
 }
 
-impl ZainoVersionedSerialise for OrchardTxList {
+impl ZainoVersionedSerde for OrchardTxList {
     const VERSION: u8 = version::V1;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {

--- a/zaino-state/src/chain_index/types/db/primitives.rs
+++ b/zaino-state/src/chain_index/types/db/primitives.rs
@@ -1,6 +1,6 @@
 //! Primitive database-serializable types.
 //!
-//! Contains basic primitive types that implement `ZainoVersionedSerialise`:
+//! Contains basic primitive types that implement `ZainoVersionedSerde`:
 //! - Height
 //! - ShardIndex
 //! - ScriptType

--- a/zaino-state/src/chain_index/types/db/shielded.rs
+++ b/zaino-state/src/chain_index/types/db/shielded.rs
@@ -1,6 +1,6 @@
 //! Shielded pool database-serializable types.
 //!
-//! Contains types for Sapling and Orchard shielded pool data that implement `ZainoVersionedSerialise`:
+//! Contains types for Sapling and Orchard shielded pool data that implement `ZainoVersionedSerde`:
 //! - SaplingCompactTx
 //! - CompactSaplingSpend
 //! - CompactSaplingOutput

--- a/zaino-state/src/chain_index/types/db/transaction.rs
+++ b/zaino-state/src/chain_index/types/db/transaction.rs
@@ -1,6 +1,6 @@
 //! Transaction-related database-serializable types.
 //!
-//! Contains types for transaction data that implement `ZainoVersionedSerialise`:
+//! Contains types for transaction data that implement `ZainoVersionedSerde`:
 //! - TransactionHash
 //! - CompactTxData
 //! - TransparentCompactTx

--- a/zaino-state/src/chain_index/types/helpers.rs
+++ b/zaino-state/src/chain_index/types/helpers.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains non-database types used for in-memory operations,
 //! conversions, and coordination between database types. These types do NOT
-//! implement `ZainoVersionedSerialise` and are not persisted to disk.
+//! implement `ZainoVersionedSerde` and are not persisted to disk.
 //!
 //! Types in this module:
 //! - BestChainLocation - Transaction location in best chain


### PR DESCRIPTION
## Motivation

`ZainoVersionedSerialise` reads and writes to db, so it deserialises too.

## Solution

Rename to `ZainoVersionSerde` seems appropiate

### Tests

Not needed, clean rename
