### PR TITLE
docs: mark `StateService` and `FetchService` types as deprecated

### DIFF
--- a/integration-tests/tests/chain_cache.rs
+++ b/integration-tests/tests/chain_cache.rs
@@ -45,6 +45,7 @@ async fn create_test_manager_and_connector(
     (test_manager, json_service)
 }
 
+#[allow(deprecated)]
 mod chain_query_interface {
 
     use std::{path::PathBuf, time::Duration};
@@ -73,6 +74,7 @@ mod chain_query_interface {
 
     use super::*;
 
+    #[allow(deprecated)]
     async fn create_test_manager_and_chain_index(
         validator: &ValidatorKind,
         chain_cache: Option<std::path::PathBuf>,

--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -8,6 +8,7 @@ use zaino_proto::proto::service::{
     AddressList, BlockId, BlockRange, Exclude, GetAddressUtxosArg, GetSubtreeRootsArg,
     TransparentAddressBlockFilter, TxFilter,
 };
+#[allow(deprecated)]
 use zaino_state::{
     BackendType, FetchService, FetchServiceConfig, FetchServiceSubscriber, LightWalletIndexer,
     StatusType, ZcashIndexer, ZcashService as _,
@@ -19,6 +20,7 @@ use zebra_rpc::client::ValidateAddressResponse;
 use zebra_rpc::methods::{AddressStrings, GetAddressTxIdsRequest, GetBlock, GetBlockHash};
 use zip32::AccountId;
 
+#[allow(deprecated)]
 async fn create_test_manager_and_fetch_service(
     validator: &ValidatorKind,
     chain_cache: Option<std::path::PathBuf>,

--- a/integration-tests/tests/json_server.rs
+++ b/integration-tests/tests/json_server.rs
@@ -2,6 +2,8 @@
 
 use zaino_common::network::ActivationHeights;
 use zaino_common::{DatabaseConfig, ServiceConfig, StorageConfig};
+
+#[allow(deprecated)]
 use zaino_state::{
     BackendType, FetchService, FetchServiceConfig, FetchServiceSubscriber, ZcashIndexer,
     ZcashService as _,
@@ -11,6 +13,7 @@ use zaino_testutils::{TestManager, ValidatorKind};
 use zebra_chain::subtree::NoteCommitmentSubtreeIndex;
 use zebra_rpc::methods::{AddressStrings, GetAddressTxIdsRequest, GetInfo};
 
+#[allow(deprecated)]
 async fn create_test_manager_and_fetch_services(
     enable_cookie_auth: bool,
     clients: bool,

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -1,6 +1,8 @@
 use zaino_common::network::ActivationHeights;
 use zaino_common::{DatabaseConfig, ServiceConfig, StorageConfig};
 use zaino_state::BackendType;
+
+#[allow(deprecated)]
 use zaino_state::{
     FetchService, FetchServiceConfig, FetchServiceSubscriber, LightWalletIndexer, StateService,
     StateServiceConfig, StateServiceSubscriber, ZcashIndexer, ZcashService as _,
@@ -13,6 +15,7 @@ use zebra_chain::subtree::NoteCommitmentSubtreeIndex;
 use zebra_rpc::methods::{AddressStrings, GetAddressTxIdsRequest, GetInfo};
 use zip32::AccountId;
 
+#[allow(deprecated)]
 async fn create_test_manager_and_services(
     validator: &ValidatorKind,
     chain_cache: Option<std::path::PathBuf>,
@@ -1408,6 +1411,7 @@ mod zebrad {
 
         /// `getmempoolinfo` computed from local Broadcast state
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        #[allow(deprecated)]
         async fn get_mempool_info() {
             let (
                 mut test_manager,

--- a/integration-tests/tests/test_vectors.rs
+++ b/integration-tests/tests/test_vectors.rs
@@ -22,6 +22,8 @@ use zaino_state::write_u32_le;
 use zaino_state::write_u64_le;
 use zaino_state::CompactSize;
 use zaino_state::{BackendType, ChainWork, IndexedBlock};
+
+#[allow(deprecated)]
 use zaino_state::{
     StateService, StateServiceConfig, StateServiceSubscriber, ZcashIndexer, ZcashService as _,
 };
@@ -47,6 +49,7 @@ macro_rules! expected_read_response {
     };
 }
 
+#[allow(deprecated)]
 async fn create_test_manager_and_services(
     validator: &ValidatorKind,
     chain_cache: Option<std::path::PathBuf>,
@@ -134,6 +137,7 @@ async fn create_test_manager_and_services(
     (test_manager, state_service, state_subscriber)
 }
 
+#[allow(deprecated)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "Not a test! Used to build test vector data for zaino_state::chain_index unit tests."]
 async fn create_200_block_regtest_chain_vectors() {

--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -69,7 +69,7 @@ use crate::{
 ///       ServiceSubscribers are used to create separate chain fetch processes while allowing central state processes to be managed in a single place.
 ///       If we want the ability to clone Service all JoinHandle's should be converted to Arc\<JoinHandle\>.
 #[derive(Debug)]
-#[deprecated = "Will be eventually replaced by `BlockchainSource"]
+#[deprecated = "Will be eventually replaced by `BlockchainSource`"]
 pub struct FetchService {
     /// JsonRPC Client.
     fetcher: JsonRpSeeConnector,

--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -40,6 +40,7 @@ use zaino_proto::proto::{
     },
 };
 
+#[allow(deprecated)]
 use crate::{
     chain_index::{
         mempool::{Mempool, MempoolSubscriber},
@@ -68,20 +69,27 @@ use crate::{
 ///       ServiceSubscribers are used to create separate chain fetch processes while allowing central state processes to be managed in a single place.
 ///       If we want the ability to clone Service all JoinHandle's should be converted to Arc\<JoinHandle\>.
 #[derive(Debug)]
+#[deprecated = "Will be eventually replaced by `BlockchainSource"]
 pub struct FetchService {
     /// JsonRPC Client.
     fetcher: JsonRpSeeConnector,
+
     /// Local compact block cache.
     block_cache: BlockCache,
+
     /// Internal mempool.
     mempool: Mempool<ValidatorConnector>,
+
     /// Service metadata.
     data: ServiceMetadata,
+
     /// StateService config data.
+    #[allow(deprecated)]
     config: FetchServiceConfig,
 }
 
 #[async_trait]
+#[allow(deprecated)]
 impl ZcashService for FetchService {
     type Subscriber = FetchServiceSubscriber;
     type Config = FetchServiceConfig;
@@ -160,6 +168,7 @@ impl ZcashService for FetchService {
     }
 }
 
+#[allow(deprecated)]
 impl Drop for FetchService {
     fn drop(&mut self) {
         self.close()
@@ -170,16 +179,22 @@ impl Drop for FetchService {
 ///
 /// Subscribers should be
 #[derive(Debug, Clone)]
+#[allow(deprecated)]
 pub struct FetchServiceSubscriber {
     /// JsonRPC Client.
     pub fetcher: JsonRpSeeConnector,
+
     /// Local compact block cache.
     pub block_cache: BlockCacheSubscriber,
+
     /// Internal mempool.
     pub mempool: MempoolSubscriber,
+
     /// Service metadata.
     pub data: ServiceMetadata,
+
     /// StateService config data.
+    #[allow(deprecated)]
     config: FetchServiceConfig,
 }
 
@@ -193,12 +208,14 @@ impl FetchServiceSubscriber {
     }
 
     /// Returns the network type running.
+    #[allow(deprecated)]
     pub fn network(&self) -> zaino_common::Network {
         self.config.network
     }
 }
 
 #[async_trait]
+#[allow(deprecated)]
 impl ZcashIndexer for FetchServiceSubscriber {
     type Error = FetchServiceError;
 
@@ -617,6 +634,7 @@ impl ZcashIndexer for FetchServiceSubscriber {
 }
 
 #[async_trait]
+#[allow(deprecated)]
 impl LightWalletIndexer for FetchServiceSubscriber {
     /// Return the height of the tip of the best chain
     async fn get_latest_block(&self) -> Result<BlockId, Self::Error> {
@@ -716,6 +734,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
     }
 
     /// Return a list of consecutive compact blocks
+    #[allow(deprecated)]
     async fn get_block_range(
         &self,
         request: BlockRange,
@@ -828,6 +847,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
     /// Same as GetBlockRange except actions contain only nullifiers
     ///
     /// NOTE: Currently this only returns Orchard nullifiers to follow Lightwalletd functionality but Sapling could be added if required by wallets.
+    #[allow(deprecated)]
     async fn get_block_range_nullifiers(
         &self,
         request: BlockRange,
@@ -953,6 +973,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
     }
 
     /// Return the txids corresponding to the given t-address within the given block range
+    #[allow(deprecated)]
     async fn get_taddress_txids(
         &self,
         request: TransparentAddressBlockFilter,
@@ -1016,6 +1037,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
     }
 
     /// Returns the total balance for a list of taddrs
+    #[allow(deprecated)]
     async fn get_taddress_balance_stream(
         &self,
         mut request: AddressStream,
@@ -1121,6 +1143,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
     /// more bandwidth-efficient; if two or more transactions in the mempool
     /// match a shortened txid, they are all sent (none is excluded). Transactions
     /// in the exclude list that don't exist in the mempool are ignored.
+    #[allow(deprecated)]
     async fn get_mempool_tx(
         &self,
         request: Exclude,
@@ -1223,6 +1246,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
 
     /// Return a stream of current Mempool transactions. This will keep the output stream open while
     /// there are mempool transactions. It will close the returned stream when a new block is mined.
+    #[allow(deprecated)]
     async fn get_mempool_stream(&self) -> Result<RawTransactionStream, Self::Error> {
         let mut mempool = self.mempool.clone();
         let service_timeout = self.config.service.timeout;
@@ -1373,6 +1397,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
         }
     }
 
+    #[allow(deprecated)]
     fn timeout_channel_size(&self) -> (u32, u32) {
         (
             self.config.service.timeout,
@@ -1436,6 +1461,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
     /// Ignores all utxos below block height [GetAddressUtxosArg.start_height].
     /// Returns max [GetAddressUtxosArg.max_entries] utxos, or unrestricted if [GetAddressUtxosArg.max_entries] = 0.
     /// Utxos are returned in a stream.
+    #[allow(deprecated)]
     async fn get_address_utxos_stream(
         &self,
         request: GetAddressUtxosArg,

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -1,5 +1,6 @@
 //! Zcash chain fetch and tx submission service backed by Zebras [`ReadStateService`].
 
+#[allow(deprecated)]
 use crate::{
     chain_index::{
         mempool::{Mempool, MempoolSubscriber},
@@ -102,27 +103,38 @@ macro_rules! expected_read_response {
 ///       If we want the ability to clone Service all JoinHandle's should be
 /// converted to Arc\<JoinHandle\>.
 #[derive(Debug)]
+#[deprecated = "Will be eventually replaced by `BlockchainSource"]
 pub struct StateService {
     /// `ReadeStateService` from Zebra-State.
     read_state_service: ReadStateService,
+
     /// Sync task handle.
     sync_task_handle: Option<Arc<tokio::task::JoinHandle<()>>>,
+
     /// JsonRPC Client.
     rpc_client: JsonRpSeeConnector,
+
     /// Local compact block cache.
     block_cache: BlockCache,
+
     /// Internal mempool.
     mempool: Mempool<ValidatorConnector>,
+
     /// Service metadata.
     data: ServiceMetadata,
+
     /// StateService config data.
+    #[allow(deprecated)]
     config: StateServiceConfig,
+
     /// Thread-safe status indicator.
     status: AtomicStatus,
+
     /// Listener for when the chain tip changes
     chain_tip_change: zebra_state::ChainTipChange,
 }
 
+#[allow(deprecated)]
 impl StateService {
     /// Uses poll_ready to update the status of the `ReadStateService`.
     async fn fetch_status_from_validator(&self) -> StatusType {
@@ -153,6 +165,7 @@ impl StateService {
 }
 
 #[async_trait]
+#[allow(deprecated)]
 impl ZcashService for StateService {
     type Subscriber = StateServiceSubscriber;
     type Config = StateServiceConfig;
@@ -311,6 +324,7 @@ impl ZcashService for StateService {
     }
 }
 
+#[allow(deprecated)]
 impl Drop for StateService {
     fn drop(&mut self) {
         self.close()
@@ -321,19 +335,27 @@ impl Drop for StateService {
 ///
 /// Subscribers should be
 #[derive(Debug, Clone)]
+#[deprecated]
 pub struct StateServiceSubscriber {
     /// Remote wrappper functionality for zebra's [`ReadStateService`].
     pub read_state_service: ReadStateService,
+
     /// JsonRPC Client.
     pub rpc_client: JsonRpSeeConnector,
+
     /// Local compact block cache.
     pub block_cache: BlockCacheSubscriber,
+
     /// Internal mempool.
     pub mempool: MempoolSubscriber,
+
     /// Service metadata.
     pub data: ServiceMetadata,
+
     /// StateService config data.
+    #[allow(deprecated)]
     config: StateServiceConfig,
+
     /// Listener for when the chain tip changes
     chain_tip_change: zebra_state::ChainTipChange,
 }
@@ -361,6 +383,7 @@ impl ChainTipSubscriber {
 ///
 /// These would be simple to add to the public interface if
 /// needed, there are currently no plans to do so.
+#[allow(deprecated)]
 impl StateServiceSubscriber {
     /// Gets a Subscriber to any updates to the latest chain tip
     pub fn chaintip_update_subscriber(&self) -> ChainTipSubscriber {
@@ -512,7 +535,7 @@ impl StateServiceSubscriber {
     }
 
     /// Return a list of consecutive compact blocks.
-    #[allow(dead_code)]
+    #[allow(dead_code, deprecated)]
     async fn get_block_range_inner(
         &self,
         request: BlockRange,
@@ -854,12 +877,14 @@ impl StateServiceSubscriber {
     }
 
     /// Returns the network type running.
+    #[allow(deprecated)]
     pub fn network(&self) -> zaino_common::Network {
         self.config.network
     }
 }
 
 #[async_trait]
+#[allow(deprecated)]
 impl ZcashIndexer for StateServiceSubscriber {
     type Error = StateServiceError;
 
@@ -1561,6 +1586,7 @@ impl ZcashIndexer for StateServiceSubscriber {
 }
 
 #[async_trait]
+#[allow(deprecated)]
 impl LightWalletIndexer for StateServiceSubscriber {
     /// Return the height of the tip of the best chain
     async fn get_latest_block(&self) -> Result<BlockId, Self::Error> {
@@ -2195,7 +2221,7 @@ impl LightWalletIndexer for StateServiceSubscriber {
     }
 }
 
-#[allow(clippy::result_large_err)]
+#[allow(clippy::result_large_err, deprecated)]
 fn header_to_block_commitments(
     header: &Header,
     network: &Network,

--- a/zaino-state/src/config.rs
+++ b/zaino-state/src/config.rs
@@ -12,8 +12,9 @@ pub enum BackendType {
     Fetch,
 }
 
-#[derive(Debug, Clone)]
 /// Unified backend configuration enum.
+#[derive(Debug, Clone)]
+#[allow(deprecated)]
 pub enum BackendConfig {
     /// StateService config.
     State(StateServiceConfig),
@@ -23,6 +24,7 @@ pub enum BackendConfig {
 
 /// Holds config data for [crate::StateService].
 #[derive(Debug, Clone)]
+#[deprecated]
 pub struct StateServiceConfig {
     /// Zebra [`zebra_state::ReadStateService`] config data
     pub validator_config: zebra_state::Config,
@@ -52,6 +54,7 @@ pub struct StateServiceConfig {
     pub no_db: bool,
 }
 
+#[allow(deprecated)]
 impl StateServiceConfig {
     /// Returns a new instance of [`StateServiceConfig`].
     #[allow(clippy::too_many_arguments)]
@@ -89,6 +92,7 @@ impl StateServiceConfig {
 
 /// Holds config data for [crate::FetchService].
 #[derive(Debug, Clone)]
+#[deprecated]
 pub struct FetchServiceConfig {
     /// Validator JsonRPC address.
     pub validator_rpc_address: std::net::SocketAddr,
@@ -114,6 +118,7 @@ pub struct FetchServiceConfig {
     pub no_db: bool,
 }
 
+#[allow(deprecated)]
 impl FetchServiceConfig {
     /// Returns a new instance of [`FetchServiceConfig`].
     #[allow(clippy::too_many_arguments)]
@@ -183,6 +188,7 @@ impl BlockCacheConfig {
     }
 }
 
+#[allow(deprecated)]
 impl From<StateServiceConfig> for BlockCacheConfig {
     fn from(value: StateServiceConfig) -> Self {
         Self {
@@ -196,6 +202,7 @@ impl From<StateServiceConfig> for BlockCacheConfig {
     }
 }
 
+#[allow(deprecated)]
 impl From<FetchServiceConfig> for BlockCacheConfig {
     fn from(value: FetchServiceConfig) -> Self {
         Self {

--- a/zaino-state/src/error.rs
+++ b/zaino-state/src/error.rs
@@ -1,4 +1,5 @@
 //! Holds error types for Zaino-state.
+#![allow(deprecated)]
 
 use crate::BlockHash;
 
@@ -6,6 +7,7 @@ use std::{any::type_name, fmt::Display};
 
 use zaino_fetch::jsonrpsee::connector::RpcRequestError;
 
+#[allow(deprecated)]
 impl<T: ToString> From<RpcRequestError<T>> for StateServiceError {
     fn from(value: RpcRequestError<T>) -> Self {
         match value {
@@ -28,6 +30,7 @@ impl<T: ToString> From<RpcRequestError<T>> for StateServiceError {
 }
 
 /// Errors related to the `StateService`.
+#[deprecated]
 #[derive(Debug, thiserror::Error)]
 pub enum StateServiceError {
     /// An rpc-specific error we haven't accounted for
@@ -130,6 +133,7 @@ impl From<StateServiceError> for tonic::Status {
     }
 }
 
+#[allow(deprecated)]
 impl<T: ToString> From<RpcRequestError<T>> for FetchServiceError {
     fn from(value: RpcRequestError<T>) -> Self {
         match value {
@@ -162,6 +166,7 @@ impl<T: ToString> From<RpcRequestError<T>> for FetchServiceError {
 }
 
 /// Errors related to the `FetchService`.
+#[deprecated]
 #[derive(Debug, thiserror::Error)]
 pub enum FetchServiceError {
     /// Critical Errors, Restart Zaino.

--- a/zaino-state/src/error.rs
+++ b/zaino-state/src/error.rs
@@ -1,5 +1,4 @@
 //! Holds error types for Zaino-state.
-#![allow(deprecated)]
 
 use crate::BlockHash;
 

--- a/zaino-state/src/lib.rs
+++ b/zaino-state/src/lib.rs
@@ -21,6 +21,7 @@ pub use indexer::{
 
 pub(crate) mod backends;
 
+#[allow(deprecated)]
 pub use backends::{
     fetch::{FetchService, FetchServiceSubscriber},
     state::{StateService, StateServiceSubscriber},
@@ -66,12 +67,14 @@ pub mod test_dependencies {
 
 pub(crate) mod config;
 
+#[allow(deprecated)]
 pub use config::{
     BackendConfig, BackendType, BlockCacheConfig, FetchServiceConfig, StateServiceConfig,
 };
 
 pub(crate) mod error;
 
+#[allow(deprecated)]
 pub use error::{FetchServiceError, StateServiceError};
 
 pub(crate) mod status;

--- a/zaino-state/src/local_cache.rs
+++ b/zaino-state/src/local_cache.rs
@@ -2,6 +2,7 @@
 
 use std::any::type_name;
 
+#[allow(deprecated)]
 use crate::{
     config::BlockCacheConfig, error::BlockCacheError, status::StatusType, StateServiceSubscriber,
 };
@@ -226,6 +227,7 @@ pub(crate) async fn fetch_block_from_node(
     try_fetcher_path(fetcher, hash_or_height).await
 }
 
+#[allow(deprecated)]
 async fn try_state_path(
     state: &ReadStateService,
     network: &Network,

--- a/zainod/src/config.rs
+++ b/zainod/src/config.rs
@@ -21,6 +21,8 @@ use tracing::{error, info};
 use zaino_common::{
     CacheConfig, DatabaseConfig, DatabaseSize, Network, ServiceConfig, StorageConfig,
 };
+
+#[allow(deprecated)]
 use zaino_state::{BackendConfig, FetchServiceConfig, StateServiceConfig};
 
 use crate::error::IndexerError;
@@ -374,6 +376,7 @@ pub fn load_config(file_path: &PathBuf) -> Result<IndexerConfig, IndexerError> {
 impl TryFrom<IndexerConfig> for BackendConfig {
     type Error = IndexerError;
 
+    #[allow(deprecated)]
     fn try_from(cfg: IndexerConfig) -> Result<Self, Self::Error> {
         match cfg.backend {
             zaino_state::BackendType::State => Ok(BackendConfig::State(StateServiceConfig {

--- a/zainod/src/error.rs
+++ b/zainod/src/error.rs
@@ -2,10 +2,13 @@
 
 use zaino_fetch::jsonrpsee::error::TransportError;
 use zaino_serve::server::error::ServerError;
+
+#[allow(deprecated)]
 use zaino_state::{FetchServiceError, StateServiceError};
 
 /// Zingo-Indexer errors.
 #[derive(Debug, thiserror::Error)]
+#[allow(deprecated)]
 pub enum IndexerError {
     /// Server based errors.
     #[error("Server error: {0}")]
@@ -36,11 +39,14 @@ pub enum IndexerError {
     Restart,
 }
 
+#[allow(deprecated)]
 impl From<StateServiceError> for IndexerError {
     fn from(value: StateServiceError) -> Self {
         IndexerError::StateServiceError(Box::new(value))
     }
 }
+
+#[allow(deprecated)]
 impl From<FetchServiceError> for IndexerError {
     fn from(value: FetchServiceError) -> Self {
         IndexerError::FetchServiceError(Box::new(value))

--- a/zainod/src/indexer.rs
+++ b/zainod/src/indexer.rs
@@ -9,6 +9,8 @@ use zaino_serve::server::{
     grpc::TonicServer,
     jsonrpc::JsonRpcServer,
 };
+
+#[allow(deprecated)]
 use zaino_state::{
     BackendConfig, FetchService, IndexerService, LightWalletService, StateService, StatusType,
     ZcashIndexer, ZcashService,
@@ -40,6 +42,7 @@ pub async fn start_indexer(
 }
 
 /// Spawns a new Indexer server.
+#[allow(deprecated)]
 pub async fn spawn_indexer(
     config: IndexerConfig,
 ) -> Result<tokio::task::JoinHandle<Result<(), IndexerError>>, IndexerError> {


### PR DESCRIPTION
## Motivation

`_Service` structs are going to be replaced. They should be marked as deprecated.

## Solution

Add attributes and `#[allow(deprecated)]` to keep track of where they're being used (and so that CI does not fail).

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
