### PR TITLE
fix: propagate no_tls_use_unencrypted_traffic to zaino-serve for regtest/dev

### DIFF
--- a/zaino-serve/Cargo.toml
+++ b/zaino-serve/Cargo.toml
@@ -10,6 +10,7 @@ version = { workspace = true }
 
 [features]
 state_service = []
+no_tls_use_unencrypted_traffic = ["tonic/tls-roots"]
 
 [dependencies]
 zaino-proto = { workspace = true }

--- a/zainod/Cargo.toml
+++ b/zainod/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [features]
 # Removes network restrictions.
-no_tls_use_unencrypted_traffic = []
+no_tls_use_unencrypted_traffic = ["zaino-serve/no_tls_use_unencrypted_traffic"]
 
 [dependencies]
 zaino-common = { workspace = true }


### PR DESCRIPTION

### Root Cause

The `no_tls_use_unencrypted_traffic` feature was declared in `zainod` but:
- Defined as an empty array → no propagation
- Never declared in `zaino-serve`, the crate that actually enforces TLS via `tonic`

So the TLS requirement was never disabled, making insecure gRPC binds impossible in Docker/regtest setups.

### Fix

- Add the `no_tls_use_unencrypted_traffic` feature to `zaino-serve` using `tonic/tls-roots` (keeps root certs but removes mandatory TLS enforcement)
- Propagate the feature from `zainod` → `zaino-serve`

After this change + building with `NO_TLS=true`, Zaino now:
- Starts cleanly
- Binds to `0.0.0.0:9067` with `insecure = true`
- Connects to Zebra on regtest port 8232
- Fully indexes blocks

Tested locally with ZecKit + Zebra regtest — works perfectly.