### PR TITLE
feat(config): add Docker DNS hostname resolution support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8309,6 +8309,7 @@ dependencies = [
  "tonic 0.12.3",
  "tracing",
  "url",
+ "zaino-common",
  "zaino-proto",
  "zaino-testvectors",
  "zebra-chain 3.1.0",

--- a/integration-tests/tests/chain_cache.rs
+++ b/integration-tests/tests/chain_cache.rs
@@ -15,7 +15,10 @@ async fn create_test_manager_and_connector<T, Service>(
 ) -> (TestManager<T, Service>, JsonRpSeeConnector)
 where
     T: ValidatorExt,
-    Service: zaino_state::ZcashService<Config: From<ZainodConfig>> + Send + Sync + 'static,
+    Service: zaino_state::ZcashService<Config: TryFrom<ZainodConfig, Error = IndexerError>>
+        + Send
+        + Sync
+        + 'static,
     IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
 {
     let test_manager = TestManager::<T, Service>::launch(
@@ -32,7 +35,7 @@ where
 
     let json_service = JsonRpSeeConnector::new_with_basic_auth(
         test_node_and_return_url(
-            test_manager.full_node_rpc_listen_address,
+            &test_manager.full_node_rpc_listen_address.to_string(),
             None,
             Some("xxxxxx".to_string()),
             Some("xxxxxx".to_string()),
@@ -68,10 +71,7 @@ mod chain_query_interface {
     };
     use zcash_local_net::validator::{zcashd::Zcashd, zebrad::Zebrad};
     use zebra_chain::{
-        parameters::{
-            testnet::{ConfiguredActivationHeights, RegtestParameters},
-            NetworkKind,
-        },
+        parameters::{testnet::RegtestParameters, NetworkKind},
         serialization::{ZcashDeserialize, ZcashDeserializeInto},
     };
 
@@ -92,7 +92,10 @@ mod chain_query_interface {
     )
     where
         C: ValidatorExt,
-        Service: zaino_state::ZcashService<Config: From<ZainodConfig>> + Send + Sync + 'static,
+        Service: zaino_state::ZcashService<Config: TryFrom<ZainodConfig, Error = IndexerError>>
+            + Send
+            + Sync
+            + 'static,
         IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
     {
         let (test_manager, json_service) = create_test_manager_and_connector::<C, Service>(
@@ -111,11 +114,11 @@ mod chain_query_interface {
                     None => test_manager.data_dir.clone(),
                 };
                 let network = match test_manager.network {
-                    NetworkKind::Regtest => zebra_chain::parameters::Network::new_regtest(
-                        RegtestParameters::from(ConfiguredActivationHeights::from(
+                    NetworkKind::Regtest => {
+                        zebra_chain::parameters::Network::new_regtest(RegtestParameters::from(
                             test_manager.local_net.get_activation_heights().await,
-                        )),
-                    ),
+                        ))
+                    }
 
                     NetworkKind::Testnet => zebra_chain::parameters::Network::new_default_testnet(),
                     NetworkKind::Mainnet => zebra_chain::parameters::Network::Mainnet,
@@ -130,7 +133,7 @@ mod chain_query_interface {
                         // todo: does this matter?
                         should_backup_non_finalized_state: true,
                     },
-                    test_manager.full_node_rpc_listen_address,
+                    test_manager.full_node_rpc_listen_address.to_string(),
                     test_manager.full_node_grpc_listen_address,
                     false,
                     None,
@@ -229,7 +232,10 @@ mod chain_query_interface {
     async fn get_block_range<C, Service>(validator: &ValidatorKind)
     where
         C: ValidatorExt,
-        Service: zaino_state::ZcashService<Config: From<ZainodConfig>> + Send + Sync + 'static,
+        Service: zaino_state::ZcashService<Config: TryFrom<ZainodConfig, Error = IndexerError>>
+            + Send
+            + Sync
+            + 'static,
         IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
     {
         let (test_manager, _json_service, _option_state_service, _chain_index, indexer) =
@@ -279,7 +285,10 @@ mod chain_query_interface {
     async fn find_fork_point<C, Service>(validator: &ValidatorKind)
     where
         C: ValidatorExt,
-        Service: zaino_state::ZcashService<Config: From<ZainodConfig>> + Send + Sync + 'static,
+        Service: zaino_state::ZcashService<Config: TryFrom<ZainodConfig, Error = IndexerError>>
+            + Send
+            + Sync
+            + 'static,
         IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
     {
         let (test_manager, _json_service, _option_state_service, _chain_index, indexer) =
@@ -319,7 +328,10 @@ mod chain_query_interface {
     async fn get_raw_transaction<C, Service>(validator: &ValidatorKind)
     where
         C: ValidatorExt,
-        Service: zaino_state::ZcashService<Config: From<ZainodConfig>> + Send + Sync + 'static,
+        Service: zaino_state::ZcashService<Config: TryFrom<ZainodConfig, Error = IndexerError>>
+            + Send
+            + Sync
+            + 'static,
         IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
     {
         let (test_manager, _json_service, _option_state_service, _chain_index, indexer) =
@@ -381,7 +393,10 @@ mod chain_query_interface {
     async fn get_transaction_status<C, Service>(validator: &ValidatorKind)
     where
         C: ValidatorExt,
-        Service: zaino_state::ZcashService<Config: From<ZainodConfig>> + Send + Sync + 'static,
+        Service: zaino_state::ZcashService<Config: TryFrom<ZainodConfig, Error = IndexerError>>
+            + Send
+            + Sync
+            + 'static,
         IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
     {
         let (test_manager, _json_service, _option_state_service, _chain_index, indexer) =
@@ -427,7 +442,10 @@ mod chain_query_interface {
     async fn sync_large_chain<C, Service>(validator: &ValidatorKind)
     where
         C: ValidatorExt,
-        Service: zaino_state::ZcashService<Config: From<ZainodConfig>> + Send + Sync + 'static,
+        Service: zaino_state::ZcashService<Config: TryFrom<ZainodConfig, Error = IndexerError>>
+            + Send
+            + Sync
+            + 'static,
         IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
     {
         let (test_manager, json_service, option_state_service, _chain_index, indexer) =

--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -187,7 +187,7 @@ async fn fetch_service_get_raw_mempool<V: ValidatorExt>(validator: &ValidatorKin
 
     let json_service = JsonRpSeeConnector::new_with_basic_auth(
         test_node_and_return_url(
-            test_manager.full_node_rpc_listen_address,
+            &test_manager.full_node_rpc_listen_address.to_string(),
             None,
             Some("xxxxxx".to_string()),
             Some("xxxxxx".to_string()),
@@ -618,7 +618,7 @@ async fn fetch_service_get_latest_block<V: ValidatorExt>(validator: &ValidatorKi
 
     let json_service = JsonRpSeeConnector::new_with_basic_auth(
         test_node_and_return_url(
-            test_manager.full_node_rpc_listen_address,
+            &test_manager.full_node_rpc_listen_address.to_string(),
             None,
             Some("xxxxxx".to_string()),
             Some("xxxxxx".to_string()),
@@ -662,7 +662,7 @@ async fn assert_fetch_service_difficulty_matches_rpc<V: ValidatorExt>(validator:
 
     let jsonrpc_client = JsonRpSeeConnector::new_with_basic_auth(
         test_node_and_return_url(
-            test_manager.full_node_rpc_listen_address,
+            &test_manager.full_node_rpc_listen_address.to_string(),
             None,
             Some("xxxxxx".to_string()),
             Some("xxxxxx".to_string()),
@@ -691,7 +691,7 @@ async fn assert_fetch_service_mininginfo_matches_rpc<V: ValidatorExt>(validator:
 
     let jsonrpc_client = JsonRpSeeConnector::new_with_basic_auth(
         test_node_and_return_url(
-            test_manager.full_node_rpc_listen_address,
+            &test_manager.full_node_rpc_listen_address.to_string(),
             None,
             Some("xxxxxx".to_string()),
             Some("xxxxxx".to_string()),
@@ -720,7 +720,7 @@ async fn assert_fetch_service_peerinfo_matches_rpc<V: ValidatorExt>(validator: &
 
     let jsonrpc_client = JsonRpSeeConnector::new_with_basic_auth(
         test_node_and_return_url(
-            test_manager.full_node_rpc_listen_address,
+            &test_manager.full_node_rpc_listen_address.to_string(),
             None,
             Some("xxxxxx".to_string()),
             Some("xxxxxx".to_string()),
@@ -774,7 +774,7 @@ async fn fetch_service_get_block_subsidy<V: ValidatorExt>(validator: &ValidatorK
 
         let jsonrpc_client = JsonRpSeeConnector::new_with_basic_auth(
             test_node_and_return_url(
-                test_manager.full_node_rpc_listen_address,
+                &test_manager.full_node_rpc_listen_address.to_string(),
                 None,
                 Some("xxxxxx".to_string()),
                 Some("xxxxxx".to_string()),
@@ -857,7 +857,7 @@ async fn fetch_service_get_block_header<V: ValidatorExt>(validator: &ValidatorKi
 
         let jsonrpc_client = JsonRpSeeConnector::new_with_basic_auth(
             test_node_and_return_url(
-                test_manager.full_node_rpc_listen_address,
+                &test_manager.full_node_rpc_listen_address.to_string(),
                 None,
                 Some("xxxxxx".to_string()),
                 Some("xxxxxx".to_string()),
@@ -1746,7 +1746,7 @@ async fn assert_fetch_service_getnetworksols_matches_rpc<V: ValidatorExt>(
 
     let jsonrpc_client = JsonRpSeeConnector::new_with_basic_auth(
         test_node_and_return_url(
-            test_manager.full_node_rpc_listen_address,
+            &test_manager.full_node_rpc_listen_address.to_string(),
             None,
             Some("xxxxxx".to_string()),
             Some("xxxxxx".to_string()),
@@ -1908,7 +1908,7 @@ mod zcashd {
 
             let jsonrpc_client = JsonRpSeeConnector::new_with_basic_auth(
                 test_node_and_return_url(
-                    test_manager.full_node_rpc_listen_address,
+                    &test_manager.full_node_rpc_listen_address.to_string(),
                     None,
                     Some("xxxxxx".to_string()),
                     Some("xxxxxx".to_string()),

--- a/integration-tests/tests/json_server.rs
+++ b/integration-tests/tests/json_server.rs
@@ -43,7 +43,7 @@ async fn create_zcashd_test_manager_and_fetch_services(
 
     println!("Launching zcashd fetch service..");
     let zcashd_fetch_service = FetchService::spawn(FetchServiceConfig::new(
-        test_manager.full_node_rpc_listen_address,
+        test_manager.full_node_rpc_listen_address.to_string(),
         None,
         None,
         None,
@@ -70,7 +70,7 @@ async fn create_zcashd_test_manager_and_fetch_services(
 
     println!("Launching zaino fetch service..");
     let zaino_fetch_service = FetchService::spawn(FetchServiceConfig::new(
-        test_manager.full_node_rpc_listen_address,
+        test_manager.full_node_rpc_listen_address.to_string(),
         test_manager.json_server_cookie_dir.clone(),
         None,
         None,

--- a/integration-tests/tests/local_cache.rs
+++ b/integration-tests/tests/local_cache.rs
@@ -40,7 +40,7 @@ async fn create_test_manager_and_block_cache<V: ValidatorExt>(
 
     let json_service = JsonRpSeeConnector::new_with_basic_auth(
         test_node_and_return_url(
-            test_manager.full_node_rpc_listen_address,
+            &test_manager.full_node_rpc_listen_address.to_string(),
             None,
             Some("xxxxxx".to_string()),
             Some("xxxxxx".to_string()),

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -78,7 +78,7 @@ async fn create_test_manager_and_services<V: ValidatorExt>(
     test_manager.local_net.print_stdout();
 
     let fetch_service = FetchService::spawn(FetchServiceConfig::new(
-        test_manager.full_node_rpc_listen_address,
+        test_manager.full_node_rpc_listen_address.to_string(),
         None,
         None,
         None,
@@ -116,7 +116,7 @@ async fn create_test_manager_and_services<V: ValidatorExt>(
             debug_validity_check_interval: None,
             should_backup_non_finalized_state: false,
         },
-        test_manager.full_node_rpc_listen_address,
+        test_manager.full_node_rpc_listen_address.to_string(),
         test_manager.full_node_grpc_listen_address,
         false,
         None,
@@ -162,7 +162,7 @@ async fn generate_blocks_and_poll_all_chain_indexes<V, Service>(
 ) where
     V: ValidatorExt,
     Service: LightWalletService + Send + Sync + 'static,
-    Service::Config: From<ZainodConfig>,
+    Service::Config: TryFrom<ZainodConfig, Error = IndexerError>,
     IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
 {
     test_manager.generate_blocks_and_poll(n).await;

--- a/integration-tests/tests/wallet_to_validator.rs
+++ b/integration-tests/tests/wallet_to_validator.rs
@@ -18,7 +18,7 @@ async fn connect_to_node_get_info_for_validator<V, Service>(validator: &Validato
 where
     V: ValidatorExt,
     Service: LightWalletService + Send + Sync + 'static,
-    Service::Config: From<ZainodConfig>,
+    Service::Config: TryFrom<ZainodConfig, Error = IndexerError>,
     IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
 {
     let mut test_manager =
@@ -40,7 +40,7 @@ async fn send_to_orchard<V, Service>(validator: &ValidatorKind)
 where
     V: ValidatorExt,
     Service: LightWalletService + Send + Sync + 'static,
-    Service::Config: From<ZainodConfig>,
+    Service::Config: TryFrom<ZainodConfig, Error = IndexerError>,
     IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
 {
     let mut test_manager =
@@ -88,7 +88,7 @@ async fn send_to_sapling<V, Service>(validator: &ValidatorKind)
 where
     V: ValidatorExt,
     Service: LightWalletService + Send + Sync + 'static,
-    Service::Config: From<ZainodConfig>,
+    Service::Config: TryFrom<ZainodConfig, Error = IndexerError>,
     IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
 {
     let mut test_manager =
@@ -136,7 +136,7 @@ async fn send_to_transparent<V, Service>(validator: &ValidatorKind)
 where
     V: ValidatorExt,
     Service: LightWalletService + Send + Sync + 'static,
-    Service::Config: From<ZainodConfig>,
+    Service::Config: TryFrom<ZainodConfig, Error = IndexerError>,
     IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
 {
     let mut test_manager =
@@ -167,7 +167,7 @@ where
 
     let fetch_service = zaino_fetch::jsonrpsee::connector::JsonRpSeeConnector::new_with_basic_auth(
         test_node_and_return_url(
-            test_manager.full_node_rpc_listen_address,
+            &test_manager.full_node_rpc_listen_address.to_string(),
             None,
             Some("xxxxxx".to_string()),
             Some("xxxxxx".to_string()),
@@ -234,7 +234,7 @@ async fn send_to_all<V, Service>(validator: &ValidatorKind)
 where
     V: ValidatorExt,
     Service: LightWalletService + Send + Sync + 'static,
-    Service::Config: From<ZainodConfig>,
+    Service::Config: TryFrom<ZainodConfig, Error = IndexerError>,
     IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
 {
     let mut test_manager =
@@ -320,7 +320,7 @@ async fn shield_for_validator<V, Service>(validator: &ValidatorKind)
 where
     V: ValidatorExt,
     Service: LightWalletService + Send + Sync + 'static,
-    Service::Config: From<ZainodConfig>,
+    Service::Config: TryFrom<ZainodConfig, Error = IndexerError>,
     IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
 {
     let mut test_manager =
@@ -388,7 +388,7 @@ async fn monitor_unverified_mempool_for_validator<V, Service>(validator: &Valida
 where
     V: ValidatorExt,
     Service: LightWalletService + Send + Sync + 'static,
-    Service::Config: From<ZainodConfig>,
+    Service::Config: TryFrom<ZainodConfig, Error = IndexerError>,
     IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
 {
     let mut test_manager =
@@ -443,7 +443,7 @@ where
 
     let fetch_service = zaino_fetch::jsonrpsee::connector::JsonRpSeeConnector::new_with_basic_auth(
         test_node_and_return_url(
-            test_manager.full_node_rpc_listen_address,
+            &test_manager.full_node_rpc_listen_address.to_string(),
             None,
             Some("xxxxxx".to_string()),
             Some("xxxxxx".to_string()),

--- a/zaino-common/src/config/validator.rs
+++ b/zaino-common/src/config/validator.rs
@@ -2,16 +2,15 @@
 
 // use serde::{Deserialize, Serialize};
 // use zebra_chain::parameters::testnet::ConfiguredActivationHeights;
-use std::net::SocketAddr;
 use std::path::PathBuf;
 
 /// Validator (full-node) type for Zaino configuration.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct ValidatorConfig {
     /// Full node / validator gprc listen port. Only exists for zebra
-    pub validator_grpc_listen_address: Option<SocketAddr>,
-    /// Full node / validator listen port.
-    pub validator_jsonrpc_listen_address: SocketAddr,
+    pub validator_grpc_listen_address: Option<String>,
+    /// Full node / validator listen address (supports hostname:port or ip:port format).
+    pub validator_jsonrpc_listen_address: String,
     /// Path to the validator cookie file. Enable validator rpc cookie authentication with Some.
     pub validator_cookie_path: Option<PathBuf>,
     /// Full node / validator Username.

--- a/zaino-common/src/lib.rs
+++ b/zaino-common/src/lib.rs
@@ -4,6 +4,10 @@
 //! and common utilities used across the Zaino blockchain indexer ecosystem.
 
 pub mod config;
+pub mod net;
+
+// Re-export network utilities
+pub use net::{resolve_socket_addr, try_resolve_address, AddressResolution};
 
 // Re-export commonly used config types at crate root for backward compatibility.
 // This allows existing code using `use zaino_common::Network` to continue working.

--- a/zaino-common/src/net.rs
+++ b/zaino-common/src/net.rs
@@ -1,0 +1,329 @@
+//! Network utilities for Zaino.
+
+use std::net::{SocketAddr, ToSocketAddrs};
+
+/// Result of attempting to resolve an address string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AddressResolution {
+    /// Successfully resolved to a socket address.
+    Resolved(SocketAddr),
+    /// Address appears to be a valid hostname:port format but DNS lookup failed.
+    /// This is acceptable for deferred resolution (e.g., Docker DNS).
+    UnresolvedHostname {
+        /// The original address string.
+        address: String,
+        /// The DNS error message.
+        error: String,
+    },
+    /// Address format is invalid (missing port, garbage input, etc.).
+    /// This should always be treated as an error.
+    InvalidFormat {
+        /// The original address string.
+        address: String,
+        /// Description of what's wrong with the format.
+        reason: String,
+    },
+}
+
+impl AddressResolution {
+    /// Returns the resolved address if available.
+    pub fn resolved(&self) -> Option<SocketAddr> {
+        match self {
+            AddressResolution::Resolved(addr) => Some(*addr),
+            _ => None,
+        }
+    }
+
+    /// Returns true if the address was successfully resolved.
+    pub fn is_resolved(&self) -> bool {
+        matches!(self, AddressResolution::Resolved(_))
+    }
+
+    /// Returns true if the address has a valid format but couldn't be resolved.
+    /// This is acceptable for deferred resolution scenarios like Docker DNS.
+    pub fn is_unresolved_hostname(&self) -> bool {
+        matches!(self, AddressResolution::UnresolvedHostname { .. })
+    }
+
+    /// Returns true if the address format is invalid.
+    pub fn is_invalid_format(&self) -> bool {
+        matches!(self, AddressResolution::InvalidFormat { .. })
+    }
+}
+
+/// Validates that an address string has a valid format (host:port).
+///
+/// This performs basic format validation without DNS lookup:
+/// - Must contain exactly one `:` separator (or be IPv6 format `[...]:port`)
+/// - Port must be a valid number
+/// - Host part must not be empty
+fn validate_address_format(address: &str) -> Result<(), String> {
+    let address = address.trim();
+
+    if address.is_empty() {
+        return Err("Address cannot be empty".to_string());
+    }
+
+    // Handle IPv6 format: [::1]:port
+    if address.starts_with('[') {
+        let Some(bracket_end) = address.find(']') else {
+            return Err("IPv6 address missing closing bracket".to_string());
+        };
+
+        if bracket_end + 1 >= address.len() {
+            return Err("Missing port after IPv6 address".to_string());
+        }
+
+        let after_bracket = &address[bracket_end + 1..];
+        if !after_bracket.starts_with(':') {
+            return Err("Expected ':' after IPv6 address bracket".to_string());
+        }
+
+        let port_str = &after_bracket[1..];
+        port_str
+            .parse::<u16>()
+            .map_err(|_| format!("Invalid port number: '{port_str}'"))?;
+
+        return Ok(());
+    }
+
+    // Handle IPv4/hostname format: host:port
+    let parts: Vec<&str> = address.rsplitn(2, ':').collect();
+    if parts.len() != 2 {
+        return Err("Missing port (expected format: 'host:port')".to_string());
+    }
+
+    let port_str = parts[0];
+    let host = parts[1];
+
+    if host.is_empty() {
+        return Err("Host cannot be empty".to_string());
+    }
+
+    port_str
+        .parse::<u16>()
+        .map_err(|_| format!("Invalid port number: '{port_str}'"))?;
+
+    Ok(())
+}
+
+/// Attempts to resolve an address string, returning detailed information about the result.
+///
+/// This function distinguishes between:
+/// - Successfully resolved addresses
+/// - Valid hostname:port format that failed DNS lookup (acceptable for Docker DNS)
+/// - Invalid address format (always an error)
+///
+/// # Examples
+///
+/// ```
+/// use zaino_common::net::{try_resolve_address, AddressResolution};
+///
+/// // IP:port format resolves immediately
+/// let result = try_resolve_address("127.0.0.1:8080");
+/// assert!(result.is_resolved());
+///
+/// // Invalid format is detected
+/// let result = try_resolve_address("no-port-here");
+/// assert!(result.is_invalid_format());
+/// ```
+pub fn try_resolve_address(address: &str) -> AddressResolution {
+    // First validate the format
+    if let Err(reason) = validate_address_format(address) {
+        return AddressResolution::InvalidFormat {
+            address: address.to_string(),
+            reason,
+        };
+    }
+
+    // Try parsing as SocketAddr first (handles ip:port format directly)
+    if let Ok(addr) = address.parse::<SocketAddr>() {
+        return AddressResolution::Resolved(addr);
+    }
+
+    // Fall back to DNS resolution for hostname:port format
+    match address.to_socket_addrs() {
+        Ok(mut addrs) => {
+            let addrs_vec: Vec<SocketAddr> = addrs.by_ref().collect();
+
+            // Prefer IPv4 if available (more compatible, especially in Docker)
+            if let Some(ipv4_addr) = addrs_vec.iter().find(|addr| addr.is_ipv4()) {
+                AddressResolution::Resolved(*ipv4_addr)
+            } else if let Some(addr) = addrs_vec.into_iter().next() {
+                AddressResolution::Resolved(addr)
+            } else {
+                AddressResolution::UnresolvedHostname {
+                    address: address.to_string(),
+                    error: "DNS returned no addresses".to_string(),
+                }
+            }
+        }
+        Err(e) => AddressResolution::UnresolvedHostname {
+            address: address.to_string(),
+            error: e.to_string(),
+        },
+    }
+}
+
+/// Resolves an address string to a [`SocketAddr`].
+///
+/// Accepts both IP:port format (e.g., "127.0.0.1:8080") and hostname:port format
+/// (e.g., "zebra:18232" for Docker DNS resolution).
+///
+/// When both IPv4 and IPv6 addresses are available, IPv4 is preferred.
+///
+/// # Examples
+///
+/// ```
+/// use zaino_common::net::resolve_socket_addr;
+///
+/// // IP:port format
+/// let addr = resolve_socket_addr("127.0.0.1:8080").unwrap();
+/// assert_eq!(addr.port(), 8080);
+///
+/// // Hostname resolution (localhost)
+/// let addr = resolve_socket_addr("localhost:8080").unwrap();
+/// assert!(addr.ip().is_loopback());
+/// ```
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The address format is invalid (missing port, invalid IP, etc.)
+/// - The hostname cannot be resolved (DNS lookup failure)
+/// - No addresses are returned from resolution
+pub fn resolve_socket_addr(address: &str) -> Result<SocketAddr, std::io::Error> {
+    match try_resolve_address(address) {
+        AddressResolution::Resolved(addr) => Ok(addr),
+        AddressResolution::UnresolvedHostname { address, error } => Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("Cannot resolve hostname '{address}': {error}"),
+        )),
+        AddressResolution::InvalidFormat { address, reason } => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Invalid address format '{address}': {reason}"),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    // === Format validation tests (no DNS, always reliable) ===
+
+    #[test]
+    fn test_resolve_ipv4_address() {
+        let result = resolve_socket_addr("127.0.0.1:8080");
+        assert!(result.is_ok());
+        let addr = result.unwrap();
+        assert_eq!(addr.ip().to_string(), "127.0.0.1");
+        assert_eq!(addr.port(), 8080);
+    }
+
+    #[test]
+    fn test_resolve_ipv4_any_address() {
+        let result = resolve_socket_addr("0.0.0.0:18232");
+        assert!(result.is_ok());
+        let addr = result.unwrap();
+        assert_eq!(addr.ip(), Ipv4Addr::UNSPECIFIED);
+        assert_eq!(addr.port(), 18232);
+    }
+
+    #[test]
+    fn test_resolve_ipv6_localhost() {
+        let result = resolve_socket_addr("[::1]:8080");
+        assert!(result.is_ok());
+        let addr = result.unwrap();
+        assert!(addr.is_ipv6());
+        assert_eq!(addr.port(), 8080);
+    }
+
+    #[test]
+    fn test_resolve_missing_port() {
+        let result = try_resolve_address("127.0.0.1");
+        assert!(result.is_invalid_format());
+    }
+
+    #[test]
+    fn test_resolve_empty_string() {
+        let result = try_resolve_address("");
+        assert!(result.is_invalid_format());
+    }
+
+    #[test]
+    fn test_resolve_invalid_port() {
+        let result = try_resolve_address("127.0.0.1:invalid");
+        assert!(result.is_invalid_format());
+    }
+
+    #[test]
+    fn test_resolve_port_too_large() {
+        let result = try_resolve_address("127.0.0.1:99999");
+        assert!(result.is_invalid_format());
+    }
+
+    #[test]
+    fn test_resolve_empty_host() {
+        let result = try_resolve_address(":8080");
+        assert!(result.is_invalid_format());
+    }
+
+    #[test]
+    fn test_resolve_ipv6_missing_port() {
+        let result = try_resolve_address("[::1]");
+        assert!(result.is_invalid_format());
+    }
+
+    #[test]
+    fn test_resolve_ipv6_missing_bracket() {
+        let result = try_resolve_address("[::1:8080");
+        assert!(result.is_invalid_format());
+    }
+
+    #[test]
+    fn test_valid_hostname_format() {
+        // This hostname has valid format but won't resolve
+        let result = try_resolve_address("nonexistent-host.invalid:8080");
+        // Should be unresolved hostname, not invalid format
+        assert!(
+            result.is_unresolved_hostname(),
+            "Expected UnresolvedHostname, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_docker_style_hostname_format() {
+        // Docker-style hostnames have valid format
+        let result = try_resolve_address("zebra:18232");
+        // Can't resolve in unit tests, but format is valid
+        assert!(
+            result.is_unresolved_hostname(),
+            "Expected UnresolvedHostname for Docker-style hostname, got {:?}",
+            result
+        );
+    }
+
+    // === DNS-dependent tests (may be flaky in CI) ===
+
+    #[test]
+    #[ignore = "DNS-dependent: may be flaky in CI environments without reliable DNS"]
+    fn test_resolve_hostname_localhost() {
+        // "localhost" should resolve to 127.0.0.1 or ::1
+        let result = resolve_socket_addr("localhost:8080");
+        assert!(result.is_ok());
+        let addr = result.unwrap();
+        assert_eq!(addr.port(), 8080);
+        assert!(addr.ip().is_loopback());
+    }
+
+    #[test]
+    #[ignore = "DNS-dependent: behavior varies by system DNS configuration"]
+    fn test_resolve_invalid_hostname_dns() {
+        // This test verifies DNS lookup failure for truly invalid hostnames
+        let result = resolve_socket_addr("this-hostname-does-not-exist.invalid:8080");
+        assert!(result.is_err());
+    }
+}

--- a/zaino-fetch/Cargo.toml
+++ b/zaino-fetch/Cargo.toml
@@ -9,6 +9,7 @@ license = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
+zaino-common = { workspace = true }
 zaino-proto = { workspace = true }
 
 # Zebra

--- a/zaino-fetch/src/jsonrpsee/connector.rs
+++ b/zaino-fetch/src/jsonrpsee/connector.rs
@@ -229,9 +229,10 @@ impl JsonRpSeeConnector {
         })
     }
 
-    /// Helper function to create from parts of a StateServiceConfig or FetchServiceConfig
+    /// Helper function to create from parts of a StateServiceConfig or FetchServiceConfig.
+    /// Accepts both hostname:port (e.g., "zebra:18232") and ip:port (e.g., "127.0.0.1:18232") formats.
     pub async fn new_from_config_parts(
-        validator_rpc_address: SocketAddr,
+        validator_rpc_address: &str,
         validator_rpc_user: String,
         validator_rpc_password: String,
         validator_cookie_path: Option<PathBuf>,
@@ -871,13 +872,22 @@ async fn test_node_connection(url: Url, auth_method: AuthMethod) -> Result<(), T
     Ok(())
 }
 
-/// Tries to connect to zebrad/zcashd using the provided SocketAddr and returns the correct URL.
+/// Resolves an address string (hostname:port or ip:port) to a SocketAddr.
+fn resolve_address(address: &str) -> Result<SocketAddr, TransportError> {
+    zaino_common::net::resolve_socket_addr(address)
+        .map_err(|e| TransportError::BadNodeData(Box::new(e), "address resolution"))
+}
+
+/// Tries to connect to zebrad/zcashd using the provided address and returns the correct URL.
+/// Accepts both hostname:port (e.g., "zebra:18232") and ip:port (e.g., "127.0.0.1:18232") formats.
 pub async fn test_node_and_return_url(
-    addr: SocketAddr,
+    address: &str,
     cookie_path: Option<PathBuf>,
     user: Option<String>,
     password: Option<String>,
 ) -> Result<Url, TransportError> {
+    let addr = resolve_address(address)?;
+
     let auth_method = match cookie_path.is_some() {
         true => {
             let cookie_file_path_str = cookie_path.expect("validator rpc cookie path missing");
@@ -913,4 +923,24 @@ pub async fn test_node_and_return_url(
     }
     error!("Error: Could not establish connection with node. Please check config and confirm node is listening at the correct address and the correct authorisation details have been entered. Exiting..");
     std::process::exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_address_wraps_common_function() {
+        // Verify the wrapper correctly converts io::Error to TransportError
+        let result = resolve_address("127.0.0.1:8080");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().port(), 8080);
+
+        let result = resolve_address("invalid");
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            TransportError::BadNodeData(_, "address resolution")
+        ));
+    }
 }

--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -109,7 +109,7 @@ impl ZcashService for FetchService {
         info!("Launching Chain Fetch Service..");
 
         let fetcher = JsonRpSeeConnector::new_from_config_parts(
-            config.validator_rpc_address,
+            &config.validator_rpc_address,
             config.validator_rpc_user.clone(),
             config.validator_rpc_password.clone(),
             config.validator_cookie_path.clone(),

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -184,7 +184,7 @@ impl ZcashService for StateService {
         info!("Spawning State Service..");
 
         let rpc_client = JsonRpSeeConnector::new_from_config_parts(
-            config.validator_rpc_address,
+            &config.validator_rpc_address,
             config.validator_rpc_user.clone(),
             config.validator_rpc_password.clone(),
             config.validator_cookie_path.clone(),

--- a/zaino-state/src/config.rs
+++ b/zaino-state/src/config.rs
@@ -29,9 +29,9 @@ pub enum BackendConfig {
 pub struct StateServiceConfig {
     /// Zebra [`zebra_state::ReadStateService`] config data
     pub validator_state_config: zebra_state::Config,
-    /// Validator JsonRPC address.
-    pub validator_rpc_address: std::net::SocketAddr,
-    /// Validator gRPC address.
+    /// Validator JsonRPC address (supports hostname:port or ip:port format).
+    pub validator_rpc_address: String,
+    /// Validator gRPC address (requires ip:port format for Zebra state sync).
     pub validator_grpc_address: std::net::SocketAddr,
     /// Validator cookie auth.
     pub validator_cookie_auth: bool,
@@ -56,7 +56,7 @@ impl StateServiceConfig {
     // TODO: replace with struct-literal init only?
     pub fn new(
         validator_state_config: zebra_state::Config,
-        validator_rpc_address: std::net::SocketAddr,
+        validator_rpc_address: String,
         validator_grpc_address: std::net::SocketAddr,
         validator_cookie_auth: bool,
         validator_cookie_path: Option<PathBuf>,
@@ -89,8 +89,8 @@ impl StateServiceConfig {
 #[derive(Debug, Clone)]
 #[deprecated]
 pub struct FetchServiceConfig {
-    /// Validator JsonRPC address.
-    pub validator_rpc_address: std::net::SocketAddr,
+    /// Validator JsonRPC address (supports hostname:port or ip:port format).
+    pub validator_rpc_address: String,
     /// Enable validator rpc cookie authentification with Some: path to the validator cookie file.
     pub validator_cookie_path: Option<PathBuf>,
     /// Validator JsonRPC user.
@@ -110,7 +110,7 @@ impl FetchServiceConfig {
     /// Returns a new instance of [`FetchServiceConfig`].
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        validator_rpc_address: std::net::SocketAddr,
+        validator_rpc_address: String,
         validator_cookie_path: Option<PathBuf>,
         validator_rpc_user: Option<String>,
         validator_rpc_password: Option<String>,

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -217,13 +217,15 @@ impl ValidatorExt for Zebrad {
     ) -> Result<(Self, ValidatorConfig), LaunchError> {
         let zebrad = Zebrad::launch(config).await?;
         let validator_config = ValidatorConfig {
-            validator_jsonrpc_listen_address: SocketAddr::new(
-                IpAddr::V4(Ipv4Addr::LOCALHOST),
-                zebrad.rpc_listen_port(),
+            validator_jsonrpc_listen_address: format!(
+                "{}:{}",
+                Ipv4Addr::LOCALHOST,
+                zebrad.rpc_listen_port()
             ),
-            validator_grpc_listen_address: Some(SocketAddr::new(
-                IpAddr::V4(Ipv4Addr::LOCALHOST),
-                zebrad.indexer_listen_port(),
+            validator_grpc_listen_address: Some(format!(
+                "{}:{}",
+                Ipv4Addr::LOCALHOST,
+                zebrad.indexer_listen_port()
             )),
             validator_cookie_path: None,
             validator_user: Some("xxxxxx".to_string()),
@@ -239,10 +241,7 @@ impl ValidatorExt for Zcashd {
     ) -> Result<(Self, ValidatorConfig), LaunchError> {
         let zcashd = Zcashd::launch(config).await?;
         let validator_config = ValidatorConfig {
-            validator_jsonrpc_listen_address: SocketAddr::new(
-                IpAddr::V4(Ipv4Addr::LOCALHOST),
-                zcashd.port(),
-            ),
+            validator_jsonrpc_listen_address: format!("{}:{}", Ipv4Addr::LOCALHOST, zcashd.port()),
             validator_grpc_listen_address: None,
             validator_cookie_path: None,
             validator_user: Some("xxxxxx".to_string()),
@@ -256,7 +255,7 @@ impl<C, Service> TestManager<C, Service>
 where
     C: ValidatorExt,
     Service: LightWalletService + Send + Sync + 'static,
-    Service::Config: From<ZainodConfig>,
+    Service::Config: TryFrom<ZainodConfig, Error = IndexerError>,
     IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
 {
     /// Launches zcash-local-net<Empty, Validator>.
@@ -378,7 +377,8 @@ where
             };
 
             let (handle, service_subscriber) = Indexer::<Service>::launch_inner(
-                Service::Config::from(indexer_config.clone()),
+                Service::Config::try_from(indexer_config.clone())
+                    .expect("Failed to convert ZainodConfig to service config"),
                 indexer_config,
             )
             .await
@@ -438,6 +438,8 @@ where
             full_node_rpc_listen_address,
             full_node_grpc_listen_address: validator_settings
                 .validator_grpc_listen_address
+                .as_ref()
+                .and_then(|addr| addr.parse().ok())
                 .unwrap_or(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0)),
             zaino_handle,
             zaino_json_rpc_listen_address: zaino_json_listen_address,

--- a/zainod/src/config.rs
+++ b/zainod/src/config.rs
@@ -122,34 +122,21 @@ impl ZainodConfig {
         let validator_addr_result =
             try_resolve_address(&self.validator_settings.validator_jsonrpc_listen_address);
 
+        // Validator address validation:
+        // - Resolved IPs: must be private (RFC1918/ULA)
+        // - Hostnames: validated at connection time (supports Docker/K8s service discovery)
+        // - Cookie auth: determined by validator_cookie_path config, not enforced by address type
         match validator_addr_result {
             AddressResolution::Resolved(validator_addr) => {
-                // Successfully resolved - perform full IP-based validation.
                 if !is_private_listen_addr(&validator_addr) {
                     return Err(IndexerError::ConfigError(
                         "Zaino may only connect to Zebra with private IP addresses.".to_string(),
                     ));
                 }
-
-                #[cfg(not(feature = "no_tls_use_unencrypted_traffic"))]
-                {
-                    // Require cookie auth for non-loopback addresses.
-                    if !is_loopback_listen_addr(&validator_addr)
-                        && self.validator_settings.validator_cookie_path.is_none()
-                    {
-                        return Err(IndexerError::ConfigError(
-                            "Validator listen address is not loopback, so cookie authentication must be enabled."
-                                .to_string(),
-                        ));
-                    }
-                }
             }
             AddressResolution::UnresolvedHostname { ref address, .. } => {
-                // Valid hostname format but DNS lookup failed (e.g., Docker DNS).
-                // Allow this - IP validation will happen at connection time.
                 info!(
-                    "Validator address '{}' is a hostname that cannot be resolved at config time. \
-                     IP validation deferred to connection time.",
+                    "Validator address '{}' cannot be resolved at config time.",
                     address
                 );
             }
@@ -275,18 +262,6 @@ pub(crate) fn is_private_listen_addr(addr: &SocketAddr) -> bool {
     match ip {
         IpAddr::V4(ipv4) => ipv4.is_private() || ipv4.is_loopback(),
         IpAddr::V6(ipv6) => ipv6.is_unique_local() || ip.is_loopback(),
-    }
-}
-
-/// Validates that the configured `address` is a loopback address.
-///
-/// Returns `Ok(BindAddress)` if valid.
-#[cfg_attr(feature = "no_tls_use_unencrypted_traffic", allow(dead_code))]
-pub(crate) fn is_loopback_listen_addr(addr: &SocketAddr) -> bool {
-    let ip = addr.ip();
-    match ip {
-        IpAddr::V4(ipv4) => ipv4.is_loopback(),
-        IpAddr::V6(ipv6) => ipv6.is_loopback(),
     }
 }
 
@@ -1016,6 +991,80 @@ mod test {
             } else {
                 panic!("Expected ConfigError, got {result:?}");
             }
+            Ok(())
+        });
+    }
+
+    #[test]
+    /// Validates that cookie authentication is config-based, not address-type-based.
+    /// Non-loopback private IPs should work without cookie auth (operator's choice).
+    pub(crate) fn test_cookie_auth_not_forced_for_non_loopback_ip() {
+        Jail::expect_with(|jail| {
+            // Non-loopback private IP (192.168.x.x) WITHOUT cookie auth should succeed
+            let toml_str = r#"
+            backend = "fetch"
+            network = "Testnet"
+
+            [validator_settings]
+            validator_jsonrpc_listen_address = "192.168.1.10:18232"
+            # Note: NO validator_cookie_path - this is intentional
+
+            [grpc_settings]
+            listen_address = "127.0.0.1:8137"
+        "#;
+            let temp_toml_path = jail.directory().join("no_cookie_auth.toml");
+            jail.create_file(&temp_toml_path, toml_str)?;
+
+            let config_result = load_config(&temp_toml_path);
+            assert!(
+                config_result.is_ok(),
+                "Non-loopback IP without cookie auth should succeed. \
+                 Cookie auth is config-based, not address-type-based. Error: {:?}",
+                config_result.err()
+            );
+
+            let config = config_result.unwrap();
+            assert!(
+                config.validator_settings.validator_cookie_path.is_none(),
+                "Cookie path should be None as configured"
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    /// Validates symmetric behavior: both IP and hostname addresses respect configuration.
+    /// Public IPs should still be rejected (private IP requirement remains).
+    pub(crate) fn test_public_ip_still_rejected() {
+        Jail::expect_with(|jail| {
+            // Public IP should be rejected regardless of cookie auth
+            let toml_str = r#"
+            backend = "fetch"
+            network = "Testnet"
+
+            [validator_settings]
+            validator_jsonrpc_listen_address = "8.8.8.8:18232"
+
+            [grpc_settings]
+            listen_address = "127.0.0.1:8137"
+        "#;
+            let temp_toml_path = jail.directory().join("public_ip.toml");
+            jail.create_file(&temp_toml_path, toml_str)?;
+
+            let config_result = load_config(&temp_toml_path);
+            assert!(
+                config_result.is_err(),
+                "Public IP should be rejected - private IP requirement still applies"
+            );
+
+            if let Err(IndexerError::ConfigError(msg)) = config_result {
+                assert!(
+                    msg.contains("private IP"),
+                    "Error should mention private IP requirement. Got: {msg}"
+                );
+            }
+
             Ok(())
         });
     }

--- a/zainod/src/config.rs
+++ b/zainod/src/config.rs
@@ -4,7 +4,7 @@ use figment::{
     Figment,
 };
 use std::{
-    net::{IpAddr, SocketAddr, ToSocketAddrs},
+    net::{IpAddr, SocketAddr},
     path::PathBuf,
 };
 // Added for Serde deserialization helpers
@@ -17,8 +17,8 @@ use serde::{
 use tracing::warn;
 use tracing::{error, info};
 use zaino_common::{
-    CacheConfig, DatabaseConfig, DatabaseSize, Network, ServiceConfig, StorageConfig,
-    ValidatorConfig,
+    try_resolve_address, AddressResolution, CacheConfig, DatabaseConfig, DatabaseSize, Network,
+    ServiceConfig, StorageConfig, ValidatorConfig,
 };
 use zaino_serve::server::config::{GrpcServerConfig, JsonRpcServerConfig};
 
@@ -117,18 +117,49 @@ impl ZainodConfig {
         let grpc_addr =
             fetch_socket_addr_from_hostname(&self.grpc_settings.listen_address.to_string())?;
 
-        let validator_addr = fetch_socket_addr_from_hostname(
-            &self
-                .validator_settings
-                .validator_jsonrpc_listen_address
-                .to_string(),
-        )?;
+        // Validate the validator address using the richer result type that distinguishes
+        // between format errors (always fail) and DNS lookup failures (can defer for Docker).
+        let validator_addr_result =
+            try_resolve_address(&self.validator_settings.validator_jsonrpc_listen_address);
 
-        // Ensure validator listen address is private.
-        if !is_private_listen_addr(&validator_addr) {
-            return Err(IndexerError::ConfigError(
-                "Zaino may only connect to Zebra with private IP addresses.".to_string(),
-            ));
+        match validator_addr_result {
+            AddressResolution::Resolved(validator_addr) => {
+                // Successfully resolved - perform full IP-based validation.
+                if !is_private_listen_addr(&validator_addr) {
+                    return Err(IndexerError::ConfigError(
+                        "Zaino may only connect to Zebra with private IP addresses.".to_string(),
+                    ));
+                }
+
+                #[cfg(not(feature = "no_tls_use_unencrypted_traffic"))]
+                {
+                    // Require cookie auth for non-loopback addresses.
+                    if !is_loopback_listen_addr(&validator_addr)
+                        && self.validator_settings.validator_cookie_path.is_none()
+                    {
+                        return Err(IndexerError::ConfigError(
+                            "Validator listen address is not loopback, so cookie authentication must be enabled."
+                                .to_string(),
+                        ));
+                    }
+                }
+            }
+            AddressResolution::UnresolvedHostname { ref address, .. } => {
+                // Valid hostname format but DNS lookup failed (e.g., Docker DNS).
+                // Allow this - IP validation will happen at connection time.
+                info!(
+                    "Validator address '{}' is a hostname that cannot be resolved at config time. \
+                     IP validation deferred to connection time.",
+                    address
+                );
+            }
+            AddressResolution::InvalidFormat { address, reason } => {
+                // Invalid address format - always fail immediately.
+                return Err(IndexerError::ConfigError(format!(
+                    "Invalid validator address '{}': {}",
+                    address, reason
+                )));
+            }
         }
 
         #[cfg(not(feature = "no_tls_use_unencrypted_traffic"))]
@@ -138,16 +169,6 @@ impl ZainodConfig {
                 return Err(IndexerError::ConfigError(
                     "TLS required when connecting to external addresses.".to_string(),
                 ));
-            }
-
-            // Ensure validator rpc cookie authentication is used when connecting to non-loopback addresses.
-            if !is_loopback_listen_addr(&validator_addr)
-                && self.validator_settings.validator_cookie_path.is_none()
-            {
-                return Err(IndexerError::ConfigError(
-                "Validator listen address is not loopback, so cookie authentication must be enabled."
-                    .to_string(),
-            ));
             }
         }
 
@@ -191,8 +212,8 @@ impl Default for ZainodConfig {
                 tls: None,
             },
             validator_settings: ValidatorConfig {
-                validator_grpc_listen_address: Some("127.0.0.1:18230".parse().unwrap()),
-                validator_jsonrpc_listen_address: "127.0.0.1:18232".parse().unwrap(),
+                validator_grpc_listen_address: Some("127.0.0.1:18230".to_string()),
+                validator_jsonrpc_listen_address: "127.0.0.1:18232".to_string(),
                 validator_cookie_path: None,
                 validator_user: Some("xxxxxx".to_string()),
                 validator_password: Some("xxxxxx".to_string()),
@@ -240,19 +261,8 @@ pub fn default_zebra_db_path() -> Result<PathBuf, IndexerError> {
 
 /// Resolves a hostname to a SocketAddr.
 fn fetch_socket_addr_from_hostname(address: &str) -> Result<SocketAddr, IndexerError> {
-    address.parse::<SocketAddr>().or_else(|_| {
-        let addrs: Vec<_> = address
-            .to_socket_addrs()
-            .map_err(|e| IndexerError::ConfigError(format!("Invalid address '{address}': {e}")))?
-            .collect();
-        if let Some(ipv4_addr) = addrs.iter().find(|addr| addr.is_ipv4()) {
-            Ok(*ipv4_addr)
-        } else {
-            addrs.into_iter().next().ok_or_else(|| {
-                IndexerError::ConfigError(format!("Unable to resolve address '{address}'"))
-            })
-        }
-    })
+    zaino_common::net::resolve_socket_addr(address)
+        .map_err(|e| IndexerError::ConfigError(format!("Invalid address '{address}': {e}")))
 }
 
 /// Validates that the configured `address` is either:
@@ -343,19 +353,41 @@ impl TryFrom<ZainodConfig> for BackendConfig {
     fn try_from(cfg: ZainodConfig) -> Result<Self, Self::Error> {
         match cfg.backend {
             zaino_state::BackendType::State => {
-                Ok(BackendConfig::State(StateServiceConfig::from(cfg)))
+                Ok(BackendConfig::State(StateServiceConfig::try_from(cfg)?))
             }
             zaino_state::BackendType::Fetch => {
-                Ok(BackendConfig::Fetch(FetchServiceConfig::from(cfg)))
+                Ok(BackendConfig::Fetch(FetchServiceConfig::try_from(cfg)?))
             }
         }
     }
 }
 
 #[allow(deprecated)]
-impl From<ZainodConfig> for StateServiceConfig {
-    fn from(cfg: ZainodConfig) -> Self {
-        StateServiceConfig {
+impl TryFrom<ZainodConfig> for StateServiceConfig {
+    type Error = IndexerError;
+
+    fn try_from(cfg: ZainodConfig) -> Result<Self, Self::Error> {
+        let grpc_listen_address = cfg
+            .validator_settings
+            .validator_grpc_listen_address
+            .as_ref()
+            .ok_or_else(|| {
+                IndexerError::ConfigError(
+                    "Missing validator_grpc_listen_address in configuration".to_string(),
+                )
+            })?;
+        let validator_grpc_address =
+            fetch_socket_addr_from_hostname(grpc_listen_address).map_err(|e| {
+                let msg = match e {
+                    IndexerError::ConfigError(msg) => msg,
+                    other => other.to_string(),
+                };
+                IndexerError::ConfigError(format!(
+                    "Invalid validator_grpc_listen_address '{grpc_listen_address}': {msg}"
+                ))
+            })?;
+
+        Ok(StateServiceConfig {
             validator_state_config: zebra_state::Config {
                 cache_dir: cfg.zebra_db_path.clone(),
                 ephemeral: false,
@@ -364,11 +396,11 @@ impl From<ZainodConfig> for StateServiceConfig {
                 debug_validity_check_interval: None,
                 should_backup_non_finalized_state: true,
             },
-            validator_rpc_address: cfg.validator_settings.validator_jsonrpc_listen_address,
-            validator_grpc_address: cfg
+            validator_rpc_address: cfg
                 .validator_settings
-                .validator_grpc_listen_address
-                .expect("Zebra config with no grpc_listen_address"),
+                .validator_jsonrpc_listen_address
+                .clone(),
+            validator_grpc_address,
             validator_cookie_auth: cfg.validator_settings.validator_cookie_path.is_some(),
             validator_cookie_path: cfg.validator_settings.validator_cookie_path,
             validator_rpc_user: cfg
@@ -382,14 +414,16 @@ impl From<ZainodConfig> for StateServiceConfig {
             service: cfg.service,
             storage: cfg.storage,
             network: cfg.network,
-        }
+        })
     }
 }
 
 #[allow(deprecated)]
-impl From<ZainodConfig> for FetchServiceConfig {
-    fn from(cfg: ZainodConfig) -> Self {
-        FetchServiceConfig {
+impl TryFrom<ZainodConfig> for FetchServiceConfig {
+    type Error = IndexerError;
+
+    fn try_from(cfg: ZainodConfig) -> Result<Self, Self::Error> {
+        Ok(FetchServiceConfig {
             validator_rpc_address: cfg.validator_settings.validator_jsonrpc_listen_address,
             validator_cookie_path: cfg.validator_settings.validator_cookie_path,
             validator_rpc_user: cfg
@@ -403,7 +437,7 @@ impl From<ZainodConfig> for FetchServiceConfig {
             service: cfg.service,
             storage: cfg.storage,
             network: cfg.network,
-        }
+        })
     }
 }
 

--- a/zainod/src/indexer.rs
+++ b/zainod/src/indexer.rs
@@ -45,7 +45,7 @@ pub async fn spawn_indexer(
     config.check_config()?;
     info!("Checking connection with node..");
     let zebrad_uri = test_node_and_return_url(
-        config.validator_settings.validator_jsonrpc_listen_address,
+        &config.validator_settings.validator_jsonrpc_listen_address,
         config.validator_settings.validator_cookie_path.clone(),
         config.validator_settings.validator_user.clone(),
         config.validator_settings.validator_password.clone(),


### PR DESCRIPTION
## Summary

This PR adds support for Docker DNS hostname resolution in validator address configuration, allowing addresses like `zebra:18232` instead of requiring IP addresses. It also makes cookie authentication config-based rather than address-type-based.

### Changes

- **Add hostname resolution support**: Changed `validator_jsonrpc_listen_address` and related fields from `SocketAddr` to `String` to accept hostnames
- **Add `zaino-common::net` module**: New utility module with `resolve_socket_addr()` and `try_resolve_address()` functions that handle both IP:port and hostname:port formats
- **Add format validation**: Invalid address formats (missing port, garbage input) fail immediately at config time with descriptive errors, while valid hostnames that can't be resolved (Docker DNS) are deferred to connection time
- **Config-based cookie auth**: Cookie authentication is determined solely by whether `validator_cookie_path` is configured, not by address type. This gives operators control over their security choices in trusted network environments.
- **Update config conversions**: Changed `From<ZainodConfig>` to `TryFrom<ZainodConfig>` for `StateServiceConfig` and `FetchServiceConfig` to properly handle fallible address resolution

### Validator Address Validation

The validation rules are:
- **Resolved IPs**: Must be private (RFC1918/ULA)
- **Hostnames**: Validated at connection time (supports Docker/K8s service discovery)
- **Cookie auth**: Determined by `validator_cookie_path` config, not enforced by address type

The `AddressResolution` enum distinguishes between:
- `Resolved(SocketAddr)` - Successfully resolved, private IP validation applies
- `UnresolvedHostname` - Valid hostname:port format but DNS lookup failed (acceptable for Docker)
- `InvalidFormat` - Malformed input that fails immediately

### Rationale for Cookie Auth Change

Previously, cookie authentication was forced for non-loopback IPs regardless of configuration. This created friction for operators in trusted network environments (Docker, Kubernetes, internal networks) where cookie auth adds operational complexity without proportional security benefit.

The change makes behavior consistent: if you configure `validator_cookie_path`, cookie auth is used; if you don't, it's not required. This respects the operator's explicit configuration choice while maintaining the private IP requirement as the network security boundary.

### Testing

- Added unit tests for address format validation (DNS-independent)
- Added tests for config-based cookie auth behavior:
  - `test_cookie_auth_not_forced_for_non_loopback_ip` - validates non-loopback private IPs work without cookie auth
  - `test_public_ip_still_rejected` - validates private IP requirement still applies
- Marked DNS-dependent tests with `#[ignore]` to prevent CI flakiness
- All 14 config tests pass

### Breaking Changes

- `test_node_and_return_url()` now takes `&str` instead of `SocketAddr`
- Config conversion traits changed from `From` to `TryFrom`
- Non-loopback private IPs no longer require cookie authentication (operator's choice)