### PR TITLE
make path to often irrelevant config file absolute

### DIFF
--- a/zainod/src/main.rs
+++ b/zainod/src/main.rs
@@ -27,12 +27,16 @@ async fn main() {
 
     let args = Args::parse();
 
+    let config_file_location = std::env::current_dir()
+        .unwrap()
+        .join("zainod/zindexer.toml");
     let config_path = args
         .config
         .unwrap_or_else(|| PathBuf::from("./zainod/zindexer.toml"));
 
+    dbg!(std::env::current_dir().expect("Failed to get current directory"));
     loop {
-        match start_indexer(load_config(&config_path).unwrap()).await {
+        match start_indexer(load_config(&config_file_location).unwrap()).await {
             Ok(joinhandle_result) => {
                 info!("Zaino Indexer started successfully.");
                 match joinhandle_result.await {


### PR DESCRIPTION
This does what it says on the tin, and improves operation.