### PR TITLE
fix exclude list in get_mempool_tx to match behaviour of LWD

### DIFF
--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -1606,10 +1606,8 @@ async fn fetch_service_get_mempool_tx(validator: &ValidatorKind) {
     let mut sorted_fetch_mempool_tx = fetch_mempool_tx.clone();
     sorted_fetch_mempool_tx.sort_by_key(|tx| tx.hash.clone());
 
-    let mut tx1_bytes = *tx_1.first().as_ref();
-    tx1_bytes.reverse();
-    let mut tx2_bytes = *tx_2.first().as_ref();
-    tx2_bytes.reverse();
+    let tx1_bytes = *tx_1.first().as_ref();
+    let tx2_bytes = *tx_2.first().as_ref();
 
     let mut sorted_txids = [tx1_bytes, tx2_bytes];
     sorted_txids.sort_by_key(|hash| *hash);
@@ -1618,7 +1616,7 @@ async fn fetch_service_get_mempool_tx(validator: &ValidatorKind) {
     assert_eq!(sorted_fetch_mempool_tx[1].hash, sorted_txids[1]);
 
     let exclude_list = Exclude {
-        txid: vec![sorted_txids[0][..8].to_vec()],
+        txid: vec![sorted_txids[0][8..].to_vec()],
     };
 
     let exclude_fetch_service_stream = fetch_service_subscriber

--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -1608,12 +1608,12 @@ async fn fetch_service_get_mempool_tx(validator: &ValidatorKind) {
 
     let tx1_bytes = *tx_1.first().as_ref();
     let tx2_bytes = *tx_2.first().as_ref();
-
     let mut sorted_txids = [tx1_bytes, tx2_bytes];
     sorted_txids.sort_by_key(|hash| *hash);
 
     assert_eq!(sorted_fetch_mempool_tx[0].hash, sorted_txids[0]);
     assert_eq!(sorted_fetch_mempool_tx[1].hash, sorted_txids[1]);
+    assert_eq!(sorted_fetch_mempool_tx.len(), 2);
 
     let exclude_list = Exclude {
         txid: vec![sorted_txids[0][8..].to_vec()],
@@ -1634,6 +1634,7 @@ async fn fetch_service_get_mempool_tx(validator: &ValidatorKind) {
     sorted_exclude_fetch_mempool_tx.sort_by_key(|tx| tx.hash.clone());
 
     assert_eq!(sorted_exclude_fetch_mempool_tx[0].hash, sorted_txids[1]);
+    assert_eq!(sorted_exclude_fetch_mempool_tx.len(), 1);
 
     test_manager.close().await;
 }

--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -43,6 +43,7 @@ use zaino_proto::proto::{
     },
 };
 
+use crate::TransactionHash;
 #[allow(deprecated)]
 use crate::{
     chain_index::{
@@ -1203,6 +1204,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
             .txid
             .iter()
             .map(|txid_bytes| {
+                // NOTE: the TransactionHash methods cannot be used for this hex encoding as exclusions could be truncated to less than 32 bytes
                 let reversed_txid_bytes: Vec<u8> = txid_bytes.iter().cloned().rev().collect();
                 hex::encode(&reversed_txid_bytes)
             })
@@ -1217,8 +1219,8 @@ impl LightWalletIndexer for FetchServiceSubscriber {
                 async {
                     for (mempool_key, mempool_value) in
                         mempool.get_filtered_mempool(exclude_txids).await
-                    {
-                        let txid_bytes = match hex::decode(mempool_key.txid) {
+                    {                        
+                        let txid = match TransactionHash::from_hex(mempool_key.txid) {
                             Ok(bytes) => bytes,
                             Err(error) => {
                                 if channel_tx
@@ -1234,7 +1236,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
                         };
                         match <FullTransaction as ParseFromSlice>::parse_from_slice(
                             mempool_value.serialized_tx.as_ref().as_ref(),
-                            Some(vec![txid_bytes]),
+                            Some(vec![txid.0.to_vec()]),
                             None,
                         ) {
                             Ok(transaction) => {

--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -1219,7 +1219,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
                 async {
                     for (mempool_key, mempool_value) in
                         mempool.get_filtered_mempool(exclude_txids).await
-                    {                        
+                    {
                         let txid = match TransactionHash::from_hex(mempool_key.txid) {
                             Ok(bytes) => bytes,
                             Err(error) => {

--- a/zaino-state/src/chain_index/mempool.rs
+++ b/zaino-state/src/chain_index/mempool.rs
@@ -384,17 +384,9 @@ impl MempoolSubscriber {
 
         let mut txids_to_exclude: HashSet<MempoolKey> = HashSet::new();
         for exclude_txid in &exclude_list {
-            // Convert to big endian (server format).
-            let server_exclude_txid: String = exclude_txid
-                .chars()
-                .collect::<Vec<_>>()
-                .chunks(2)
-                .rev()
-                .map(|chunk| chunk.iter().collect::<String>())
-                .collect();
             let matching_txids: Vec<&String> = mempool_txids
                 .iter()
-                .filter(|txid| txid.starts_with(&server_exclude_txid))
+                .filter(|txid| txid.starts_with(exclude_txid))
                 .collect();
 
             if matching_txids.len() == 1 {

--- a/zaino-state/src/chain_index/tests.rs
+++ b/zaino-state/src/chain_index/tests.rs
@@ -391,22 +391,9 @@ mod mockchain_tests {
             })
             .unwrap_or_default();
         let exclude_tx = mempool_transactions.pop().unwrap();
-        dbg!(&exclude_tx.hash());
-
-        // Reverse format to client type.
-        //
-        // TODO: Explore whether this is the correct byte order or whether we
-        // replicated a bug in old code.
-        let exclude_txid: String = exclude_tx
+        let exclude_txid = exclude_tx
             .hash()
-            .to_string()
-            .chars()
-            .collect::<Vec<_>>()
-            .chunks(2)
-            .rev()
-            .map(|chunk| chunk.iter().collect::<String>())
-            .collect();
-        dbg!(&exclude_txid);
+            .to_string();
         mempool_transactions.sort_by_key(|a| a.hash());
 
         let mut found_mempool_transactions: Vec<zebra_chain::transaction::Transaction> =

--- a/zaino-state/src/chain_index/tests.rs
+++ b/zaino-state/src/chain_index/tests.rs
@@ -391,9 +391,7 @@ mod mockchain_tests {
             })
             .unwrap_or_default();
         let exclude_tx = mempool_transactions.pop().unwrap();
-        let exclude_txid = exclude_tx
-            .hash()
-            .to_string();
+        let exclude_txid = exclude_tx.hash().to_string();
         mempool_transactions.sort_by_key(|a| a.hash());
 
         let mut found_mempool_transactions: Vec<zebra_chain::transaction::Transaction> =

--- a/zaino-state/src/chain_index/tests/mempool.rs
+++ b/zaino-state/src/chain_index/tests/mempool.rs
@@ -97,7 +97,7 @@ async fn get_filtered_mempool() {
     let (_mempool, subscriber, mockchain, block_data) = spawn_mempool_and_mockchain().await;
 
     mockchain.mine_blocks(150);
-    let active_chain_height = dbg!(mockchain.active_height());
+    let active_chain_height = mockchain.active_height();
 
     sleep(Duration::from_millis(2000)).await;
 
@@ -108,24 +108,15 @@ async fn get_filtered_mempool() {
         .unwrap_or_default();
 
     let exclude_hash = mempool_transactions[0].hash();
-    // Reverse format to client type.
-    let client_exclude_txid: String = exclude_hash
-        .to_string()
-        .chars()
-        .collect::<Vec<_>>()
-        .chunks(2)
-        .rev()
-        .map(|chunk| chunk.iter().collect::<String>())
-        .collect();
 
     let subscriber_tx = subscriber
-        .get_filtered_mempool(vec![client_exclude_txid])
+        .get_filtered_mempool(vec![exclude_hash.to_string()])
         .await;
 
     println!("Checking transactions..");
 
     for transaction in mempool_transactions.into_iter() {
-        let transaction_hash = dbg!(transaction.hash());
+        let transaction_hash = transaction.hash();
         if transaction_hash == exclude_hash {
             // check tx is *not* in mempool transactions
             let maybe_subscriber_tx = subscriber_tx


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

a. Client RPC `get_mempool_tx` test is failing due to zaino not excluding mempool txs in the exclude list
b. fixes a bug where `get_mempool_tx` returns compact tx's with reversed txids (fixed in LWD but not yet released)

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

## Solution

remove the incorrect byte chunk reversal of the txid hex-encoded string, probably due to other reversal issues that are now solved.

<!-- Describe the changes in the PR. -->

### Tests

https://github.com/zingolabs/infrastructure/pull/168

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work


<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
