### PR TITLE
minor fixes (updates) to rpc_api.md

### DIFF
--- a/docs/rpc_api.md
+++ b/docs/rpc_api.md
@@ -1,6 +1,9 @@
 # Zaino RPC APIs
 ## Lightwallet gRPC Services
-Zaino Currently Serves the following gRPC services as defined in the [LightWallet Protocol](https://github.com/zcash/librustzcash/blob/main/zcash_client_backend/proto/service.proto):
+Zaino Currently Serves the following gRPC services as defined in the [LightWallet Protocol](https://github.com/zcash/lightwallet-protocol/blob/main/walletrpc/service.proto):
+
+(gRPC service (function) arguments and return values are defined [here](https://github.com/zcash/lightwallet-protocol/blob/main/walletrpc/compact_formats.proto))
+
   - GetLatestBlock (ChainSpec) returns (BlockID)
   - GetBlock (BlockID) returns (CompactBlock)
   - GetBlockNullifiers (BlockID) returns (CompactBlock)
@@ -8,7 +11,7 @@ Zaino Currently Serves the following gRPC services as defined in the [LightWalle
   - GetBlockRangeNullifiers (BlockRange) returns (stream CompactBlock)
   - GetTransaction (TxFilter) returns (RawTransaction)
   - SendTransaction (RawTransaction) returns (SendResponse)
-  - GetTaddressTxids (TransparentAddressBlockFilter) returns (stream RawTransaction)
+  - GetTaddressTransactions (TransparentAddressBlockFilter) returns (stream RawTransaction)
   - GetTaddressBalance (AddressList) returns (Balance)
   - GetTaddressBalanceStream (stream Address) returns (Balance) (**MARKED FOR DEPRECATION**)
   - GetMempoolTx (Exclude) returns (stream CompactTx)
@@ -19,11 +22,8 @@ Zaino Currently Serves the following gRPC services as defined in the [LightWalle
   - GetAddressUtxos (GetAddressUtxosArg) returns (GetAddressUtxosReplyList)
   - GetAddressUtxosStream (GetAddressUtxosArg) returns (stream GetAddressUtxosReply)
   - GetLightdInfo (Empty) returns (LightdInfo)
-  - Ping (Duration) returns (PingResponse) (**CURRENTLY UNIMPLEMENTED**)
-
 
 ## Zcash RPC Services
 Zaino has also committed to taking over responsibility for serving all [Zcash RPC Services](https://zcash.github.io/rpc/) required by non-validator (miner) clients from Zcashd.
 A full specification of the Zcash RPC services served by Zaino, and their current state of development, can be seen [here](./Zaino-zcash-rpcs.pdf).
-
 


### PR DESCRIPTION
I'm just trying to get up to speed on zaino (to possibly contribute to code dev), so while reading the documentation, I noticed a few minor problems, fixed by this PR.

- The lightwallet protocol definition files have moved to their own separate repo (the link here was out of date)
- The gRPC method `GetTaddressTxids` has been deprecated; actually, renamed to `GetTaddressTransactions` (change because the old name is misleading)
- I think we can remove `Ping` because it's test-only, and actually, I haven't used that for a very long time (and I very much doubt anyone else has).