### PR TITLE
Add readiness polling to test utilities after block generation

### DIFF
--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -10,7 +10,7 @@ use zaino_proto::proto::service::{
 use zaino_state::ChainIndex;
 use zaino_state::FetchServiceSubscriber;
 #[allow(deprecated)]
-use zaino_state::{FetchService, LightWalletIndexer, StatusType, ZcashIndexer};
+use zaino_state::{FetchService, LightWalletIndexer, Status, StatusType, ZcashIndexer};
 use zaino_testutils::{TestManager, ValidatorExt, ValidatorKind};
 use zebra_chain::parameters::subsidy::ParameterSubsidy as _;
 use zebra_chain::subtree::NoteCommitmentSubtreeIndex;

--- a/zaino-common/src/lib.rs
+++ b/zaino-common/src/lib.rs
@@ -4,6 +4,8 @@
 //! and common utilities used across the Zaino blockchain indexer ecosystem.
 
 pub mod config;
+pub mod probing;
+pub mod status;
 
 // Re-export commonly used config types at crate root for backward compatibility.
 // This allows existing code using `use zaino_common::Network` to continue working.

--- a/zaino-common/src/probing.rs
+++ b/zaino-common/src/probing.rs
@@ -1,0 +1,71 @@
+//! Service health and readiness probing traits.
+//!
+//! This module provides decoupled traits for health and readiness checks,
+//! following the Kubernetes probe model:
+//!
+//! - [`Liveness`]: Is the component alive and functioning?
+//! - [`Readiness`]: Is the component ready to serve requests?
+//! - [`VitalsProbe`]: Combined trait for components supporting both probes.
+//!
+//! These traits are intentionally simple (returning `bool`) and decoupled
+//! from any specific status type, allowing flexible implementation across
+//! different components.
+//!
+//! # Example
+//!
+//! ```
+//! use zaino_common::probing::{Liveness, Readiness, VitalsProbe};
+//!
+//! struct MyService {
+//!     connected: bool,
+//!     synced: bool,
+//! }
+//!
+//! impl Liveness for MyService {
+//!     fn is_live(&self) -> bool {
+//!         self.connected
+//!     }
+//! }
+//!
+//! impl Readiness for MyService {
+//!     fn is_ready(&self) -> bool {
+//!         self.connected && self.synced
+//!     }
+//! }
+//!
+//! // VitalsProbe is automatically implemented via blanket impl
+//! fn check_service(service: &impl VitalsProbe) {
+//!     println!("Live: {}, Ready: {}", service.is_live(), service.is_ready());
+//! }
+//! ```
+
+/// Liveness probe: Is this component alive and functioning?
+///
+/// A component is considered "live" if it is not in a broken or
+/// unrecoverable state. This corresponds to Kubernetes liveness probes.
+///
+/// Failure to be live typically means the component should be restarted.
+pub trait Liveness {
+    /// Returns `true` if the component is alive and functioning.
+    fn is_live(&self) -> bool;
+}
+
+/// Readiness probe: Is this component ready to serve requests?
+///
+/// A component is considered "ready" if it can accept and process
+/// requests. This corresponds to Kubernetes readiness probes.
+///
+/// A component may be live but not ready (e.g., still syncing).
+pub trait Readiness {
+    /// Returns `true` if the component is ready to serve requests.
+    fn is_ready(&self) -> bool;
+}
+
+/// Combined vitals probe for components supporting both liveness and readiness.
+///
+/// This trait is automatically implemented for any type that implements
+/// both [`Liveness`] and [`Readiness`].
+pub trait VitalsProbe: Liveness + Readiness {}
+
+// Blanket implementation: anything with Liveness + Readiness gets VitalsProbe
+impl<T: Liveness + Readiness> VitalsProbe for T {}

--- a/zaino-common/src/status.rs
+++ b/zaino-common/src/status.rs
@@ -1,0 +1,108 @@
+//! Service status types.
+//!
+//! This module provides [`StatusType`], an enum representing service operational states.
+
+use std::fmt;
+
+/// Status of a service component.
+///
+/// Represents the operational state of a component.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum StatusType {
+    /// Running initial startup routine.
+    Spawning = 0,
+    /// Back-end process is currently syncing.
+    Syncing = 1,
+    /// Process is ready.
+    Ready = 2,
+    /// Process is busy working.
+    Busy = 3,
+    /// Running shutdown routine.
+    Closing = 4,
+    /// Offline.
+    Offline = 5,
+    /// Non-critical errors.
+    RecoverableError = 6,
+    /// Critical errors.
+    CriticalError = 7,
+}
+
+impl From<usize> for StatusType {
+    fn from(value: usize) -> Self {
+        match value {
+            0 => StatusType::Spawning,
+            1 => StatusType::Syncing,
+            2 => StatusType::Ready,
+            3 => StatusType::Busy,
+            4 => StatusType::Closing,
+            5 => StatusType::Offline,
+            6 => StatusType::RecoverableError,
+            _ => StatusType::CriticalError,
+        }
+    }
+}
+
+impl From<StatusType> for usize {
+    fn from(status: StatusType) -> Self {
+        status as usize
+    }
+}
+
+impl fmt::Display for StatusType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let status_str = match self {
+            StatusType::Spawning => "Spawning",
+            StatusType::Syncing => "Syncing",
+            StatusType::Ready => "Ready",
+            StatusType::Busy => "Busy",
+            StatusType::Closing => "Closing",
+            StatusType::Offline => "Offline",
+            StatusType::RecoverableError => "RecoverableError",
+            StatusType::CriticalError => "CriticalError",
+        };
+        write!(f, "{status_str}")
+    }
+}
+
+impl StatusType {
+    /// Returns the corresponding status symbol for the StatusType.
+    pub fn get_status_symbol(&self) -> String {
+        let (symbol, color_code) = match self {
+            // Yellow Statuses
+            StatusType::Syncing => ("\u{1F7E1}", "\x1b[33m"),
+            // Cyan Statuses
+            StatusType::Spawning | StatusType::Busy => ("\u{1F7E1}", "\x1b[36m"),
+            // Green Status
+            StatusType::Ready => ("\u{1F7E2}", "\x1b[32m"),
+            // Grey Statuses
+            StatusType::Closing | StatusType::Offline => ("\u{26AB}", "\x1b[90m"),
+            // Red Error Statuses
+            StatusType::RecoverableError | StatusType::CriticalError => ("\u{1F534}", "\x1b[31m"),
+        };
+
+        format!("{}{}{}", color_code, symbol, "\x1b[0m")
+    }
+
+    /// Look at two statuses, and return the more 'severe' of the two.
+    pub fn combine(self, other: StatusType) -> StatusType {
+        match (self, other) {
+            // If either is Closing, return Closing.
+            (StatusType::Closing, _) | (_, StatusType::Closing) => StatusType::Closing,
+            // If either is Offline or CriticalError, return CriticalError.
+            (StatusType::Offline, _)
+            | (_, StatusType::Offline)
+            | (StatusType::CriticalError, _)
+            | (_, StatusType::CriticalError) => StatusType::CriticalError,
+            // If either is RecoverableError, return RecoverableError.
+            (StatusType::RecoverableError, _) | (_, StatusType::RecoverableError) => {
+                StatusType::RecoverableError
+            }
+            // If either is Spawning, return Spawning.
+            (StatusType::Spawning, _) | (_, StatusType::Spawning) => StatusType::Spawning,
+            // If either is Syncing, return Syncing.
+            (StatusType::Syncing, _) | (_, StatusType::Syncing) => StatusType::Syncing,
+            // Otherwise, return Ready.
+            _ => StatusType::Ready,
+        }
+    }
+}

--- a/zaino-common/src/status.rs
+++ b/zaino-common/src/status.rs
@@ -1,8 +1,15 @@
-//! Service status types.
+//! Service status types and traits.
 //!
-//! This module provides [`StatusType`], an enum representing service operational states.
+//! This module provides:
+//! - [`StatusType`]: An enum representing service operational states
+//! - [`Status`]: A trait for types that can report their status
+//!
+//! Types implementing [`Status`] automatically gain [`Liveness`](crate::probing::Liveness)
+//! and [`Readiness`](crate::probing::Readiness) implementations via blanket impls.
 
 use std::fmt;
+
+use crate::probing::{Liveness, Readiness};
 
 /// Status of a service component.
 ///
@@ -104,5 +111,36 @@ impl StatusType {
             // Otherwise, return Ready.
             _ => StatusType::Ready,
         }
+    }
+
+    /// Returns `true` if this status indicates the component is alive (liveness probe).
+    pub fn is_live(self) -> bool {
+        !matches!(self, StatusType::Offline | StatusType::CriticalError)
+    }
+
+    /// Returns `true` if this status indicates the component is ready to serve (readiness probe).
+    pub fn is_ready(self) -> bool {
+        matches!(self, StatusType::Ready | StatusType::Busy)
+    }
+}
+
+/// Trait for types that can report their [`StatusType`].
+///
+/// Implementing this trait automatically provides [`Liveness`] and [`Readiness`]
+/// implementations via blanket impls.
+pub trait Status {
+    /// Returns the current status of this component.
+    fn status(&self) -> StatusType;
+}
+
+impl<T: Status> Liveness for T {
+    fn is_live(&self) -> bool {
+        self.status().is_live()
+    }
+}
+
+impl<T: Status> Readiness for T {
+    fn is_ready(&self) -> bool {
+        self.status().is_ready()
     }
 }

--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -56,7 +56,7 @@ use crate::{
     indexer::{
         handle_raw_transaction, IndexerSubscriber, LightWalletIndexer, ZcashIndexer, ZcashService,
     },
-    status::StatusType,
+    status::{Status, StatusType},
     stream::{
         AddressStream, CompactBlockStream, CompactTransactionStream, RawTransactionStream,
         UtxoReplyStream,
@@ -90,6 +90,13 @@ pub struct FetchService {
     /// StateService config data.
     #[allow(deprecated)]
     config: FetchServiceConfig,
+}
+
+#[allow(deprecated)]
+impl Status for FetchService {
+    fn status(&self) -> StatusType {
+        self.indexer.status()
+    }
 }
 
 #[async_trait]
@@ -148,11 +155,6 @@ impl ZcashService for FetchService {
             data: self.data.clone(),
             config: self.config.clone(),
         })
-    }
-
-    /// Returns the current status.
-    fn status(&self) -> StatusType {
-        self.indexer.status()
     }
 
     /// Shuts down the StateService.

--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -133,7 +133,7 @@ impl ZcashService for FetchService {
             config,
         };
 
-        while fetch_service.status().await != StatusType::Ready {
+        while fetch_service.status() != StatusType::Ready {
             tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         }
 
@@ -150,8 +150,8 @@ impl ZcashService for FetchService {
         })
     }
 
-    /// Fetches the current status
-    async fn status(&self) -> StatusType {
+    /// Returns the current status.
+    fn status(&self) -> StatusType {
         self.indexer.status()
     }
 

--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -191,9 +191,16 @@ pub struct FetchServiceSubscriber {
     config: FetchServiceConfig,
 }
 
+impl Status for FetchServiceSubscriber {
+    fn status(&self) -> StatusType {
+        self.indexer.status()
+    }
+}
+
 impl FetchServiceSubscriber {
     /// Fetches the current status
-    pub fn status(&self) -> StatusType {
+    #[deprecated(note = "Use the Status trait method instead")]
+    pub fn get_status(&self) -> StatusType {
         self.indexer.status()
     }
 

--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -697,7 +697,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
     /// Return the height of the tip of the best chain
     async fn get_latest_block(&self) -> Result<BlockId, Self::Error> {
         let tip = self.indexer.snapshot_nonfinalized_state().best_tip;
-        dbg!(&tip);
+        // dbg!(&tip);
 
         Ok(BlockId {
             height: tip.height.0 as u64,

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -87,7 +87,7 @@ use chrono::{DateTime, Utc};
 use futures::{TryFutureExt as _, TryStreamExt as _};
 use hex::{FromHex as _, ToHex};
 use indexmap::IndexMap;
-use std::{collections::HashSet, error::Error, fmt, future::poll_fn, str::FromStr, sync::Arc};
+use std::{collections::HashSet, error::Error, fmt, str::FromStr, sync::Arc};
 use tokio::{
     sync::mpsc,
     time::{self, timeout},
@@ -151,29 +151,7 @@ pub struct StateService {
     status: AtomicStatus,
 }
 
-// #[allow(deprecated)]
 impl StateService {
-    /// Uses poll_ready to update the status of the `ReadStateService`.
-    async fn fetch_status_from_validator(&self) -> StatusType {
-        let mut read_state_service = self.read_state_service.clone();
-        poll_fn(|cx| match read_state_service.poll_ready(cx) {
-            std::task::Poll::Ready(Ok(())) => {
-                self.status.store(StatusType::Ready);
-                std::task::Poll::Ready(StatusType::Ready)
-            }
-            std::task::Poll::Ready(Err(e)) => {
-                eprintln!("Service readiness error: {e:?}");
-                self.status.store(StatusType::CriticalError);
-                std::task::Poll::Ready(StatusType::CriticalError)
-            }
-            std::task::Poll::Pending => {
-                self.status.store(StatusType::Busy);
-                std::task::Poll::Pending
-            }
-        })
-        .await
-    }
-
     #[cfg(feature = "test_dependencies")]
     /// Helper for tests
     pub fn read_state_service(&self) -> &ReadStateService {
@@ -334,15 +312,12 @@ impl ZcashService for StateService {
     }
 
     /// Returns the StateService's Status.
-    ///
-    /// We first check for `status = StatusType::Closing` as this signifies a shutdown order
-    /// from an external process.
-    async fn status(&self) -> StatusType {
+    fn status(&self) -> StatusType {
         let current_status = self.status.load();
         if current_status == StatusType::Closing {
             current_status
         } else {
-            self.fetch_status_from_validator().await
+            self.indexer.status()
         }
     }
 

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -372,6 +372,12 @@ pub struct StateServiceSubscriber {
     pub data: ServiceMetadata,
 }
 
+impl Status for StateServiceSubscriber {
+    fn status(&self) -> StatusType {
+        self.indexer.status()
+    }
+}
+
 /// A subscriber to any chaintip updates
 #[derive(Clone)]
 pub struct ChainTipSubscriber {

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -1935,17 +1935,10 @@ impl ZcashIndexer for StateServiceSubscriber {
 impl LightWalletIndexer for StateServiceSubscriber {
     /// Return the height of the tip of the best chain
     async fn get_latest_block(&self) -> Result<BlockId, Self::Error> {
-        let mut state = self.read_state_service.clone();
-        let response = state
-            .ready()
-            .and_then(|service| service.call(ReadRequest::Tip))
-            .await?;
-        let (chain_height, chain_hash) = expected_read_response!(response, Tip).ok_or(
-            RpcError::new_from_legacycode(LegacyCode::Misc, "no blocks in chain"),
-        )?;
+        let tip = self.indexer.snapshot_nonfinalized_state().best_tip;
         Ok(BlockId {
-            height: chain_height.as_usize() as u64,
-            hash: chain_hash.0.to_vec(),
+            height: tip.height.0 as u64,
+            hash: tip.blockhash.0.to_vec(),
         })
     }
 

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -25,7 +25,6 @@ use crate::{
     utils::{blockid_to_hashorheight, get_build_info, ServiceMetadata},
     BackendType, MempoolKey,
 };
-use crate::{error::ChainIndexError, ChainIndex, NodeBackedChainIndex, NodeBackedChainIndexSubscriber, State};
 
 use nonempty::NonEmpty;
 use tokio_stream::StreamExt as _;

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -17,7 +17,7 @@ use crate::{
         handle_raw_transaction, IndexerSubscriber, LightWalletIndexer, ZcashIndexer, ZcashService,
     },
     local_cache::{compact_block_to_nullifiers, BlockCache, BlockCacheSubscriber},
-    status::{AtomicStatus, StatusType},
+    status::{AtomicStatus, Status, StatusType},
     stream::{
         AddressStream, CompactBlockStream, CompactTransactionStream, RawTransactionStream,
         UtxoReplyStream,
@@ -156,6 +156,17 @@ impl StateService {
     /// Helper for tests
     pub fn read_state_service(&self) -> &ReadStateService {
         &self.read_state_service
+    }
+}
+
+impl Status for StateService {
+    fn status(&self) -> StatusType {
+        let current_status = self.status.load();
+        if current_status == StatusType::Closing {
+            current_status
+        } else {
+            self.indexer.status()
+        }
     }
 }
 
@@ -309,16 +320,6 @@ impl ZcashService for StateService {
             config: self.config.clone(),
             chain_tip_change: self.chain_tip_change.clone(),
         })
-    }
-
-    /// Returns the StateService's Status.
-    fn status(&self) -> StatusType {
-        let current_status = self.status.load();
-        if current_status == StatusType::Closing {
-            current_status
-        } else {
-            self.indexer.status()
-        }
     }
 
     /// Shuts down the StateService.

--- a/zaino-state/src/chain_index.rs
+++ b/zaino-state/src/chain_index.rs
@@ -15,6 +15,7 @@ use crate::chain_index::non_finalised_state::BestTip;
 use crate::chain_index::types::db::metadata::MempoolInfo;
 use crate::chain_index::types::{BestChainLocation, NonBestChainLocation};
 use crate::error::{ChainIndexError, ChainIndexErrorKind, FinalisedStateError};
+use crate::status::Status;
 use crate::{AtomicStatus, StatusType, SyncError};
 use crate::{IndexedBlock, TransactionHash};
 use std::collections::HashSet;
@@ -571,8 +572,8 @@ pub struct NodeBackedChainIndexSubscriber<Source: BlockchainSource = ValidatorCo
 }
 
 impl<Source: BlockchainSource> NodeBackedChainIndexSubscriber<Source> {
-    /// Displays the status of the chain_index
-    pub fn status(&self) -> StatusType {
+    /// Returns the combined status of all chain index components.
+    pub fn combined_status(&self) -> StatusType {
         let finalized_status = self.finalized_state.status();
         let mempool_status = self.mempool.status();
         let combined_status = self
@@ -638,6 +639,12 @@ impl<Source: BlockchainSource> NodeBackedChainIndexSubscriber<Source> {
                 }
                 .into_iter(),
             ))
+    }
+}
+
+impl<Source: BlockchainSource> Status for NodeBackedChainIndexSubscriber<Source> {
+    fn status(&self) -> StatusType {
+        self.combined_status()
     }
 }
 

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -849,12 +849,41 @@ impl DbV1 {
         ))?;
         let block_height_bytes = block_height.to_bytes()?;
 
-        // check this is the *next* block in the chain.
-        tokio::task::block_in_place(|| {
+        // Check if this specific block already exists (idempotent write support for shared DB).
+        // This handles the case where multiple processes share the same ZainoDB.
+        let block_already_exists = tokio::task::block_in_place(|| {
             let ro = self.env.begin_ro_txn()?;
-            let cur = ro.open_ro_cursor(self.headers)?;
 
-            // Position the cursor at the last header we currently have
+            // First, check if a block at this specific height already exists
+            match ro.get(self.headers, &block_height_bytes) {
+                Ok(stored_header_bytes) => {
+                    // Block exists at this height - verify it's the same block
+                    // Data is stored as StoredEntryVar<BlockHeaderData>, so deserialize properly
+                    let stored_entry = StoredEntryVar::<BlockHeaderData>::from_bytes(stored_header_bytes)
+                        .map_err(|e| FinalisedStateError::Custom(format!(
+                            "header decode error during idempotency check: {e}"
+                        )))?;
+                    let stored_header = stored_entry.inner();
+                    if *stored_header.index().hash() == block_hash {
+                        // Same block already written, this is a no-op success
+                        return Ok(true);
+                    } else {
+                        return Err(FinalisedStateError::Custom(format!(
+                            "block at height {block_height:?} already exists with different hash \
+                             (stored: {:?}, incoming: {:?})",
+                            stored_header.index().hash(),
+                            block_hash
+                        )));
+                    }
+                }
+                Err(lmdb::Error::NotFound) => {
+                    // Block doesn't exist at this height, check if it's the next in sequence
+                }
+                Err(e) => return Err(FinalisedStateError::LmdbError(e)),
+            }
+
+            // Now verify this is the next block in the chain
+            let cur = ro.open_ro_cursor(self.headers)?;
             match cur.get(None, None, lmdb_sys::MDB_LAST) {
                 // Database already has blocks
                 Ok((last_height_bytes, _last_header_bytes)) => {
@@ -880,8 +909,18 @@ impl DbV1 {
                 }
                 Err(e) => return Err(FinalisedStateError::LmdbError(e)),
             }
-            Ok::<_, FinalisedStateError>(())
+            Ok::<_, FinalisedStateError>(false)
         })?;
+
+        // If block already exists with same hash, return success without re-writing
+        if block_already_exists {
+            self.status.store(StatusType::Ready);
+            info!(
+                "Block {} at height {} already exists in ZainoDB, skipping write.",
+                &block_hash, &block_height.0
+            );
+            return Ok(());
+        }
 
         // Build DBHeight
         let height_entry = StoredEntryFixed::new(
@@ -1215,13 +1254,74 @@ impl DbV1 {
 
                 Ok(())
             }
-            Err(e) => {
-                warn!("Error writing block to DB.");
+            Err(FinalisedStateError::LmdbError(lmdb::Error::KeyExist)) => {
+                // Block write failed because key already exists - another process wrote it
+                // between our check and our write. Wait briefly and verify it's the same block.
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-                let _ = self.delete_block(&block).await;
+                let height_bytes = block_height.to_bytes()?;
+                let verification_result = tokio::task::block_in_place(|| {
+                    // Sync to see latest commits from other processes
+                    self.env.sync(true).ok();
+                    let ro = self.env.begin_ro_txn()?;
+                    match ro.get(self.headers, &height_bytes) {
+                        Ok(stored_header_bytes) => {
+                            // Data is stored as StoredEntryVar<BlockHeaderData>
+                            let stored_entry = StoredEntryVar::<BlockHeaderData>::from_bytes(stored_header_bytes)
+                                .map_err(|e| FinalisedStateError::Custom(format!(
+                                    "header decode error in KeyExist handler: {e}"
+                                )))?;
+                            let stored_header = stored_entry.inner();
+                            if *stored_header.index().hash() == block_hash {
+                                Ok(true) // Block already written correctly
+                            } else {
+                                Err(FinalisedStateError::Custom(format!(
+                                    "KeyExist race: different block at height {} \
+                                     (stored: {:?}, incoming: {:?})",
+                                    block_height.0,
+                                    stored_header.index().hash(),
+                                    block_hash
+                                )))
+                            }
+                        }
+                        Err(lmdb::Error::NotFound) => {
+                            Err(FinalisedStateError::Custom(format!(
+                                "KeyExist but block not found at height {} after sync",
+                                block_height.0
+                            )))
+                        }
+                        Err(e) => Err(FinalisedStateError::LmdbError(e)),
+                    }
+                });
+
+                match verification_result {
+                    Ok(_) => {
+                        // Block was already written correctly by another process
+                        self.status.store(StatusType::Ready);
+                        info!(
+                            "Block {} at height {} was already written by another process, skipping.",
+                            &block_hash, &block_height.0
+                        );
+                        Ok(())
+                    }
+                    Err(e) => {
+                        warn!("Error writing block to DB: {e}");
+                        self.status.store(StatusType::RecoverableError);
+                        Err(FinalisedStateError::InvalidBlock {
+                            height: block_height.0,
+                            hash: block_hash,
+                            reason: e.to_string(),
+                        })
+                    }
+                }
+            }
+            Err(e) => {
+                warn!("Error writing block to DB: {e}");
+
+                // let _ = self.delete_block(&block).await;
                 tokio::task::block_in_place(|| self.env.sync(true))
                     .map_err(|e| FinalisedStateError::Custom(format!("LMDB sync failed: {e}")))?;
-                self.status.store(StatusType::RecoverableError);
+                self.status.store(StatusType::CriticalError);
                 Err(FinalisedStateError::InvalidBlock {
                     height: block_height.0,
                     hash: block_hash,

--- a/zaino-state/src/indexer.rs
+++ b/zaino-state/src/indexer.rs
@@ -35,7 +35,7 @@ use zebra_rpc::{
 };
 
 use crate::{
-    status::StatusType,
+    status::Status,
     stream::{
         AddressStream, CompactBlockStream, CompactTransactionStream, RawTransactionStream,
         SubtreeRootReplyStream, UtxoReplyStream,
@@ -80,8 +80,11 @@ where
 }
 
 /// Zcash Service functionality.
+///
+/// Implementors automatically gain [`Liveness`](zaino_common::probing::Liveness) and
+/// [`Readiness`](zaino_common::probing::Readiness) via the [`Status`] supertrait.
 #[async_trait]
-pub trait ZcashService: Sized {
+pub trait ZcashService: Sized + Status {
     /// Backend type. Read state or fetch service.
     const BACKEND_TYPE: BackendType;
 
@@ -97,9 +100,6 @@ pub trait ZcashService: Sized {
 
     /// Returns a [`IndexerSubscriber`].
     fn get_subscriber(&self) -> IndexerSubscriber<Self::Subscriber>;
-
-    /// Returns the current status.
-    fn status(&self) -> StatusType;
 
     /// Shuts down the StateService.
     fn close(&mut self);

--- a/zaino-state/src/indexer.rs
+++ b/zaino-state/src/indexer.rs
@@ -89,7 +89,7 @@ pub trait ZcashService: Sized + Status {
     const BACKEND_TYPE: BackendType;
 
     /// A subscriber to the service, used to fetch chain data.
-    type Subscriber: Clone + ZcashIndexer + LightWalletIndexer;
+    type Subscriber: Clone + ZcashIndexer + LightWalletIndexer + Status;
 
     /// Service Config.
     type Config: Clone;

--- a/zaino-state/src/indexer.rs
+++ b/zaino-state/src/indexer.rs
@@ -98,8 +98,8 @@ pub trait ZcashService: Sized {
     /// Returns a [`IndexerSubscriber`].
     fn get_subscriber(&self) -> IndexerSubscriber<Self::Subscriber>;
 
-    /// Fetches the current status
-    async fn status(&self) -> StatusType;
+    /// Returns the current status.
+    fn status(&self) -> StatusType;
 
     /// Shuts down the StateService.
     fn close(&mut self);

--- a/zaino-state/src/lib.rs
+++ b/zaino-state/src/lib.rs
@@ -79,7 +79,7 @@ pub use error::{FetchServiceError, StateServiceError};
 
 pub(crate) mod status;
 
-pub use status::{AtomicStatus, StatusType};
+pub use status::{AtomicStatus, Status, StatusType};
 
 pub(crate) mod stream;
 

--- a/zaino-state/src/status.rs
+++ b/zaino-state/src/status.rs
@@ -1,150 +1,35 @@
-//! Holds a thread safe status implementation.
+//! Thread-safe status wrapper.
+//!
+//! This module provides [`AtomicStatus`], a thread-safe wrapper for [`StatusType`].
 
-use std::{
-    fmt,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
 };
 
-/// Holds a thread safe representation of a StatusType.
-/// Possible values:
-/// - [0: Spawning]
-/// - [1: Syncing]
-/// - [2: Ready]
-/// - [3: Busy]
-/// - [4: Closing].
-/// - [>=5: Offline].
-/// - [>=6: Error].
-/// - [>=7: Critical-Error].
-///   TODO: Refine error code spec.
+pub use zaino_common::status::StatusType;
+
+/// Holds a thread-safe representation of a [`StatusType`].
 #[derive(Debug, Clone)]
 pub struct AtomicStatus {
     inner: Arc<AtomicUsize>,
 }
 
 impl AtomicStatus {
-    /// Creates a new AtomicStatus
+    /// Creates a new AtomicStatus.
     pub fn new(status: StatusType) -> Self {
         Self {
             inner: Arc::new(AtomicUsize::new(status.into())),
         }
     }
 
-    /// Loads the value held in the AtomicStatus
+    /// Loads the value held in the AtomicStatus.
     pub fn load(&self) -> StatusType {
         StatusType::from(self.inner.load(Ordering::SeqCst))
     }
 
-    /// Sets the value held in the AtomicStatus
+    /// Sets the value held in the AtomicStatus.
     pub fn store(&self, status: StatusType) {
-        self.inner
-            .store(status.into(), std::sync::atomic::Ordering::SeqCst);
-    }
-}
-
-/// Status of the server's components.
-///
-/// TODO: Some of these statuses may be artefacts of a previous version
-/// of the status. We may be able to remove some of them
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum StatusType {
-    /// Running initial startup routine.
-    Spawning = 0,
-    /// Back-end process is currently syncing.
-    Syncing = 1,
-    /// Process is ready.
-    Ready = 2,
-    /// Process is busy working.
-    Busy = 3,
-    /// Running shutdown routine.
-    Closing = 4,
-    /// Offline.
-    Offline = 5,
-    /// Non Critical Errors.
-    RecoverableError = 6,
-    /// Critical Errors.
-    CriticalError = 7,
-}
-
-impl From<usize> for StatusType {
-    fn from(value: usize) -> Self {
-        match value {
-            0 => StatusType::Spawning,
-            1 => StatusType::Syncing,
-            2 => StatusType::Ready,
-            3 => StatusType::Busy,
-            4 => StatusType::Closing,
-            5 => StatusType::Offline,
-            6 => StatusType::RecoverableError,
-            _ => StatusType::CriticalError,
-        }
-    }
-}
-
-impl From<StatusType> for usize {
-    fn from(status: StatusType) -> Self {
-        status as usize
-    }
-}
-
-impl fmt::Display for StatusType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let status_str = match self {
-            StatusType::Spawning => "Spawning",
-            StatusType::Syncing => "Syncing",
-            StatusType::Ready => "Ready",
-            StatusType::Busy => "Busy",
-            StatusType::Closing => "Closing",
-            StatusType::Offline => "Offline",
-            StatusType::RecoverableError => "RecoverableError",
-            StatusType::CriticalError => "CriticalError",
-        };
-        write!(f, "{status_str}")
-    }
-}
-
-impl StatusType {
-    /// Returns the corresponding status symbol for the StatusType
-    pub fn get_status_symbol(&self) -> String {
-        let (symbol, color_code) = match self {
-            // Yellow Statuses
-            StatusType::Syncing => ("\u{1F7E1}", "\x1b[33m"),
-            // Cyan Statuses
-            StatusType::Spawning | StatusType::Busy => ("\u{1F7E1}", "\x1b[36m"),
-            // Green Status
-            StatusType::Ready => ("\u{1F7E2}", "\x1b[32m"),
-            // Grey Statuses
-            StatusType::Closing | StatusType::Offline => ("\u{26AB}", "\x1b[90m"),
-            // Red Error Statuses
-            StatusType::RecoverableError | StatusType::CriticalError => ("\u{1F534}", "\x1b[31m"),
-        };
-
-        format!("{}{}{}", color_code, symbol, "\x1b[0m")
-    }
-
-    /// Look at two statuses, and return the more
-    /// 'severe' of the two statuses
-    pub fn combine(self, other: StatusType) -> StatusType {
-        match (self, other) {
-            // If either is Closing, return Closing.
-            (StatusType::Closing, _) | (_, StatusType::Closing) => StatusType::Closing,
-            // If either is Offline or CriticalError, return CriticalError.
-            (StatusType::Offline, _)
-            | (_, StatusType::Offline)
-            | (StatusType::CriticalError, _)
-            | (_, StatusType::CriticalError) => StatusType::CriticalError,
-            // If either is RecoverableError, return RecoverableError.
-            (StatusType::RecoverableError, _) | (_, StatusType::RecoverableError) => {
-                StatusType::RecoverableError
-            }
-            // If either is Spawning, return Spawning.
-            (StatusType::Spawning, _) | (_, StatusType::Spawning) => StatusType::Spawning,
-            // If either is Syncing, return Syncing.
-            (StatusType::Syncing, _) | (_, StatusType::Syncing) => StatusType::Syncing,
-            // Otherwise, return Ready.
-            _ => StatusType::Ready,
-        }
+        self.inner.store(status.into(), Ordering::SeqCst);
     }
 }

--- a/zaino-state/src/status.rs
+++ b/zaino-state/src/status.rs
@@ -7,7 +7,7 @@ use std::sync::{
     Arc,
 };
 
-pub use zaino_common::status::StatusType;
+pub use zaino_common::status::{Status, StatusType};
 
 /// Holds a thread-safe representation of a [`StatusType`].
 #[derive(Debug, Clone)]
@@ -31,5 +31,11 @@ impl AtomicStatus {
     /// Sets the value held in the AtomicStatus.
     pub fn store(&self, status: StatusType) {
         self.inner.store(status.into(), Ordering::SeqCst);
+    }
+}
+
+impl Status for AtomicStatus {
+    fn status(&self) -> StatusType {
+        self.load()
     }
 }

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -77,7 +77,7 @@ pub async fn poll_until_ready(
         let mut interval = tokio::time::interval(poll_interval);
         loop {
             interval.tick().await;
-            if component.is_ready() {
+            if dbg!(component.is_ready()) {
                 return;
             }
         }
@@ -535,11 +535,13 @@ where
     }
 
     /// Generate `n` blocks for the local network and poll zaino's fetch/state subscriber until the chain index is synced to the target height.
-    pub async fn generate_blocks_and_poll_indexer(
+    pub async fn generate_blocks_and_poll_indexer<I>(
         &self,
         n: u32,
-        indexer: &impl LightWalletIndexer,
-    ) {
+        indexer: &I,
+    ) where
+        I: LightWalletIndexer + Readiness,
+    {
         let chain_height = self.local_net.get_chain_height().await;
         let mut next_block_height = u64::from(chain_height) + 1;
         let mut interval = tokio::time::interval(std::time::Duration::from_millis(200));
@@ -561,6 +563,24 @@ where
                     interval.tick().await;
                 }
                 next_block_height += 1;
+            }
+        }
+
+        // After height is reached, wait for readiness and measure if it adds time
+        if !indexer.is_ready() {
+            let start = std::time::Instant::now();
+            poll_until_ready(
+                indexer,
+                std::time::Duration::from_millis(50),
+                std::time::Duration::from_secs(30),
+            )
+            .await;
+            let elapsed = start.elapsed();
+            if elapsed.as_millis() > 0 {
+                info!(
+                    "Readiness wait after height poll took {:?} (height polling alone was insufficient)",
+                    elapsed
+                );
             }
         }
     }
@@ -597,6 +617,24 @@ where
                     interval.tick().await;
                 }
                 next_block_height += 1;
+            }
+        }
+
+        // After height is reached, wait for readiness and measure if it adds time
+        if !chain_index.is_ready() {
+            let start = std::time::Instant::now();
+            poll_until_ready(
+                chain_index,
+                std::time::Duration::from_millis(50),
+                std::time::Duration::from_secs(30),
+            )
+            .await;
+            let elapsed = start.elapsed();
+            if elapsed.as_millis() > 0 {
+                info!(
+                    "Readiness wait after height poll took {:?} (height polling alone was insufficient)",
+                    elapsed
+                );
             }
         }
     }

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -18,6 +18,7 @@ use tracing::info;
 use tracing_subscriber::EnvFilter;
 use zaino_common::{
     network::{ActivationHeights, ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS},
+    probing::Readiness,
     validator::ValidatorConfig,
     CacheConfig, DatabaseConfig, Network, ServiceConfig, StorageConfig,
 };
@@ -61,6 +62,28 @@ pub fn make_uri(indexer_port: portpicker::Port) -> http::Uri {
     format!("http://127.0.0.1:{indexer_port}")
         .try_into()
         .unwrap()
+}
+
+/// Polls until the given component reports ready.
+///
+/// Returns `true` if the component became ready within the timeout,
+/// `false` if the timeout was reached.
+pub async fn poll_until_ready(
+    component: &impl Readiness,
+    poll_interval: std::time::Duration,
+    timeout: std::time::Duration,
+) -> bool {
+    tokio::time::timeout(timeout, async {
+        let mut interval = tokio::time::interval(poll_interval);
+        loop {
+            interval.tick().await;
+            if component.is_ready() {
+                return;
+            }
+        }
+    })
+    .await
+    .is_ok()
 }
 
 // temporary until activation heights are unified to zebra-chain type.
@@ -457,8 +480,15 @@ where
             test_manager.local_net.generate_blocks(1).await.unwrap();
         }
 
-        // FIXME: zaino's status can still be syncing instead of ready at this point
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        // Wait for zaino to be ready to serve requests
+        if let Some(ref subscriber) = test_manager.service_subscriber {
+            poll_until_ready(
+                subscriber,
+                std::time::Duration::from_millis(100),
+                std::time::Duration::from_secs(30),
+            )
+            .await;
+        }
 
         Ok(test_manager)
     }

--- a/zainod/src/indexer.rs
+++ b/zainod/src/indexer.rs
@@ -123,18 +123,18 @@ where
             loop {
                 // Log the servers status.
                 if last_log_time.elapsed() >= log_interval {
-                    indexer.log_status().await;
+                    indexer.log_status();
                     last_log_time = Instant::now();
                 }
 
                 // Check for restart signals.
-                if indexer.check_for_critical_errors().await {
+                if indexer.check_for_critical_errors() {
                     indexer.close().await;
                     return Err(IndexerError::Restart);
                 }
 
                 // Check for shutdown signals.
-                if indexer.check_for_shutdown().await {
+                if indexer.check_for_shutdown() {
                     indexer.close().await;
                     return Ok(());
                 }
@@ -147,14 +147,14 @@ where
     }
 
     /// Checks indexers status and servers internal statuses for either offline of critical error signals.
-    async fn check_for_critical_errors(&self) -> bool {
-        let status = self.status_int().await;
+    fn check_for_critical_errors(&self) -> bool {
+        let status = self.status_int();
         status == 5 || status >= 7
     }
 
     /// Checks indexers status and servers internal status for closure signal.
-    async fn check_for_shutdown(&self) -> bool {
-        if self.status_int().await == 4 {
+    fn check_for_shutdown(&self) -> bool {
+        if self.status_int() == 4 {
             return true;
         }
         false
@@ -178,10 +178,10 @@ where
         }
     }
 
-    /// Returns the indexers current status usize, caliculates from internal statuses.
-    async fn status_int(&self) -> usize {
+    /// Returns the indexers current status usize, calculates from internal statuses.
+    fn status_int(&self) -> usize {
         let service_status = match &self.service {
-            Some(service) => service.inner_ref().status().await,
+            Some(service) => service.inner_ref().status(),
             None => return 7,
         };
 
@@ -203,14 +203,14 @@ where
     }
 
     /// Returns the current StatusType of the indexer.
-    pub async fn status(&self) -> StatusType {
-        StatusType::from(self.status_int().await)
+    pub fn status(&self) -> StatusType {
+        StatusType::from(self.status_int())
     }
 
     /// Logs the indexers status.
-    pub async fn log_status(&self) {
+    pub fn log_status(&self) {
         let service_status = match &self.service {
-            Some(service) => service.inner_ref().status().await,
+            Some(service) => service.inner_ref().status(),
             None => StatusType::Offline,
         };
 


### PR DESCRIPTION
Fixes #779

**Blocked by #778** - This PR depends on the race condition fix and idempotent DB writes from #778 (which in turn depends on #776). Please review those PRs first.

This PR adds readiness polling to the `generate_blocks_and_poll` test utility functions, ensuring that tests wait for full service readiness after block generation completes.

## Summary

- Added readiness polling after height sync completes in `generate_blocks_and_poll` functions
- Tests now wait for the service to be fully ready before proceeding, eliminating timing-related flakes