### PR TITLE
fix(`zainod`): remove redundant `version` command

### DIFF
--- a/zainod/src/main.rs
+++ b/zainod/src/main.rs
@@ -1,6 +1,6 @@
 //! Zingo-Indexer daemon
 
-use clap::{CommandFactory, Parser};
+use clap::Parser;
 use std::path::PathBuf;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
@@ -26,12 +26,6 @@ async fn main() {
         .init();
 
     let args = Args::parse();
-
-    if std::env::args().any(|arg| arg == "--version" || arg == "-V") {
-        let cmd = Args::command();
-        println!("{}", cmd.get_version().unwrap());
-        return;
-    }
 
     let config_path = args
         .config


### PR DESCRIPTION
## Motivation

We're deriving `version` AND defining the version command. This is redundant.

## Solution

Use only the derive macro provided.

### Tests

Manually tested with `cargo run -- --version` and `cargo run -- -V`.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
