### PR TITLE
BUG FIX: Database partial write safeguard and docs

### DIFF
--- a/zaino-proto/src/proto/service.rs
+++ b/zaino-proto/src/proto/service.rs
@@ -380,10 +380,10 @@ pub mod compact_tx_streamer_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct CompactTxStreamerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -427,9 +427,8 @@ pub mod compact_tx_streamer_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             CompactTxStreamerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -469,26 +468,18 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ChainSpec>,
         ) -> std::result::Result<tonic::Response<super::BlockId>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLatestBlock",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetLatestBlock",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetLatestBlock",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Return the compact block corresponding to the given block identifier
@@ -499,26 +490,18 @@ pub mod compact_tx_streamer_client {
             tonic::Response<crate::proto::compact_formats::CompactBlock>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlock",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetBlock",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetBlock",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Same as GetBlock except the returned CompactBlock value contains only
@@ -533,26 +516,18 @@ pub mod compact_tx_streamer_client {
             tonic::Response<crate::proto::compact_formats::CompactBlock>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockNullifiers",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetBlockNullifiers",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetBlockNullifiers",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Return a list of consecutive compact blocks in the specified range,
@@ -564,31 +539,21 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::BlockRange>,
         ) -> std::result::Result<
-            tonic::Response<
-                tonic::codec::Streaming<crate::proto::compact_formats::CompactBlock>,
-            >,
+            tonic::Response<tonic::codec::Streaming<crate::proto::compact_formats::CompactBlock>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockRange",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetBlockRange",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetBlockRange",
+            ));
             self.inner.server_streaming(req, path, codec).await
         }
         /// Same as GetBlockRange except the returned CompactBlock values contain
@@ -600,31 +565,21 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::BlockRange>,
         ) -> std::result::Result<
-            tonic::Response<
-                tonic::codec::Streaming<crate::proto::compact_formats::CompactBlock>,
-            >,
+            tonic::Response<tonic::codec::Streaming<crate::proto::compact_formats::CompactBlock>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockRangeNullifiers",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetBlockRangeNullifiers",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetBlockRangeNullifiers",
+            ));
             self.inner.server_streaming(req, path, codec).await
         }
         /// Return the requested full (not compact) transaction (as from zcashd)
@@ -632,26 +587,18 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::TxFilter>,
         ) -> std::result::Result<tonic::Response<super::RawTransaction>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTransaction",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetTransaction",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetTransaction",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Submit the given transaction to the Zcash network
@@ -659,26 +606,18 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::RawTransaction>,
         ) -> std::result::Result<tonic::Response<super::SendResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/SendTransaction",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "SendTransaction",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "SendTransaction",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Return RawTransactions that match the given transparent address filter.
@@ -692,26 +631,18 @@ pub mod compact_tx_streamer_client {
             tonic::Response<tonic::codec::Streaming<super::RawTransaction>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressTxids",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetTaddressTxids",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetTaddressTxids",
+            ));
             self.inner.server_streaming(req, path, codec).await
         }
         /// Return the transactions corresponding to the given t-address within the given block range.
@@ -723,78 +654,54 @@ pub mod compact_tx_streamer_client {
             tonic::Response<tonic::codec::Streaming<super::RawTransaction>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressTransactions",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetTaddressTransactions",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetTaddressTransactions",
+            ));
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn get_taddress_balance(
             &mut self,
             request: impl tonic::IntoRequest<super::AddressList>,
         ) -> std::result::Result<tonic::Response<super::Balance>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressBalance",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetTaddressBalance",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetTaddressBalance",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_taddress_balance_stream(
             &mut self,
             request: impl tonic::IntoStreamingRequest<Message = super::Address>,
         ) -> std::result::Result<tonic::Response<super::Balance>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressBalanceStream",
             );
             let mut req = request.into_streaming_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetTaddressBalanceStream",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetTaddressBalanceStream",
+            ));
             self.inner.client_streaming(req, path, codec).await
         }
         /// Returns a stream of the compact transaction representation for transactions
@@ -813,31 +720,21 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetMempoolTxRequest>,
         ) -> std::result::Result<
-            tonic::Response<
-                tonic::codec::Streaming<crate::proto::compact_formats::CompactTx>,
-            >,
+            tonic::Response<tonic::codec::Streaming<crate::proto::compact_formats::CompactTx>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetMempoolTx",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetMempoolTx",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetMempoolTx",
+            ));
             self.inner.server_streaming(req, path, codec).await
         }
         /// Return a stream of current Mempool transactions. This will keep the output stream open while
@@ -849,26 +746,18 @@ pub mod compact_tx_streamer_client {
             tonic::Response<tonic::codec::Streaming<super::RawTransaction>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetMempoolStream",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetMempoolStream",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetMempoolStream",
+            ));
             self.inner.server_streaming(req, path, codec).await
         }
         /// GetTreeState returns the note commitment tree state corresponding to the given block.
@@ -879,52 +768,36 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::BlockId>,
         ) -> std::result::Result<tonic::Response<super::TreeState>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTreeState",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetTreeState",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetTreeState",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_latest_tree_state(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> std::result::Result<tonic::Response<super::TreeState>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLatestTreeState",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetLatestTreeState",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetLatestTreeState",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Returns a stream of information about roots of subtrees of the note commitment tree
@@ -936,55 +809,37 @@ pub mod compact_tx_streamer_client {
             tonic::Response<tonic::codec::Streaming<super::SubtreeRoot>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetSubtreeRoots",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetSubtreeRoots",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetSubtreeRoots",
+            ));
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn get_address_utxos(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAddressUtxosArg>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetAddressUtxosReplyList>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetAddressUtxosReplyList>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetAddressUtxos",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetAddressUtxos",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetAddressUtxos",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_address_utxos_stream(
@@ -994,26 +849,18 @@ pub mod compact_tx_streamer_client {
             tonic::Response<tonic::codec::Streaming<super::GetAddressUtxosReply>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetAddressUtxosStream",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetAddressUtxosStream",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetAddressUtxosStream",
+            ));
             self.inner.server_streaming(req, path, codec).await
         }
         /// Return information about this lightwalletd instance and the blockchain
@@ -1021,26 +868,18 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> std::result::Result<tonic::Response<super::LightdInfo>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLightdInfo",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                        "GetLightdInfo",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "GetLightdInfo",
+            ));
             self.inner.unary(req, path, codec).await
         }
         /// Testing-only, requires lightwalletd --ping-very-insecure (do not enable in production)
@@ -1048,23 +887,18 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::Duration>,
         ) -> std::result::Result<tonic::Response<super::PingResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/Ping",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("cash.z.wallet.sdk.rpc.CompactTxStreamer", "Ping"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                "Ping",
+            ));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -1076,7 +910,7 @@ pub mod compact_tx_streamer_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with CompactTxStreamerServer.
@@ -1113,8 +947,7 @@ pub mod compact_tx_streamer_server {
                     crate::proto::compact_formats::CompactBlock,
                     tonic::Status,
                 >,
-            >
-            + std::marker::Send
+            > + std::marker::Send
             + 'static;
         /// Return a list of consecutive compact blocks in the specified range,
         /// which is inclusive of `range.end`.
@@ -1124,18 +957,14 @@ pub mod compact_tx_streamer_server {
         async fn get_block_range(
             &self,
             request: tonic::Request<super::BlockRange>,
-        ) -> std::result::Result<
-            tonic::Response<Self::GetBlockRangeStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::GetBlockRangeStream>, tonic::Status>;
         /// Server streaming response type for the GetBlockRangeNullifiers method.
         type GetBlockRangeNullifiersStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<
                     crate::proto::compact_formats::CompactBlock,
                     tonic::Status,
                 >,
-            >
-            + std::marker::Send
+            > + std::marker::Send
             + 'static;
         /// Same as GetBlockRange except the returned CompactBlock values contain
         /// only nullifiers.
@@ -1145,10 +974,7 @@ pub mod compact_tx_streamer_server {
         async fn get_block_range_nullifiers(
             &self,
             request: tonic::Request<super::BlockRange>,
-        ) -> std::result::Result<
-            tonic::Response<Self::GetBlockRangeNullifiersStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::GetBlockRangeNullifiersStream>, tonic::Status>;
         /// Return the requested full (not compact) transaction (as from zcashd)
         async fn get_transaction(
             &self,
@@ -1162,8 +988,7 @@ pub mod compact_tx_streamer_server {
         /// Server streaming response type for the GetTaddressTxids method.
         type GetTaddressTxidsStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::RawTransaction, tonic::Status>,
-            >
-            + std::marker::Send
+            > + std::marker::Send
             + 'static;
         /// Return RawTransactions that match the given transparent address filter.
         ///
@@ -1172,25 +997,18 @@ pub mod compact_tx_streamer_server {
         async fn get_taddress_txids(
             &self,
             request: tonic::Request<super::TransparentAddressBlockFilter>,
-        ) -> std::result::Result<
-            tonic::Response<Self::GetTaddressTxidsStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::GetTaddressTxidsStream>, tonic::Status>;
         /// Server streaming response type for the GetTaddressTransactions method.
         type GetTaddressTransactionsStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::RawTransaction, tonic::Status>,
-            >
-            + std::marker::Send
+            > + std::marker::Send
             + 'static;
         /// Return the transactions corresponding to the given t-address within the given block range.
         /// Mempool transactions are not included in the results.
         async fn get_taddress_transactions(
             &self,
             request: tonic::Request<super::TransparentAddressBlockFilter>,
-        ) -> std::result::Result<
-            tonic::Response<Self::GetTaddressTransactionsStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::GetTaddressTransactionsStream>, tonic::Status>;
         async fn get_taddress_balance(
             &self,
             request: tonic::Request<super::AddressList>,
@@ -1201,12 +1019,8 @@ pub mod compact_tx_streamer_server {
         ) -> std::result::Result<tonic::Response<super::Balance>, tonic::Status>;
         /// Server streaming response type for the GetMempoolTx method.
         type GetMempoolTxStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<
-                    crate::proto::compact_formats::CompactTx,
-                    tonic::Status,
-                >,
-            >
-            + std::marker::Send
+                Item = std::result::Result<crate::proto::compact_formats::CompactTx, tonic::Status>,
+            > + std::marker::Send
             + 'static;
         /// Returns a stream of the compact transaction representation for transactions
         /// currently in the mempool. The results of this operation may be a few
@@ -1223,25 +1037,18 @@ pub mod compact_tx_streamer_server {
         async fn get_mempool_tx(
             &self,
             request: tonic::Request<super::GetMempoolTxRequest>,
-        ) -> std::result::Result<
-            tonic::Response<Self::GetMempoolTxStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::GetMempoolTxStream>, tonic::Status>;
         /// Server streaming response type for the GetMempoolStream method.
         type GetMempoolStreamStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::RawTransaction, tonic::Status>,
-            >
-            + std::marker::Send
+            > + std::marker::Send
             + 'static;
         /// Return a stream of current Mempool transactions. This will keep the output stream open while
         /// there are mempool transactions. It will close the returned stream when a new block is mined.
         async fn get_mempool_stream(
             &self,
             request: tonic::Request<super::Empty>,
-        ) -> std::result::Result<
-            tonic::Response<Self::GetMempoolStreamStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::GetMempoolStreamStream>, tonic::Status>;
         /// GetTreeState returns the note commitment tree state corresponding to the given block.
         /// See section 3.7 of the Zcash protocol specification. It returns several other useful
         /// values also (even though they can be obtained using GetBlock).
@@ -1257,38 +1064,27 @@ pub mod compact_tx_streamer_server {
         /// Server streaming response type for the GetSubtreeRoots method.
         type GetSubtreeRootsStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::SubtreeRoot, tonic::Status>,
-            >
-            + std::marker::Send
+            > + std::marker::Send
             + 'static;
         /// Returns a stream of information about roots of subtrees of the note commitment tree
         /// for the specified shielded protocol (Sapling or Orchard).
         async fn get_subtree_roots(
             &self,
             request: tonic::Request<super::GetSubtreeRootsArg>,
-        ) -> std::result::Result<
-            tonic::Response<Self::GetSubtreeRootsStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::GetSubtreeRootsStream>, tonic::Status>;
         async fn get_address_utxos(
             &self,
             request: tonic::Request<super::GetAddressUtxosArg>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetAddressUtxosReplyList>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetAddressUtxosReplyList>, tonic::Status>;
         /// Server streaming response type for the GetAddressUtxosStream method.
         type GetAddressUtxosStreamStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::GetAddressUtxosReply, tonic::Status>,
-            >
-            + std::marker::Send
+            > + std::marker::Send
             + 'static;
         async fn get_address_utxos_stream(
             &self,
             request: tonic::Request<super::GetAddressUtxosArg>,
-        ) -> std::result::Result<
-            tonic::Response<Self::GetAddressUtxosStreamStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::GetAddressUtxosStreamStream>, tonic::Status>;
         /// Return information about this lightwalletd instance and the blockchain
         async fn get_lightd_info(
             &self,
@@ -1321,10 +1117,7 @@ pub mod compact_tx_streamer_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1379,23 +1172,16 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLatestBlock" => {
                     #[allow(non_camel_case_types)]
                     struct GetLatestBlockSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::UnaryService<super::ChainSpec>
-                    for GetLatestBlockSvc<T> {
+                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::ChainSpec> for GetLatestBlockSvc<T> {
                         type Response = super::BlockId;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ChainSpec>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_latest_block(&inner, request)
-                                    .await
+                                <T as CompactTxStreamer>::get_latest_block(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1425,14 +1211,9 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlock" => {
                     #[allow(non_camel_case_types)]
                     struct GetBlockSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::UnaryService<super::BlockId> for GetBlockSvc<T> {
+                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::BlockId> for GetBlockSvc<T> {
                         type Response = crate::proto::compact_formats::CompactBlock;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BlockId>,
@@ -1469,25 +1250,18 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockNullifiers" => {
                     #[allow(non_camel_case_types)]
                     struct GetBlockNullifiersSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::UnaryService<super::BlockId>
-                    for GetBlockNullifiersSvc<T> {
+                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::BlockId>
+                        for GetBlockNullifiersSvc<T>
+                    {
                         type Response = crate::proto::compact_formats::CompactBlock;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BlockId>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_block_nullifiers(
-                                        &inner,
-                                        request,
-                                    )
+                                <T as CompactTxStreamer>::get_block_nullifiers(&inner, request)
                                     .await
                             };
                             Box::pin(fut)
@@ -1518,24 +1292,21 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockRange" => {
                     #[allow(non_camel_case_types)]
                     struct GetBlockRangeSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::ServerStreamingService<super::BlockRange>
-                    for GetBlockRangeSvc<T> {
+                    impl<T: CompactTxStreamer>
+                        tonic::server::ServerStreamingService<super::BlockRange>
+                        for GetBlockRangeSvc<T>
+                    {
                         type Response = crate::proto::compact_formats::CompactBlock;
                         type ResponseStream = T::GetBlockRangeStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BlockRange>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_block_range(&inner, request)
-                                    .await
+                                <T as CompactTxStreamer>::get_block_range(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1565,16 +1336,14 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockRangeNullifiers" => {
                     #[allow(non_camel_case_types)]
                     struct GetBlockRangeNullifiersSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::ServerStreamingService<super::BlockRange>
-                    for GetBlockRangeNullifiersSvc<T> {
+                    impl<T: CompactTxStreamer>
+                        tonic::server::ServerStreamingService<super::BlockRange>
+                        for GetBlockRangeNullifiersSvc<T>
+                    {
                         type Response = crate::proto::compact_formats::CompactBlock;
                         type ResponseStream = T::GetBlockRangeNullifiersStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BlockRange>,
@@ -1582,10 +1351,9 @@ pub mod compact_tx_streamer_server {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as CompactTxStreamer>::get_block_range_nullifiers(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                    &inner, request,
+                                )
+                                .await
                             };
                             Box::pin(fut)
                         }
@@ -1615,23 +1383,16 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTransaction" => {
                     #[allow(non_camel_case_types)]
                     struct GetTransactionSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::UnaryService<super::TxFilter>
-                    for GetTransactionSvc<T> {
+                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::TxFilter> for GetTransactionSvc<T> {
                         type Response = super::RawTransaction;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::TxFilter>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_transaction(&inner, request)
-                                    .await
+                                <T as CompactTxStreamer>::get_transaction(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1661,23 +1422,18 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/SendTransaction" => {
                     #[allow(non_camel_case_types)]
                     struct SendTransactionSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::UnaryService<super::RawTransaction>
-                    for SendTransactionSvc<T> {
+                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::RawTransaction>
+                        for SendTransactionSvc<T>
+                    {
                         type Response = super::SendResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RawTransaction>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::send_transaction(&inner, request)
-                                    .await
+                                <T as CompactTxStreamer>::send_transaction(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1707,28 +1463,21 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressTxids" => {
                     #[allow(non_camel_case_types)]
                     struct GetTaddressTxidsSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::ServerStreamingService<
-                        super::TransparentAddressBlockFilter,
-                    > for GetTaddressTxidsSvc<T> {
+                    impl<T: CompactTxStreamer>
+                        tonic::server::ServerStreamingService<super::TransparentAddressBlockFilter>
+                        for GetTaddressTxidsSvc<T>
+                    {
                         type Response = super::RawTransaction;
                         type ResponseStream = T::GetTaddressTxidsStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::TransparentAddressBlockFilter>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_taddress_txids(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                <T as CompactTxStreamer>::get_taddress_txids(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1758,27 +1507,21 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressTransactions" => {
                     #[allow(non_camel_case_types)]
                     struct GetTaddressTransactionsSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::ServerStreamingService<
-                        super::TransparentAddressBlockFilter,
-                    > for GetTaddressTransactionsSvc<T> {
+                    impl<T: CompactTxStreamer>
+                        tonic::server::ServerStreamingService<super::TransparentAddressBlockFilter>
+                        for GetTaddressTransactionsSvc<T>
+                    {
                         type Response = super::RawTransaction;
                         type ResponseStream = T::GetTaddressTransactionsStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::TransparentAddressBlockFilter>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_taddress_transactions(
-                                        &inner,
-                                        request,
-                                    )
+                                <T as CompactTxStreamer>::get_taddress_transactions(&inner, request)
                                     .await
                             };
                             Box::pin(fut)
@@ -1809,25 +1552,18 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressBalance" => {
                     #[allow(non_camel_case_types)]
                     struct GetTaddressBalanceSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::UnaryService<super::AddressList>
-                    for GetTaddressBalanceSvc<T> {
+                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::AddressList>
+                        for GetTaddressBalanceSvc<T>
+                    {
                         type Response = super::Balance;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::AddressList>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_taddress_balance(
-                                        &inner,
-                                        request,
-                                    )
+                                <T as CompactTxStreamer>::get_taddress_balance(&inner, request)
                                     .await
                             };
                             Box::pin(fut)
@@ -1858,15 +1594,11 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressBalanceStream" => {
                     #[allow(non_camel_case_types)]
                     struct GetTaddressBalanceStreamSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::ClientStreamingService<super::Address>
-                    for GetTaddressBalanceStreamSvc<T> {
+                    impl<T: CompactTxStreamer> tonic::server::ClientStreamingService<super::Address>
+                        for GetTaddressBalanceStreamSvc<T>
+                    {
                         type Response = super::Balance;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<tonic::Streaming<super::Address>>,
@@ -1874,10 +1606,9 @@ pub mod compact_tx_streamer_server {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as CompactTxStreamer>::get_taddress_balance_stream(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                    &inner, request,
+                                )
+                                .await
                             };
                             Box::pin(fut)
                         }
@@ -1907,24 +1638,21 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetMempoolTx" => {
                     #[allow(non_camel_case_types)]
                     struct GetMempoolTxSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::ServerStreamingService<super::GetMempoolTxRequest>
-                    for GetMempoolTxSvc<T> {
+                    impl<T: CompactTxStreamer>
+                        tonic::server::ServerStreamingService<super::GetMempoolTxRequest>
+                        for GetMempoolTxSvc<T>
+                    {
                         type Response = crate::proto::compact_formats::CompactTx;
                         type ResponseStream = T::GetMempoolTxStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetMempoolTxRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_mempool_tx(&inner, request)
-                                    .await
+                                <T as CompactTxStreamer>::get_mempool_tx(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1954,27 +1682,17 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetMempoolStream" => {
                     #[allow(non_camel_case_types)]
                     struct GetMempoolStreamSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::ServerStreamingService<super::Empty>
-                    for GetMempoolStreamSvc<T> {
+                    impl<T: CompactTxStreamer> tonic::server::ServerStreamingService<super::Empty>
+                        for GetMempoolStreamSvc<T>
+                    {
                         type Response = super::RawTransaction;
                         type ResponseStream = T::GetMempoolStreamStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::Empty>,
-                        ) -> Self::Future {
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_mempool_stream(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                <T as CompactTxStreamer>::get_mempool_stream(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2004,23 +1722,16 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTreeState" => {
                     #[allow(non_camel_case_types)]
                     struct GetTreeStateSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::UnaryService<super::BlockId>
-                    for GetTreeStateSvc<T> {
+                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::BlockId> for GetTreeStateSvc<T> {
                         type Response = super::TreeState;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BlockId>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_tree_state(&inner, request)
-                                    .await
+                                <T as CompactTxStreamer>::get_tree_state(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2050,23 +1761,13 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLatestTreeState" => {
                     #[allow(non_camel_case_types)]
                     struct GetLatestTreeStateSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::Empty>
-                    for GetLatestTreeStateSvc<T> {
+                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::Empty> for GetLatestTreeStateSvc<T> {
                         type Response = super::TreeState;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::Empty>,
-                        ) -> Self::Future {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_latest_tree_state(
-                                        &inner,
-                                        request,
-                                    )
+                                <T as CompactTxStreamer>::get_latest_tree_state(&inner, request)
                                     .await
                             };
                             Box::pin(fut)
@@ -2097,24 +1798,21 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetSubtreeRoots" => {
                     #[allow(non_camel_case_types)]
                     struct GetSubtreeRootsSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::ServerStreamingService<super::GetSubtreeRootsArg>
-                    for GetSubtreeRootsSvc<T> {
+                    impl<T: CompactTxStreamer>
+                        tonic::server::ServerStreamingService<super::GetSubtreeRootsArg>
+                        for GetSubtreeRootsSvc<T>
+                    {
                         type Response = super::SubtreeRoot;
                         type ResponseStream = T::GetSubtreeRootsStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetSubtreeRootsArg>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_subtree_roots(&inner, request)
-                                    .await
+                                <T as CompactTxStreamer>::get_subtree_roots(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2144,23 +1842,19 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetAddressUtxos" => {
                     #[allow(non_camel_case_types)]
                     struct GetAddressUtxosSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::UnaryService<super::GetAddressUtxosArg>
-                    for GetAddressUtxosSvc<T> {
+                    impl<T: CompactTxStreamer>
+                        tonic::server::UnaryService<super::GetAddressUtxosArg>
+                        for GetAddressUtxosSvc<T>
+                    {
                         type Response = super::GetAddressUtxosReplyList;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetAddressUtxosArg>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_address_utxos(&inner, request)
-                                    .await
+                                <T as CompactTxStreamer>::get_address_utxos(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2190,26 +1884,21 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetAddressUtxosStream" => {
                     #[allow(non_camel_case_types)]
                     struct GetAddressUtxosStreamSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::ServerStreamingService<super::GetAddressUtxosArg>
-                    for GetAddressUtxosStreamSvc<T> {
+                    impl<T: CompactTxStreamer>
+                        tonic::server::ServerStreamingService<super::GetAddressUtxosArg>
+                        for GetAddressUtxosStreamSvc<T>
+                    {
                         type Response = super::GetAddressUtxosReply;
                         type ResponseStream = T::GetAddressUtxosStreamStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetAddressUtxosArg>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_address_utxos_stream(
-                                        &inner,
-                                        request,
-                                    )
+                                <T as CompactTxStreamer>::get_address_utxos_stream(&inner, request)
                                     .await
                             };
                             Box::pin(fut)
@@ -2240,21 +1929,13 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLightdInfo" => {
                     #[allow(non_camel_case_types)]
                     struct GetLightdInfoSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::Empty>
-                    for GetLightdInfoSvc<T> {
+                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::Empty> for GetLightdInfoSvc<T> {
                         type Response = super::LightdInfo;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::Empty>,
-                        ) -> Self::Future {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_lightd_info(&inner, request)
-                                    .await
+                                <T as CompactTxStreamer>::get_lightd_info(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2284,14 +1965,9 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/Ping" => {
                     #[allow(non_camel_case_types)]
                     struct PingSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<
-                        T: CompactTxStreamer,
-                    > tonic::server::UnaryService<super::Duration> for PingSvc<T> {
+                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::Duration> for PingSvc<T> {
                         type Response = super::PingResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::Duration>,
@@ -2325,23 +2001,19 @@ pub mod compact_tx_streamer_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
             }
         }
     }

--- a/zaino-state/src/chain_index/finalised_state/CHANGELOG.md
+++ b/zaino-state/src/chain_index/finalised_state/CHANGELOG.md
@@ -45,6 +45,8 @@ Migration
 - Completion criteria: <how we decide migration is done>
 - Failure handling: <rollback / retry behavior>
 
+Bug Fixes / Optimisations
+
 --------------------------------------------------------------------------------
 DB VERSION v1.0.0 (from v0.0.0)
 Date: 2025-08-13
@@ -97,8 +99,10 @@ Migration
 - Failure handling:
   - do not promote partially built v1; continue using v0 if present; rebuild v1 on retry.
 
+Bug Fixes / Optimisations
+- Complete DB rework
 --------------------------------------------------------------------------------
-DB VERSION v1.0.0 (from v1.1.0)
+DB VERSION v1.1.0 (from v1.0.0)
 Date: 2026-01-27
 --------------------------------------------------------------------------------
 
@@ -145,6 +149,9 @@ Migration
   - DbMetadata.migration_status reset to Empty.
 - Failure handling:
   - Idempotent: re-running re-writes the same metadata; no partial state beyond metadata.
+
+Bug Fixes / Optimisations
+- Added safety check for idempotent DB writes
 
 --------------------------------------------------------------------------------
 (append new entries below)

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -943,9 +943,11 @@ impl DbV1 {
     }
 
     // *** DB write / delete methods ***
-    // These should only ever be used in a single DB control task.
+    // **These should only ever be used in a single DB control task.**
 
     /// Writes a given (finalised) [`IndexedBlock`] to ZainoDB.
+    ///
+    /// NOTE: This method should never leave a block partially written to the database.
     pub(crate) async fn write_block(&self, block: IndexedBlock) -> Result<(), FinalisedStateError> {
         self.status.store(StatusType::Syncing);
         let block_hash = *block.index().hash();
@@ -963,10 +965,13 @@ impl DbV1 {
                 Ok(stored_header_bytes) => {
                     // Block exists at this height - verify it's the same block
                     // Data is stored as StoredEntryVar<BlockHeaderData>, so deserialize properly
-                    let stored_entry = StoredEntryVar::<BlockHeaderData>::from_bytes(stored_header_bytes)
-                        .map_err(|e| FinalisedStateError::Custom(format!(
-                            "header decode error during idempotency check: {e}"
-                        )))?;
+                    let stored_entry =
+                        StoredEntryVar::<BlockHeaderData>::from_bytes(stored_header_bytes)
+                            .map_err(|e| {
+                                FinalisedStateError::Custom(format!(
+                                    "header decode error during idempotency check: {e}"
+                                ))
+                            })?;
                     let stored_header = stored_entry.inner();
                     if *stored_header.index().hash() == block_hash {
                         // Same block already written, this is a no-op success
@@ -1352,7 +1357,11 @@ impl DbV1 {
             }
             Err(FinalisedStateError::LmdbError(lmdb::Error::KeyExist)) => {
                 // Block write failed because key already exists - another process wrote it
-                // between our check and our write. Wait briefly and verify it's the same block.
+                // between our check and our write.
+                //
+                // Wait briefly and verify it's the same block and was fully written to the finalised state.
+                // Partially written block should be deleted from the database and the write error reported
+                // so the on disk tables are never corrupted by a partial block writes.
                 tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
                 let height_bytes = block_height.to_bytes()?;
@@ -1363,13 +1372,25 @@ impl DbV1 {
                     match ro.get(self.headers, &height_bytes) {
                         Ok(stored_header_bytes) => {
                             // Data is stored as StoredEntryVar<BlockHeaderData>
-                            let stored_entry = StoredEntryVar::<BlockHeaderData>::from_bytes(stored_header_bytes)
-                                .map_err(|e| FinalisedStateError::Custom(format!(
-                                    "header decode error in KeyExist handler: {e}"
-                                )))?;
+                            let stored_entry =
+                                StoredEntryVar::<BlockHeaderData>::from_bytes(stored_header_bytes)
+                                    .map_err(|e| {
+                                        FinalisedStateError::Custom(format!(
+                                            "header decode error in KeyExist handler: {e}"
+                                        ))
+                                    })?;
                             let stored_header = stored_entry.inner();
                             if *stored_header.index().hash() == block_hash {
-                                Ok(true) // Block already written correctly
+                                // Block hash exists, verify block was fully written.
+                                self.validate_block_blocking(block_height, block_hash)
+                                    .map(|()| true)
+                                    .map_err(|e| {
+                                        FinalisedStateError::Custom(format!(
+                                            "Block write fail at height {}, with hash {:?}, \
+                                            validation error: {}",
+                                            block_height.0, block_hash, e
+                                        ))
+                                    })
                             } else {
                                 Err(FinalisedStateError::Custom(format!(
                                     "KeyExist race: different block at height {} \
@@ -1380,12 +1401,10 @@ impl DbV1 {
                                 )))
                             }
                         }
-                        Err(lmdb::Error::NotFound) => {
-                            Err(FinalisedStateError::Custom(format!(
-                                "KeyExist but block not found at height {} after sync",
-                                block_height.0
-                            )))
-                        }
+                        Err(lmdb::Error::NotFound) => Err(FinalisedStateError::Custom(format!(
+                            "KeyExist but block not found at height {} after sync",
+                            block_height.0
+                        ))),
                         Err(e) => Err(FinalisedStateError::LmdbError(e)),
                     }
                 });
@@ -1402,6 +1421,12 @@ impl DbV1 {
                     }
                     Err(e) => {
                         warn!("Error writing block to DB: {e}");
+
+                        let _ = self.delete_block(&block).await;
+                        tokio::task::block_in_place(|| self.env.sync(true)).map_err(|e| {
+                            FinalisedStateError::Custom(format!("LMDB sync failed: {e}"))
+                        })?;
+                        self.status.store(StatusType::CriticalError);
                         self.status.store(StatusType::RecoverableError);
                         Err(FinalisedStateError::InvalidBlock {
                             height: block_height.0,
@@ -1414,7 +1439,7 @@ impl DbV1 {
             Err(e) => {
                 warn!("Error writing block to DB: {e}");
 
-                // let _ = self.delete_block(&block).await;
+                let _ = self.delete_block(&block).await;
                 tokio::task::block_in_place(|| self.env.sync(true))
                     .map_err(|e| FinalisedStateError::Custom(format!("LMDB sync failed: {e}")))?;
                 self.status.store(StatusType::CriticalError);

--- a/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -43,6 +43,52 @@
 //! building the new database in full. This enables developers to minimise transient disk usage
 //! during migrations.
 //!
+//! # Notes on MigrationType
+//!
+//! Database versioning (and migration) is split into three distinct types, dependant of the severity
+//! of changes being made to the database:
+//! - Major versions / migrations:
+//!   - Major schema / capability changes, notably changes that require refetching the complete
+//!     blockchain from the backing validator / finaliser to build / update database indices.
+//!   - Migrations should follow the "primary" database / "shadow" database model. The legacy database
+//!     should be spawned as the "primary" and set to carry on serving data during migration. The new
+//!     database version is then spawned as the "shadow" and built in a background process. Once the
+//!     "shadow" is built to "primary" db tip height it is promoted to primary, taking over serving
+//!     data from the legacy database, the demoted database can then be safely removed from disk. It is
+//!     also possible to partially build the new database version , promote specific database capability,
+//!     and delete specific tables from the legacy database, reducing transient disk usage.
+//! - Minor versions / migrations:
+//!   - Updates involving minor schema / capability changes, notably changes that can be rebuilt in place
+//!     (changes that do not require fetching new data from the backing validator / finaliser) or that can
+//!     rely on updates to the versioned serialisation / deserialisation of database structures.
+//!   - Migrations for minor patch bumps can follow several paths. If the database table being updated
+//!     holds variable length items, and the actual data being held is not changed (only format changes
+//!     being applied) then it may be possible to rely on serialisation / deserialisation updates to the
+//!     items being chenged, with the database table holding a mix of serialisation versions. However,
+//!     if the table being updated is of fixed length items, or the actual data held is being updated,
+//!     then it will be necessary to rebuild that table in full, possibly requiring database downtime for
+//!     the migration. Since this only involves moving data already held in the database (rather than
+//!     fetching new data from the backing validator) migration should be quick and short downtimes are
+//!     accepted.
+//! - Patch versions / migrations:
+//!   - Changes to database code that do not touch the database schema, these include bug fixes,
+//!     performance improvements etc.
+//!   - Migrations for patch updates only need to handle updating the stored DbMetadata singleton.
+//!
+//! # Development: adding a new migration step
+//!
+//! 1. Introduce a new `struct MigrationX_Y_ZToA_B_C;` and implement `Migration<T>`.
+//! 2. Add a new `MigrationStep` variant and register it in `MigrationManager::get_migration()` by
+//!    matching on the *current* version.
+//! 3. Ensure the migration is:
+//!    - deterministic,
+//!    - resumable (use `DbMetadata::migration_status` and/or shadow tip),
+//!    - crash-safe (never leaves a partially promoted DB).
+//! 4. Add tests/fixtures for:
+//!    - starting from the old version,
+//!    - resuming mid-build if applicable,
+//!    - validating the promoted DB serves required capabilities.
+//!
 //! # Implemented migrations
 //!
 //! ## v0.0.0 → v1.0.0
@@ -79,50 +125,8 @@
 //! This release also introduces [`MigrationStep`], the enum-based migration dispatcher used by
 //! [`MigrationManager`], to allow selecting between multiple concrete migration implementations.
 //!
-//! # Development: adding a new migration step
-//!
-//! 1. Introduce a new `struct MigrationX_Y_ZToA_B_C;` and implement `Migration<T>`.
-//! 2. Add a new `MigrationStep` variant and register it in `MigrationManager::get_migration()` by
-//!    matching on the *current* version.
-//! 3. Ensure the migration is:
-//!    - deterministic,
-//!    - resumable (use `DbMetadata::migration_status` and/or shadow tip),
-//!    - crash-safe (never leaves a partially promoted DB).
-//! 4. Add tests/fixtures for:
-//!    - starting from the old version,
-//!    - resuming mid-build if applicable,
-//!    - validating the promoted DB serves required capabilities.
-//!
-//! # Notes on MigrationType
-//! Database versioning (and migration) is split into three distinct types, dependant of the severity
-//! of changes being made to the database:
-//! - Major versions / migrations:
-//!   - Major schema / capability changes, notably changes that require refetching the complete
-//!     blockchain from the backing validator / finaliser to build / update database indices.
-//!   - Migrations should follow the "primary" database / "shadow" database model. The legacy database
-//!     should be spawned as the "primary" and set to carry on serving data during migration. The new
-//!     database version is then spawned as the "shadow" and built in a background process. Once the
-//!     "shadow" is built to "primary" db tip height it is promoted to primary, taking over serving
-//!     data from the legacy database, the demoted database can then be safely removed from disk. It is
-//!     also possible to partially build the new database version , promote specific database capability,
-//!     and delete specific tables from the legacy database, reducing transient disk usage.
-//! - Minor versions / migrations:
-//!   - Updates involving minor schema / capability changes, notably changes that can be rebuilt in place
-//!     (changes that do not require fetching new data from the backing validator / finaliser) or that can
-//!     rely on updates to the versioned serialisation / deserialisation of database structures.
-//!   - Migrations for minor patch bumps can follow several paths. If the database table being updated
-//!     holds variable length items, and the actual data being held is not changed (only format changes
-//!     being applied) then it may be possible to rely on serialisation / deserialisation updates to the
-//!     items being chenged, with the database table holding a mix of serialisation versions. However,
-//!     if the table being updated is of fixed length items, or the actual data held is being updated,
-//!     then it will be necessary to rebuild that table in full, possibly requiring database downtime for
-//!     the migration. Since this only involves moving data already held in the database (rather than
-//!     fetching new data from the backing validator) migration should be quick and short downtimes are
-//!     accepted.
-//! - Patch versions / migrations:
-//!   - Changes to database code that do not touch the database schema, these include bug fixes,
-//!     performance improvements etc.
-//!   - Migrations for patch updates only need to handle updating the stored DbMetadata singleton.
+//! Bug Fixes:
+//! - Added safety check for idempotent DB writes
 
 use super::{
     capability::{
@@ -141,10 +145,11 @@ use crate::{
     BlockHash, BlockMetadata, BlockWithMetadata, ChainWork, Height, IndexedBlock,
 };
 
+use zebra_chain::parameters::NetworkKind;
+
 use async_trait::async_trait;
 use std::sync::Arc;
 use tracing::info;
-use zebra_chain::parameters::NetworkKind;
 
 /// Broad categorisation of migration severity.
 ///
@@ -539,6 +544,9 @@ impl<T: BlockchainSource> Migration<T> for Migration0_0_0To1_0_0 {
 ///
 /// Because the persisted schema contract is unchanged, this migration only updates the stored
 /// [`DbMetadata::version`] from `1.0.0` to `1.1.0`.
+///
+/// Bug Fixes:
+/// - Added safety check for idempotent DB writes
 ///
 /// Safety and resumability:
 /// - Idempotent: if run more than once, it will re-write the same metadata.

--- a/zaino-state/src/error.rs
+++ b/zaino-state/src/error.rs
@@ -608,7 +608,8 @@ impl ChainIndexError {
     pub(crate) fn validator_data_error_block_coinbase_height_missing() -> Self {
         Self {
             kind: ChainIndexErrorKind::InternalServerError,
-            message: "validator error: data error: block.coinbase_height() returned None".to_string(),
+            message: "validator error: data error: block.coinbase_height() returned None"
+                .to_string(),
             source: None,
         }
     }

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -543,11 +543,8 @@ where
     ///
     /// Panics if the indexer is not live (Offline or CriticalError), indicating the
     /// backing validator has crashed or become unreachable.
-    pub async fn generate_blocks_and_poll_indexer<I>(
-        &self,
-        n: u32,
-        indexer: &I,
-    ) where
+    pub async fn generate_blocks_and_poll_indexer<I>(&self, n: u32, indexer: &I)
+    where
         I: LightWalletIndexer + Liveness + Status,
     {
         let chain_height = self.local_net.get_chain_height().await;


### PR DESCRIPTION
Fixes bug in database write leading to partially written blocks, corrupting database tables. Updates database changelog and migration documentation. (Also ran cargo fmt --all)

Closes #836 
Closes #837 

NOTE: The changes in `zaino_proto/src/proto/service.rs` and `zaino_state/src/error.rs` are all from running `cargo fmt --all`
