### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/architecture.yaml
+++ b/.github/ISSUE_TEMPLATE/architecture.yaml
@@ -1,0 +1,63 @@
+name: "Architecture Issue"
+description: Document structural concerns, design decisions, or refactoring needs
+labels: ["architecture"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to document architectural concerns, design problems, or areas needing refactoring.
+
+        These issues help track technical debt and guide future development.
+
+  - type: textarea
+    id: observation
+    attributes:
+      label: Observation
+      description: What architectural concern have you identified?
+      placeholder: |
+        The X module is tightly coupled with Y...
+        The current design makes it difficult to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: location
+    attributes:
+      label: Location in codebase
+      description: Which modules, files, or components are affected?
+      placeholder: |
+        - `zaino-state/src/...`
+        - `chain_index::finalized_state::...`
+    validations:
+      required: true
+
+  - type: dropdown
+    id: concern_type
+    attributes:
+      label: Type of concern
+      description: What category best describes this?
+      multiple: true
+      options:
+        - Coupling / Dependencies
+        - Abstraction boundaries
+        - Separation of concerns
+        - API design
+        - Module organization
+        - Type system / Safety
+        - Persistence layer
+        - Error handling
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: How does this affect development, maintenance, or correctness?
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested direction
+      description: Any ideas on how to address this? (optional)

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,88 @@
+name: "Bug Report"
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+        **Before submitting**, please check if a similar issue already exists.
+
+  - type: dropdown
+    id: usage
+    attributes:
+      label: Usage mode
+      description: How are you using Zaino?
+      options:
+        - zainod (running the daemon)
+        - Library integration (using zaino-* crates)
+        - Both / Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: List the steps to reproduce the issue.
+      placeholder: |
+        1. Start zainod with config...
+        2. Send request to...
+        3. Observe error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Please include:
+        - Zaino version or commit hash
+        - Backend version (zebra/zcashd)
+        - OS and platform
+      placeholder: |
+        Zaino: v0.x.x or commit abc123
+        Backend: Zebra 27.0.0
+        OS: Linux x86_64 / macOS ARM64
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: Paste your zainod config file (redact any sensitive values).
+      render: toml
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Relevant log output. Use debug logging if possible (`level = "debug"` in config).
+        Wrap long logs in `<details>` tags.
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other relevant information (config snippets, block heights, tx ids, etc.)

--- a/.github/ISSUE_TEMPLATE/code_smell.yaml
+++ b/.github/ISSUE_TEMPLATE/code_smell.yaml
@@ -1,0 +1,67 @@
+name: "Code Smell"
+description: Flag anti-patterns, naming issues, or code that needs attention
+labels: ["code-smell"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this to flag code that works but has problems worth addressing.
+
+        Code smells are indicators of deeper issues - they may or may not need immediate action.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What's the smell?
+      description: Describe the problematic pattern or code.
+    validations:
+      required: true
+
+  - type: textarea
+    id: location
+    attributes:
+      label: Location
+      description: Where is this code? (file paths, module names, function names)
+      placeholder: |
+        `chain_index/src/finalized_state/entry.rs:42`
+    validations:
+      required: true
+
+  - type: dropdown
+    id: smell_type
+    attributes:
+      label: Category
+      description: What type of smell is this?
+      multiple: true
+      options:
+        - Naming confusion
+        - Duplication
+        - Long function / God object
+        - Primitive obsession
+        - Feature envy
+        - Inappropriate intimacy (tight coupling)
+        - Dead code
+        - Magic numbers / strings
+        - Missing abstraction
+        - Test smell
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Severity
+      description: How urgently should this be addressed?
+      options:
+        - Low - Nice to fix eventually
+        - Medium - Should fix when touching this code
+        - High - Actively causing problems
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: How might this be improved? (optional)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions & Discussion
+    url: https://github.com/zingolabs/zaino/discussions
+    about: Ask questions or start a discussion (if Discussions is enabled)
+  - name: Zcash Community Forum
+    url: https://forum.zcashcommunity.com/
+    about: General Zcash ecosystem questions

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,68 @@
+name: "Feature Request"
+description: Suggest a new feature or API enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement!
+
+        Feature requests help us understand what the community needs.
+
+  - type: dropdown
+    id: usage
+    attributes:
+      label: Usage mode
+      description: How are you using Zaino?
+      options:
+        - zainod (running the daemon)
+        - Library integration (using zaino-* crates)
+        - Both / Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What problem does this solve? What are you trying to accomplish?
+      placeholder: I'm trying to... but currently...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How do you envision this working?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered other approaches? What are the trade-offs?
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of Zaino does this relate to?
+      multiple: true
+      options:
+        - gRPC API (CompactTxStreamer)
+        - JSON-RPC API
+        - Indexing / Chain state
+        - Configuration
+        - Performance
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other relevant information, examples from other projects, etc.

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -1,0 +1,54 @@
+name: "Task"
+description: Track implementation work, todos, or specific deliverables
+labels: ["tracking"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for tracking specific work items, implementation tasks, or deliverables.
+
+        Tasks are actionable items with a clear definition of done.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Task description
+      description: What needs to be done?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why is this needed? Link to parent issues or discussions if relevant.
+      placeholder: |
+        Part of #123
+        Related to the X migration...
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How do we know when this is done?
+      placeholder: |
+        - [ ] Implement X
+        - [ ] Add tests for Y
+        - [ ] Update documentation
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the codebase?
+      multiple: true
+      options:
+        - zainod
+        - zaino-state
+        - zaino-serve
+        - zaino-fetch
+        - zaino-proto
+        - chain_index
+        - Testing / CI
+        - Documentation
+        - Other


### PR DESCRIPTION
- Bug Report & Feature Request for consumers (with usage mode: daemon vs library)
- Architecture Issue, Code Smell, Task for maintainers
- config.yml with blank issues enabled and contact links

## Motivation

Issue creation is currently fully manual, we can leverage GitHub's features to streamline the process.

Once these changes merge, the issue creation interface will serve useful templates for both maintainers and external contributors/consumers.