### PR TITLE
Release Blocker Bug hot fixes

### DIFF
--- a/zaino-proto/src/proto/service.rs
+++ b/zaino-proto/src/proto/service.rs
@@ -380,10 +380,10 @@ pub mod compact_tx_streamer_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct CompactTxStreamerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -427,8 +427,9 @@ pub mod compact_tx_streamer_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             CompactTxStreamerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -468,18 +469,26 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::ChainSpec>,
         ) -> std::result::Result<tonic::Response<super::BlockId>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLatestBlock",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetLatestBlock",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetLatestBlock",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Return the compact block corresponding to the given block identifier
@@ -490,18 +499,26 @@ pub mod compact_tx_streamer_client {
             tonic::Response<crate::proto::compact_formats::CompactBlock>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlock",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetBlock",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetBlock",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Same as GetBlock except the returned CompactBlock value contains only
@@ -516,18 +533,26 @@ pub mod compact_tx_streamer_client {
             tonic::Response<crate::proto::compact_formats::CompactBlock>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockNullifiers",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetBlockNullifiers",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetBlockNullifiers",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Return a list of consecutive compact blocks in the specified range,
@@ -539,21 +564,31 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::BlockRange>,
         ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<crate::proto::compact_formats::CompactBlock>>,
+            tonic::Response<
+                tonic::codec::Streaming<crate::proto::compact_formats::CompactBlock>,
+            >,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockRange",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetBlockRange",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetBlockRange",
+                    ),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         /// Same as GetBlockRange except the returned CompactBlock values contain
@@ -565,21 +600,31 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::BlockRange>,
         ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<crate::proto::compact_formats::CompactBlock>>,
+            tonic::Response<
+                tonic::codec::Streaming<crate::proto::compact_formats::CompactBlock>,
+            >,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockRangeNullifiers",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetBlockRangeNullifiers",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetBlockRangeNullifiers",
+                    ),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         /// Return the requested full (not compact) transaction (as from zcashd)
@@ -587,18 +632,26 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::TxFilter>,
         ) -> std::result::Result<tonic::Response<super::RawTransaction>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTransaction",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetTransaction",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetTransaction",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Submit the given transaction to the Zcash network
@@ -606,18 +659,26 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::RawTransaction>,
         ) -> std::result::Result<tonic::Response<super::SendResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/SendTransaction",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "SendTransaction",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "SendTransaction",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Return RawTransactions that match the given transparent address filter.
@@ -631,18 +692,26 @@ pub mod compact_tx_streamer_client {
             tonic::Response<tonic::codec::Streaming<super::RawTransaction>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressTxids",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetTaddressTxids",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetTaddressTxids",
+                    ),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         /// Return the transactions corresponding to the given t-address within the given block range.
@@ -654,54 +723,78 @@ pub mod compact_tx_streamer_client {
             tonic::Response<tonic::codec::Streaming<super::RawTransaction>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressTransactions",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetTaddressTransactions",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetTaddressTransactions",
+                    ),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn get_taddress_balance(
             &mut self,
             request: impl tonic::IntoRequest<super::AddressList>,
         ) -> std::result::Result<tonic::Response<super::Balance>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressBalance",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetTaddressBalance",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetTaddressBalance",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_taddress_balance_stream(
             &mut self,
             request: impl tonic::IntoStreamingRequest<Message = super::Address>,
         ) -> std::result::Result<tonic::Response<super::Balance>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressBalanceStream",
             );
             let mut req = request.into_streaming_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetTaddressBalanceStream",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetTaddressBalanceStream",
+                    ),
+                );
             self.inner.client_streaming(req, path, codec).await
         }
         /// Returns a stream of the compact transaction representation for transactions
@@ -720,21 +813,31 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::GetMempoolTxRequest>,
         ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<crate::proto::compact_formats::CompactTx>>,
+            tonic::Response<
+                tonic::codec::Streaming<crate::proto::compact_formats::CompactTx>,
+            >,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetMempoolTx",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetMempoolTx",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetMempoolTx",
+                    ),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         /// Return a stream of current Mempool transactions. This will keep the output stream open while
@@ -746,18 +849,26 @@ pub mod compact_tx_streamer_client {
             tonic::Response<tonic::codec::Streaming<super::RawTransaction>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetMempoolStream",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetMempoolStream",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetMempoolStream",
+                    ),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         /// GetTreeState returns the note commitment tree state corresponding to the given block.
@@ -768,36 +879,52 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::BlockId>,
         ) -> std::result::Result<tonic::Response<super::TreeState>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTreeState",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetTreeState",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetTreeState",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_latest_tree_state(
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> std::result::Result<tonic::Response<super::TreeState>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLatestTreeState",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetLatestTreeState",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetLatestTreeState",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Returns a stream of information about roots of subtrees of the note commitment tree
@@ -809,37 +936,55 @@ pub mod compact_tx_streamer_client {
             tonic::Response<tonic::codec::Streaming<super::SubtreeRoot>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetSubtreeRoots",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetSubtreeRoots",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetSubtreeRoots",
+                    ),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         pub async fn get_address_utxos(
             &mut self,
             request: impl tonic::IntoRequest<super::GetAddressUtxosArg>,
-        ) -> std::result::Result<tonic::Response<super::GetAddressUtxosReplyList>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAddressUtxosReplyList>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetAddressUtxos",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetAddressUtxos",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetAddressUtxos",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_address_utxos_stream(
@@ -849,18 +994,26 @@ pub mod compact_tx_streamer_client {
             tonic::Response<tonic::codec::Streaming<super::GetAddressUtxosReply>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetAddressUtxosStream",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetAddressUtxosStream",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetAddressUtxosStream",
+                    ),
+                );
             self.inner.server_streaming(req, path, codec).await
         }
         /// Return information about this lightwalletd instance and the blockchain
@@ -868,18 +1021,26 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::Empty>,
         ) -> std::result::Result<tonic::Response<super::LightdInfo>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLightdInfo",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "GetLightdInfo",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "cash.z.wallet.sdk.rpc.CompactTxStreamer",
+                        "GetLightdInfo",
+                    ),
+                );
             self.inner.unary(req, path, codec).await
         }
         /// Testing-only, requires lightwalletd --ping-very-insecure (do not enable in production)
@@ -887,18 +1048,23 @@ pub mod compact_tx_streamer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::Duration>,
         ) -> std::result::Result<tonic::Response<super::PingResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/Ping",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "cash.z.wallet.sdk.rpc.CompactTxStreamer",
-                "Ping",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("cash.z.wallet.sdk.rpc.CompactTxStreamer", "Ping"),
+                );
             self.inner.unary(req, path, codec).await
         }
     }
@@ -910,7 +1076,7 @@ pub mod compact_tx_streamer_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with CompactTxStreamerServer.
@@ -947,7 +1113,8 @@ pub mod compact_tx_streamer_server {
                     crate::proto::compact_formats::CompactBlock,
                     tonic::Status,
                 >,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         /// Return a list of consecutive compact blocks in the specified range,
         /// which is inclusive of `range.end`.
@@ -957,14 +1124,18 @@ pub mod compact_tx_streamer_server {
         async fn get_block_range(
             &self,
             request: tonic::Request<super::BlockRange>,
-        ) -> std::result::Result<tonic::Response<Self::GetBlockRangeStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::GetBlockRangeStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the GetBlockRangeNullifiers method.
         type GetBlockRangeNullifiersStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<
                     crate::proto::compact_formats::CompactBlock,
                     tonic::Status,
                 >,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         /// Same as GetBlockRange except the returned CompactBlock values contain
         /// only nullifiers.
@@ -974,7 +1145,10 @@ pub mod compact_tx_streamer_server {
         async fn get_block_range_nullifiers(
             &self,
             request: tonic::Request<super::BlockRange>,
-        ) -> std::result::Result<tonic::Response<Self::GetBlockRangeNullifiersStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::GetBlockRangeNullifiersStream>,
+            tonic::Status,
+        >;
         /// Return the requested full (not compact) transaction (as from zcashd)
         async fn get_transaction(
             &self,
@@ -988,7 +1162,8 @@ pub mod compact_tx_streamer_server {
         /// Server streaming response type for the GetTaddressTxids method.
         type GetTaddressTxidsStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::RawTransaction, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         /// Return RawTransactions that match the given transparent address filter.
         ///
@@ -997,18 +1172,25 @@ pub mod compact_tx_streamer_server {
         async fn get_taddress_txids(
             &self,
             request: tonic::Request<super::TransparentAddressBlockFilter>,
-        ) -> std::result::Result<tonic::Response<Self::GetTaddressTxidsStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::GetTaddressTxidsStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the GetTaddressTransactions method.
         type GetTaddressTransactionsStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::RawTransaction, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         /// Return the transactions corresponding to the given t-address within the given block range.
         /// Mempool transactions are not included in the results.
         async fn get_taddress_transactions(
             &self,
             request: tonic::Request<super::TransparentAddressBlockFilter>,
-        ) -> std::result::Result<tonic::Response<Self::GetTaddressTransactionsStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::GetTaddressTransactionsStream>,
+            tonic::Status,
+        >;
         async fn get_taddress_balance(
             &self,
             request: tonic::Request<super::AddressList>,
@@ -1019,8 +1201,12 @@ pub mod compact_tx_streamer_server {
         ) -> std::result::Result<tonic::Response<super::Balance>, tonic::Status>;
         /// Server streaming response type for the GetMempoolTx method.
         type GetMempoolTxStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<crate::proto::compact_formats::CompactTx, tonic::Status>,
-            > + std::marker::Send
+                Item = std::result::Result<
+                    crate::proto::compact_formats::CompactTx,
+                    tonic::Status,
+                >,
+            >
+            + std::marker::Send
             + 'static;
         /// Returns a stream of the compact transaction representation for transactions
         /// currently in the mempool. The results of this operation may be a few
@@ -1037,18 +1223,25 @@ pub mod compact_tx_streamer_server {
         async fn get_mempool_tx(
             &self,
             request: tonic::Request<super::GetMempoolTxRequest>,
-        ) -> std::result::Result<tonic::Response<Self::GetMempoolTxStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::GetMempoolTxStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the GetMempoolStream method.
         type GetMempoolStreamStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::RawTransaction, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         /// Return a stream of current Mempool transactions. This will keep the output stream open while
         /// there are mempool transactions. It will close the returned stream when a new block is mined.
         async fn get_mempool_stream(
             &self,
             request: tonic::Request<super::Empty>,
-        ) -> std::result::Result<tonic::Response<Self::GetMempoolStreamStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::GetMempoolStreamStream>,
+            tonic::Status,
+        >;
         /// GetTreeState returns the note commitment tree state corresponding to the given block.
         /// See section 3.7 of the Zcash protocol specification. It returns several other useful
         /// values also (even though they can be obtained using GetBlock).
@@ -1064,27 +1257,38 @@ pub mod compact_tx_streamer_server {
         /// Server streaming response type for the GetSubtreeRoots method.
         type GetSubtreeRootsStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::SubtreeRoot, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         /// Returns a stream of information about roots of subtrees of the note commitment tree
         /// for the specified shielded protocol (Sapling or Orchard).
         async fn get_subtree_roots(
             &self,
             request: tonic::Request<super::GetSubtreeRootsArg>,
-        ) -> std::result::Result<tonic::Response<Self::GetSubtreeRootsStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::GetSubtreeRootsStream>,
+            tonic::Status,
+        >;
         async fn get_address_utxos(
             &self,
             request: tonic::Request<super::GetAddressUtxosArg>,
-        ) -> std::result::Result<tonic::Response<super::GetAddressUtxosReplyList>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GetAddressUtxosReplyList>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the GetAddressUtxosStream method.
         type GetAddressUtxosStreamStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::GetAddressUtxosReply, tonic::Status>,
-            > + std::marker::Send
+            >
+            + std::marker::Send
             + 'static;
         async fn get_address_utxos_stream(
             &self,
             request: tonic::Request<super::GetAddressUtxosArg>,
-        ) -> std::result::Result<tonic::Response<Self::GetAddressUtxosStreamStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::GetAddressUtxosStreamStream>,
+            tonic::Status,
+        >;
         /// Return information about this lightwalletd instance and the blockchain
         async fn get_lightd_info(
             &self,
@@ -1117,7 +1321,10 @@ pub mod compact_tx_streamer_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1172,16 +1379,23 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLatestBlock" => {
                     #[allow(non_camel_case_types)]
                     struct GetLatestBlockSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::ChainSpec> for GetLatestBlockSvc<T> {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::ChainSpec>
+                    for GetLatestBlockSvc<T> {
                         type Response = super::BlockId;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ChainSpec>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_latest_block(&inner, request).await
+                                <T as CompactTxStreamer>::get_latest_block(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1211,9 +1425,14 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlock" => {
                     #[allow(non_camel_case_types)]
                     struct GetBlockSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::BlockId> for GetBlockSvc<T> {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::BlockId> for GetBlockSvc<T> {
                         type Response = crate::proto::compact_formats::CompactBlock;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BlockId>,
@@ -1250,18 +1469,25 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockNullifiers" => {
                     #[allow(non_camel_case_types)]
                     struct GetBlockNullifiersSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::BlockId>
-                        for GetBlockNullifiersSvc<T>
-                    {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::BlockId>
+                    for GetBlockNullifiersSvc<T> {
                         type Response = crate::proto::compact_formats::CompactBlock;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BlockId>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_block_nullifiers(&inner, request)
+                                <T as CompactTxStreamer>::get_block_nullifiers(
+                                        &inner,
+                                        request,
+                                    )
                                     .await
                             };
                             Box::pin(fut)
@@ -1292,21 +1518,24 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockRange" => {
                     #[allow(non_camel_case_types)]
                     struct GetBlockRangeSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer>
-                        tonic::server::ServerStreamingService<super::BlockRange>
-                        for GetBlockRangeSvc<T>
-                    {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ServerStreamingService<super::BlockRange>
+                    for GetBlockRangeSvc<T> {
                         type Response = crate::proto::compact_formats::CompactBlock;
                         type ResponseStream = T::GetBlockRangeStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BlockRange>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_block_range(&inner, request).await
+                                <T as CompactTxStreamer>::get_block_range(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1336,14 +1565,16 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetBlockRangeNullifiers" => {
                     #[allow(non_camel_case_types)]
                     struct GetBlockRangeNullifiersSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer>
-                        tonic::server::ServerStreamingService<super::BlockRange>
-                        for GetBlockRangeNullifiersSvc<T>
-                    {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ServerStreamingService<super::BlockRange>
+                    for GetBlockRangeNullifiersSvc<T> {
                         type Response = crate::proto::compact_formats::CompactBlock;
                         type ResponseStream = T::GetBlockRangeNullifiersStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BlockRange>,
@@ -1351,9 +1582,10 @@ pub mod compact_tx_streamer_server {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as CompactTxStreamer>::get_block_range_nullifiers(
-                                    &inner, request,
-                                )
-                                .await
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1383,16 +1615,23 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTransaction" => {
                     #[allow(non_camel_case_types)]
                     struct GetTransactionSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::TxFilter> for GetTransactionSvc<T> {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::TxFilter>
+                    for GetTransactionSvc<T> {
                         type Response = super::RawTransaction;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::TxFilter>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_transaction(&inner, request).await
+                                <T as CompactTxStreamer>::get_transaction(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1422,18 +1661,23 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/SendTransaction" => {
                     #[allow(non_camel_case_types)]
                     struct SendTransactionSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::RawTransaction>
-                        for SendTransactionSvc<T>
-                    {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::RawTransaction>
+                    for SendTransactionSvc<T> {
                         type Response = super::SendResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RawTransaction>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::send_transaction(&inner, request).await
+                                <T as CompactTxStreamer>::send_transaction(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1463,21 +1707,28 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressTxids" => {
                     #[allow(non_camel_case_types)]
                     struct GetTaddressTxidsSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer>
-                        tonic::server::ServerStreamingService<super::TransparentAddressBlockFilter>
-                        for GetTaddressTxidsSvc<T>
-                    {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ServerStreamingService<
+                        super::TransparentAddressBlockFilter,
+                    > for GetTaddressTxidsSvc<T> {
                         type Response = super::RawTransaction;
                         type ResponseStream = T::GetTaddressTxidsStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::TransparentAddressBlockFilter>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_taddress_txids(&inner, request).await
+                                <T as CompactTxStreamer>::get_taddress_txids(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1507,21 +1758,27 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressTransactions" => {
                     #[allow(non_camel_case_types)]
                     struct GetTaddressTransactionsSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer>
-                        tonic::server::ServerStreamingService<super::TransparentAddressBlockFilter>
-                        for GetTaddressTransactionsSvc<T>
-                    {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ServerStreamingService<
+                        super::TransparentAddressBlockFilter,
+                    > for GetTaddressTransactionsSvc<T> {
                         type Response = super::RawTransaction;
                         type ResponseStream = T::GetTaddressTransactionsStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::TransparentAddressBlockFilter>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_taddress_transactions(&inner, request)
+                                <T as CompactTxStreamer>::get_taddress_transactions(
+                                        &inner,
+                                        request,
+                                    )
                                     .await
                             };
                             Box::pin(fut)
@@ -1552,18 +1809,25 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressBalance" => {
                     #[allow(non_camel_case_types)]
                     struct GetTaddressBalanceSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::AddressList>
-                        for GetTaddressBalanceSvc<T>
-                    {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::AddressList>
+                    for GetTaddressBalanceSvc<T> {
                         type Response = super::Balance;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::AddressList>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_taddress_balance(&inner, request)
+                                <T as CompactTxStreamer>::get_taddress_balance(
+                                        &inner,
+                                        request,
+                                    )
                                     .await
                             };
                             Box::pin(fut)
@@ -1594,11 +1858,15 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTaddressBalanceStream" => {
                     #[allow(non_camel_case_types)]
                     struct GetTaddressBalanceStreamSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer> tonic::server::ClientStreamingService<super::Address>
-                        for GetTaddressBalanceStreamSvc<T>
-                    {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ClientStreamingService<super::Address>
+                    for GetTaddressBalanceStreamSvc<T> {
                         type Response = super::Balance;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<tonic::Streaming<super::Address>>,
@@ -1606,9 +1874,10 @@ pub mod compact_tx_streamer_server {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as CompactTxStreamer>::get_taddress_balance_stream(
-                                    &inner, request,
-                                )
-                                .await
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1638,21 +1907,24 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetMempoolTx" => {
                     #[allow(non_camel_case_types)]
                     struct GetMempoolTxSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer>
-                        tonic::server::ServerStreamingService<super::GetMempoolTxRequest>
-                        for GetMempoolTxSvc<T>
-                    {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ServerStreamingService<super::GetMempoolTxRequest>
+                    for GetMempoolTxSvc<T> {
                         type Response = crate::proto::compact_formats::CompactTx;
                         type ResponseStream = T::GetMempoolTxStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetMempoolTxRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_mempool_tx(&inner, request).await
+                                <T as CompactTxStreamer>::get_mempool_tx(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1682,17 +1954,27 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetMempoolStream" => {
                     #[allow(non_camel_case_types)]
                     struct GetMempoolStreamSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer> tonic::server::ServerStreamingService<super::Empty>
-                        for GetMempoolStreamSvc<T>
-                    {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ServerStreamingService<super::Empty>
+                    for GetMempoolStreamSvc<T> {
                         type Response = super::RawTransaction;
                         type ResponseStream = T::GetMempoolStreamStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
-                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Empty>,
+                        ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_mempool_stream(&inner, request).await
+                                <T as CompactTxStreamer>::get_mempool_stream(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1722,16 +2004,23 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTreeState" => {
                     #[allow(non_camel_case_types)]
                     struct GetTreeStateSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::BlockId> for GetTreeStateSvc<T> {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::BlockId>
+                    for GetTreeStateSvc<T> {
                         type Response = super::TreeState;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::BlockId>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_tree_state(&inner, request).await
+                                <T as CompactTxStreamer>::get_tree_state(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1761,13 +2050,23 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLatestTreeState" => {
                     #[allow(non_camel_case_types)]
                     struct GetLatestTreeStateSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::Empty> for GetLatestTreeStateSvc<T> {
+                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::Empty>
+                    for GetLatestTreeStateSvc<T> {
                         type Response = super::TreeState;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Empty>,
+                        ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_latest_tree_state(&inner, request)
+                                <T as CompactTxStreamer>::get_latest_tree_state(
+                                        &inner,
+                                        request,
+                                    )
                                     .await
                             };
                             Box::pin(fut)
@@ -1798,21 +2097,24 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetSubtreeRoots" => {
                     #[allow(non_camel_case_types)]
                     struct GetSubtreeRootsSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer>
-                        tonic::server::ServerStreamingService<super::GetSubtreeRootsArg>
-                        for GetSubtreeRootsSvc<T>
-                    {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ServerStreamingService<super::GetSubtreeRootsArg>
+                    for GetSubtreeRootsSvc<T> {
                         type Response = super::SubtreeRoot;
                         type ResponseStream = T::GetSubtreeRootsStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetSubtreeRootsArg>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_subtree_roots(&inner, request).await
+                                <T as CompactTxStreamer>::get_subtree_roots(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1842,19 +2144,23 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetAddressUtxos" => {
                     #[allow(non_camel_case_types)]
                     struct GetAddressUtxosSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer>
-                        tonic::server::UnaryService<super::GetAddressUtxosArg>
-                        for GetAddressUtxosSvc<T>
-                    {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::GetAddressUtxosArg>
+                    for GetAddressUtxosSvc<T> {
                         type Response = super::GetAddressUtxosReplyList;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetAddressUtxosArg>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_address_utxos(&inner, request).await
+                                <T as CompactTxStreamer>::get_address_utxos(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1884,21 +2190,26 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetAddressUtxosStream" => {
                     #[allow(non_camel_case_types)]
                     struct GetAddressUtxosStreamSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer>
-                        tonic::server::ServerStreamingService<super::GetAddressUtxosArg>
-                        for GetAddressUtxosStreamSvc<T>
-                    {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::ServerStreamingService<super::GetAddressUtxosArg>
+                    for GetAddressUtxosStreamSvc<T> {
                         type Response = super::GetAddressUtxosReply;
                         type ResponseStream = T::GetAddressUtxosStreamStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetAddressUtxosArg>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_address_utxos_stream(&inner, request)
+                                <T as CompactTxStreamer>::get_address_utxos_stream(
+                                        &inner,
+                                        request,
+                                    )
                                     .await
                             };
                             Box::pin(fut)
@@ -1929,13 +2240,21 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLightdInfo" => {
                     #[allow(non_camel_case_types)]
                     struct GetLightdInfoSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::Empty> for GetLightdInfoSvc<T> {
+                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::Empty>
+                    for GetLightdInfoSvc<T> {
                         type Response = super::LightdInfo;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(&mut self, request: tonic::Request<super::Empty>) -> Self::Future {
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::Empty>,
+                        ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CompactTxStreamer>::get_lightd_info(&inner, request).await
+                                <T as CompactTxStreamer>::get_lightd_info(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1965,9 +2284,14 @@ pub mod compact_tx_streamer_server {
                 "/cash.z.wallet.sdk.rpc.CompactTxStreamer/Ping" => {
                     #[allow(non_camel_case_types)]
                     struct PingSvc<T: CompactTxStreamer>(pub Arc<T>);
-                    impl<T: CompactTxStreamer> tonic::server::UnaryService<super::Duration> for PingSvc<T> {
+                    impl<
+                        T: CompactTxStreamer,
+                    > tonic::server::UnaryService<super::Duration> for PingSvc<T> {
                         type Response = super::PingResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::Duration>,
@@ -2001,19 +2325,23 @@ pub mod compact_tx_streamer_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }

--- a/zaino-state/src/chain_index.rs
+++ b/zaino-state/src/chain_index.rs
@@ -17,7 +17,7 @@ use crate::chain_index::types::db::metadata::MempoolInfo;
 use crate::chain_index::types::{BestChainLocation, NonBestChainLocation};
 use crate::error::{ChainIndexError, ChainIndexErrorKind, FinalisedStateError};
 use crate::status::Status;
-use crate::{AtomicStatus, CompactBlockStream, StatusType, SyncError};
+use crate::{AtomicStatus, CompactBlockStream, NodeConnectionError, StatusType, SyncError};
 use crate::{IndexedBlock, TransactionHash};
 use std::collections::HashSet;
 use std::{sync::Arc, time::Duration};
@@ -534,6 +534,8 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
         let nfs = self.non_finalized_state.clone();
         let fs = self.finalized_db.clone();
         let status = self.status.clone();
+        let source = self.non_finalized_state.source.clone();
+
         tokio::task::spawn(async move {
             let result: Result<(), SyncError> = async {
                 loop {
@@ -542,44 +544,38 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                     }
 
                     status.store(StatusType::Syncing);
+
+                    // Sync fs to chain tip - 100.
+                    let chain_height = source
+                        .clone()
+                        .get_best_block_height()
+                        .await
+                        .map_err(|error| {
+                            SyncError::ValidatorConnectionError(
+                                NodeConnectionError::UnrecoverableError(Box::new(error)),
+                            )
+                        })?
+                        .ok_or_else(|| {
+                            SyncError::ValidatorConnectionError(
+                                NodeConnectionError::UnrecoverableError(Box::new(
+                                    std::io::Error::other("node returned no best block height"),
+                                )),
+                            )
+                        })?;
+                    let finalised_height = crate::Height(chain_height.0.saturating_sub(100));
+
+                    // TODO / FIX: Improve error handling here, fix and rebuild db on error.
+                    fs.sync_to_height(finalised_height, &source)
+                        .await
+                        .map_err(|error| {
+                            SyncError::ValidatorConnectionError(
+                                NodeConnectionError::UnrecoverableError(Box::new(error)),
+                            )
+                        })?;
+
                     // Sync nfs to chain tip, trimming blocks to finalized tip.
                     nfs.sync(fs.clone()).await?;
 
-                    // Sync fs to chain tip - 100.
-                    {
-                        let snapshot = nfs.get_snapshot();
-                        while snapshot.best_tip.height.0
-                            > (fs
-                                .to_reader()
-                                .db_height()
-                                .await
-                                .map_err(|_e| SyncError::CannotReadFinalizedState)?
-                                .unwrap_or(types::Height(0))
-                                .0
-                                + 100)
-                        {
-                            let next_finalized_height = fs
-                                .to_reader()
-                                .db_height()
-                                .await
-                                .map_err(|_e| SyncError::CannotReadFinalizedState)?
-                                .map(|height| height + 1)
-                                .unwrap_or(types::Height(0));
-                            let next_finalized_block = snapshot
-                                .blocks
-                                .get(
-                                    snapshot
-                                        .heights_to_hashes
-                                        .get(&(next_finalized_height))
-                                        .ok_or(SyncError::CompetingSyncProcess)?,
-                                )
-                                .ok_or(SyncError::CompetingSyncProcess)?;
-                            // TODO: Handle write errors better (fix db and continue)
-                            fs.write_block(next_finalized_block.clone())
-                                .await
-                                .map_err(|_e| SyncError::CompetingSyncProcess)?;
-                        }
-                    }
                     status.store(StatusType::Ready);
                     // TODO: configure sleep duration?
                     tokio::time::sleep(Duration::from_millis(500)).await

--- a/zaino-state/src/chain_index/finalised_state.rs
+++ b/zaino-state/src/chain_index/finalised_state.rs
@@ -494,7 +494,7 @@ impl ZainoDB {
     pub(crate) async fn sync_to_height<T>(
         &self,
         height: Height,
-        source: T,
+        source: &T,
     ) -> Result<(), FinalisedStateError>
     where
         T: BlockchainSource,
@@ -502,6 +502,14 @@ impl ZainoDB {
         let network = self.cfg.network;
         let db_height_opt = self.db_height().await?;
         let mut db_height = db_height_opt.unwrap_or(GENESIS_HEIGHT);
+
+        let zebra_network = network.to_zebra_network();
+        let sapling_activation_height = zebra_chain::parameters::NetworkUpgrade::Sapling
+            .activation_height(&zebra_network)
+            .expect("Sapling activation height must be set");
+        let nu5_activation_height = zebra_chain::parameters::NetworkUpgrade::Nu5
+            .activation_height(&zebra_network)
+            .expect("NU5 activation height must be set");
 
         let mut parent_chainwork = if db_height_opt.is_none() {
             ChainWork::from_u256(0.into())
@@ -542,26 +550,33 @@ impl ZainoDB {
 
             let block_hash = BlockHash::from(block.hash().0);
 
-            let (sapling_root, sapling_size, orchard_root, orchard_size) =
-                match source.get_commitment_tree_roots(block_hash).await? {
-                    (Some((sapling_root, sapling_size)), Some((orchard_root, orchard_size))) => {
-                        (sapling_root, sapling_size, orchard_root, orchard_size)
-                    }
-                    (None, _) => {
-                        return Err(FinalisedStateError::BlockchainSourceError(
-                            BlockchainSourceError::Unrecoverable(format!(
-                                "missing Sapling commitment tree root for block {block_hash}"
-                            )),
-                        ));
-                    }
-                    (_, None) => {
-                        return Err(FinalisedStateError::BlockchainSourceError(
-                            BlockchainSourceError::Unrecoverable(format!(
-                                "missing Orchard commitment tree root for block {block_hash}"
-                            )),
-                        ));
-                    }
-                };
+            // Fetch sapling / orchard commitment tree data if above relevant network upgrade.
+            let (sapling_opt, orchard_opt) = source.get_commitment_tree_roots(block_hash).await?;
+            let is_sapling_active = height_int >= sapling_activation_height.0;
+            let is_orchard_active = height_int >= nu5_activation_height.0;
+            let (sapling_root, sapling_size) = if is_sapling_active {
+                sapling_opt.ok_or_else(|| {
+                    FinalisedStateError::BlockchainSourceError(
+                        BlockchainSourceError::Unrecoverable(format!(
+                            "missing Sapling commitment tree root for block {block_hash}"
+                        )),
+                    )
+                })?
+            } else {
+                (zebra_chain::sapling::tree::Root::default(), 0)
+            };
+
+            let (orchard_root, orchard_size) = if is_orchard_active {
+                orchard_opt.ok_or_else(|| {
+                    FinalisedStateError::BlockchainSourceError(
+                        BlockchainSourceError::Unrecoverable(format!(
+                            "missing Orchard commitment tree root for block {block_hash}"
+                        )),
+                    )
+                })?
+            } else {
+                (zebra_chain::orchard::tree::Root::default(), 0)
+            };
 
             let metadata = BlockMetadata::new(
                 sapling_root,

--- a/zaino-state/src/chain_index/finalised_state.rs
+++ b/zaino-state/src/chain_index/finalised_state.rs
@@ -192,8 +192,17 @@ use crate::{
     BlockHash, BlockMetadata, BlockWithMetadata, ChainWork, Height, IndexedBlock, StatusType,
 };
 
-use std::{sync::Arc, time::Duration};
-use tokio::time::{interval, MissedTickBehavior};
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+use tokio::{
+    sync::watch,
+    time::{interval, MissedTickBehavior},
+};
 
 use super::source::BlockchainSource;
 
@@ -530,81 +539,129 @@ impl ZainoDB {
             }
         };
 
-        for height_int in (db_height.0)..=height.0 {
-            let block = match source
-                .get_block(zebra_state::HashOrHeight::Height(
-                    zebra_chain::block::Height(height_int),
-                ))
-                .await?
-            {
-                Some(block) => block,
-                None => {
-                    return Err(FinalisedStateError::BlockchainSourceError(
-                        BlockchainSourceError::Unrecoverable(format!(
-                            "error fetching block at height {} from validator",
-                            height.0
-                        )),
-                    ));
+        // Track last time we emitted an info log so we only print every 10s.
+        let current_height = Arc::new(AtomicU64::new(db_height.0 as u64));
+        let target_height = height.0 as u64;
+
+        // Shutdown signal for the reporter task.
+        let (shutdown_tx, shutdown_rx) = watch::channel(());
+        // Spawn reporter task that logs every 10 seconds, even while write_block() is running.
+        let reporter_current = Arc::clone(&current_height);
+        let reporter_network = network;
+        let mut reporter_shutdown = shutdown_rx.clone();
+        let reporter_handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(10));
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        let cur = reporter_current.load(Ordering::Relaxed);
+                        tracing::info!(
+                            "sync_to_height: syncing height {current} / {target} on network = {:?}",
+                            reporter_network,
+                            current = cur,
+                            target = target_height
+                        );
+                    }
+                    // stop when we receive a shutdown signal
+                    _ = reporter_shutdown.changed() => {
+                        break;
+                    }
                 }
-            };
+            }
+        });
 
-            let block_hash = BlockHash::from(block.hash().0);
+        // Run the main sync logic inside an inner async block so we always get
+        // a chance to shutdown the reporter task regardless of how this block exits.
+        let result: Result<(), FinalisedStateError> = (async {
+            for height_int in (db_height.0)..=height.0 {
+                // Update the shared progress value as soon as we start processing this height.
+                current_height.store(height_int as u64, Ordering::Relaxed);
 
-            // Fetch sapling / orchard commitment tree data if above relevant network upgrade.
-            let (sapling_opt, orchard_opt) = source.get_commitment_tree_roots(block_hash).await?;
-            let is_sapling_active = height_int >= sapling_activation_height.0;
-            let is_orchard_active = height_int >= nu5_activation_height.0;
-            let (sapling_root, sapling_size) = if is_sapling_active {
-                sapling_opt.ok_or_else(|| {
-                    FinalisedStateError::BlockchainSourceError(
-                        BlockchainSourceError::Unrecoverable(format!(
-                            "missing Sapling commitment tree root for block {block_hash}"
-                        )),
-                    )
-                })?
-            } else {
-                (zebra_chain::sapling::tree::Root::default(), 0)
-            };
+                let block = match source
+                    .get_block(zebra_state::HashOrHeight::Height(
+                        zebra_chain::block::Height(height_int),
+                    ))
+                    .await?
+                {
+                    Some(block) => block,
+                    None => {
+                        return Err(FinalisedStateError::BlockchainSourceError(
+                            BlockchainSourceError::Unrecoverable(format!(
+                                "error fetching block at height {} from validator",
+                                height.0
+                            )),
+                        ));
+                    }
+                };
 
-            let (orchard_root, orchard_size) = if is_orchard_active {
-                orchard_opt.ok_or_else(|| {
-                    FinalisedStateError::BlockchainSourceError(
-                        BlockchainSourceError::Unrecoverable(format!(
-                            "missing Orchard commitment tree root for block {block_hash}"
-                        )),
-                    )
-                })?
-            } else {
-                (zebra_chain::orchard::tree::Root::default(), 0)
-            };
+                let block_hash = BlockHash::from(block.hash().0);
 
-            let metadata = BlockMetadata::new(
-                sapling_root,
-                sapling_size as u32,
-                orchard_root,
-                orchard_size as u32,
-                parent_chainwork,
-                network.to_zebra_network(),
-            );
+                // Fetch sapling / orchard commitment tree data if above relevant network upgrade.
+                let (sapling_opt, orchard_opt) =
+                    source.get_commitment_tree_roots(block_hash).await?;
+                let is_sapling_active = height_int >= sapling_activation_height.0;
+                let is_orchard_active = height_int >= nu5_activation_height.0;
+                let (sapling_root, sapling_size) = if is_sapling_active {
+                    sapling_opt.ok_or_else(|| {
+                        FinalisedStateError::BlockchainSourceError(
+                            BlockchainSourceError::Unrecoverable(format!(
+                                "missing Sapling commitment tree root for block {block_hash}"
+                            )),
+                        )
+                    })?
+                } else {
+                    (zebra_chain::sapling::tree::Root::default(), 0)
+                };
 
-            let block_with_metadata = BlockWithMetadata::new(block.as_ref(), metadata);
-            let chain_block = match IndexedBlock::try_from(block_with_metadata) {
-                Ok(block) => block,
-                Err(_) => {
-                    return Err(FinalisedStateError::BlockchainSourceError(
-                        BlockchainSourceError::Unrecoverable(format!(
-                            "error building block data at height {}",
-                            height.0
-                        )),
-                    ));
-                }
-            };
-            parent_chainwork = *chain_block.index().chainwork();
+                let (orchard_root, orchard_size) = if is_orchard_active {
+                    orchard_opt.ok_or_else(|| {
+                        FinalisedStateError::BlockchainSourceError(
+                            BlockchainSourceError::Unrecoverable(format!(
+                                "missing Orchard commitment tree root for block {block_hash}"
+                            )),
+                        )
+                    })?
+                } else {
+                    (zebra_chain::orchard::tree::Root::default(), 0)
+                };
 
-            self.write_block(chain_block).await?;
-        }
+                let metadata = BlockMetadata::new(
+                    sapling_root,
+                    sapling_size as u32,
+                    orchard_root,
+                    orchard_size as u32,
+                    parent_chainwork,
+                    network.to_zebra_network(),
+                );
 
-        Ok(())
+                let block_with_metadata = BlockWithMetadata::new(block.as_ref(), metadata);
+                let chain_block = match IndexedBlock::try_from(block_with_metadata) {
+                    Ok(block) => block,
+                    Err(_) => {
+                        return Err(FinalisedStateError::BlockchainSourceError(
+                            BlockchainSourceError::Unrecoverable(format!(
+                                "error building block data at height {}",
+                                height.0
+                            )),
+                        ));
+                    }
+                };
+                parent_chainwork = *chain_block.index().chainwork();
+
+                self.write_block(chain_block).await?;
+            }
+
+            Ok(())
+        })
+        .await;
+
+        // Signal the reporter to shut down and wait for it to finish.
+        // Ignore send error if receiver already dropped.
+        let _ = shutdown_tx.send(());
+        // Await the reporter to ensure clean shutdown; ignore errors if it panicked/was aborted.
+        let _ = reporter_handle.await;
+
+        result
     }
 
     /// Appends a single fully constructed [`IndexedBlock`] to the database.

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -1192,7 +1192,6 @@ impl DbV1 {
             config: self.config.clone(),
         };
         let join_handle = tokio::task::spawn_blocking(move || {
-            // let post_result = tokio::task::spawn_blocking(move || {
             // Write block to ZainoDB
             let mut txn = zaino_db.env.begin_rw_txn()?;
 
@@ -1245,11 +1244,7 @@ impl DbV1 {
                 WriteFlags::NO_OVERWRITE,
             )?;
 
-            txn.commit()?;
-
             // Write spent to ZainoDB
-            let mut txn = zaino_db.env.begin_rw_txn()?;
-
             for (outpoint, tx_location) in spent_map {
                 let outpoint_bytes = &outpoint.to_bytes()?;
                 let tx_location_entry_bytes =
@@ -1262,11 +1257,7 @@ impl DbV1 {
                 )?;
             }
 
-            txn.commit()?;
-
             // Write outputs to ZainoDB addrhist
-            let mut txn = zaino_db.env.begin_rw_txn()?;
-
             for (addr_script, records) in addrhist_outputs_map {
                 let addr_bytes = addr_script.to_bytes()?;
 
@@ -1294,8 +1285,6 @@ impl DbV1 {
                 }
             }
 
-            txn.commit()?;
-
             // Write inputs to ZainoDB addrhist
             for (addr_script, records) in addrhist_inputs_map {
                 let addr_bytes = addr_script.to_bytes()?;
@@ -1317,14 +1306,12 @@ impl DbV1 {
                 for (_record, record_entry_bytes, (prev_output_script, prev_output_record)) in
                     stored_entries
                 {
-                    let mut txn = zaino_db.env.begin_rw_txn()?;
                     txn.put(
                         zaino_db.address_history,
                         &addr_bytes,
                         &record_entry_bytes,
                         WriteFlags::empty(),
                     )?;
-                    txn.commit()?;
 
                     // mark corresponding output as spent
                     let prev_addr_bytes = prev_output_script.to_bytes()?;
@@ -1334,7 +1321,8 @@ impl DbV1 {
                         })?;
                     let prev_entry_bytes =
                         StoredEntryFixed::new(&prev_addr_bytes, packed_prev).to_bytes()?;
-                    let updated = zaino_db.mark_addr_hist_record_spent_blocking(
+                    let updated = zaino_db.mark_addr_hist_record_spent_in_txn(
+                        &mut txn,
                         &prev_output_script,
                         &prev_entry_bytes,
                     )?;
@@ -1353,6 +1341,8 @@ impl DbV1 {
                     }
                 }
             }
+
+            txn.commit()?;
 
             zaino_db.env.sync(true).map_err(|e| {
                 FinalisedStateError::Custom(format!("LMDB sync failed before validation: {e}"))
@@ -1385,7 +1375,7 @@ impl DbV1 {
                 tokio::task::block_in_place(|| self.env.sync(true))
                     .map_err(|e| FinalisedStateError::Custom(format!("LMDB sync failed: {e}")))?;
                 self.status.store(StatusType::Ready);
-                if block.index().height().0 % 100 == 0 {
+                if block.index().height().0.is_multiple_of(100) {
                     info!(
                         "Successfully committed block {} at height {} to ZainoDB.",
                         &block.index().hash(),
@@ -1753,7 +1743,6 @@ impl DbV1 {
                     Err(e) => return Err(FinalisedStateError::LmdbError(e)),
                 }
             }
-            let _ = txn.commit();
 
             // Delete addrhist input data and mark old outputs spent in this block as unspent
             for (addr_script, records) in &addrhist_inputs_map {
@@ -1787,7 +1776,8 @@ impl DbV1 {
                         );
                         spent_prev_entry[19..51].copy_from_slice(&checksum);
 
-                        let updated = zaino_db.mark_addr_hist_record_unspent_blocking(
+                        let updated = zaino_db.mark_addr_hist_record_unspent_in_txn(
+                            &mut txn,
                             prev_output_script,
                             &spent_prev_entry,
                         )?;
@@ -1810,7 +1800,8 @@ impl DbV1 {
 
                 // Delete all input records created in this block.
                 zaino_db
-                    .delete_addrhist_dups_blocking(
+                    .delete_addrhist_dups_in_txn(
+                        &mut txn,
                         &addr_script
                             .to_bytes()
                             .map_err(|_| FinalisedStateError::InvalidBlock {
@@ -1834,7 +1825,8 @@ impl DbV1 {
 
             // Delete addrhist output data
             for (addr_script, records) in &addrhist_outputs_map {
-                zaino_db.delete_addrhist_dups_blocking(
+                zaino_db.delete_addrhist_dups_in_txn(
+                    &mut txn,
                     &addr_script
                         .to_bytes()
                         .map_err(|_| FinalisedStateError::InvalidBlock {
@@ -1851,8 +1843,6 @@ impl DbV1 {
             }
 
             // Delete block data
-            let mut txn = zaino_db.env.begin_rw_txn()?;
-
             for &db in &[
                 zaino_db.headers,
                 zaino_db.txids,
@@ -4933,7 +4923,7 @@ impl DbV1 {
                     let stored_vout = u16::from_be_bytes([val[8], val[9]]);
 
                     (flags & AddrEventBytes::FLAG_IS_INPUT) != 0
-                        && stored_vout == input_index as u16
+                        && stored_vout as usize == input_index
                 });
 
                 if !matched {
@@ -5540,9 +5530,10 @@ impl DbV1 {
     ///
     /// `expected` is the number of records to delete;
     ///
-    /// WARNING: This is a blocking function and **MUST** be called within a blocking thread / task.
-    fn delete_addrhist_dups_blocking(
+    /// WARNING: This operates *inside* an existing RW txn and must **not** commit it.
+    fn delete_addrhist_dups_in_txn(
         &self,
+        txn: &mut lmdb::RwTransaction<'_>,
         addr_bytes: &[u8],
         block_height: Height,
         delete_inputs: bool,
@@ -5563,7 +5554,6 @@ impl DbV1 {
         let mut remaining = expected;
         let height_be = block_height.0.to_be_bytes();
 
-        let mut txn = self.env.begin_rw_txn()?;
         let mut cur = txn.open_rw_cursor(self.address_history)?;
 
         match cur
@@ -5622,7 +5612,6 @@ impl DbV1 {
         }
 
         drop(cur);
-        txn.commit()?;
         Ok(())
     }
 
@@ -5631,83 +5620,65 @@ impl DbV1 {
     ///
     /// Returns Ok(true) if a record was updated, Ok(false) if not found, or Err on DB error.
     ///
-    /// WARNING: This is a blocking function and **MUST** be called within a blocking thread / task.
-    fn mark_addr_hist_record_spent_blocking(
+    /// WARNING: This operates *inside* an existing RW txn and must **not** commit it.
+    fn mark_addr_hist_record_spent_in_txn(
         &self,
+        txn: &mut lmdb::RwTransaction<'_>,
         addr_script: &AddrScript,
+
         expected_prev_entry_bytes: &[u8],
     ) -> Result<bool, FinalisedStateError> {
         let addr_bytes = addr_script.to_bytes()?;
-        let mut txn = self.env.begin_rw_txn()?;
-        {
-            let mut cur = txn.open_rw_cursor(self.address_history)?;
 
-            // iterate duplicates for the address, but do an exact-value comparison
-            // to find *the* duplicate we intend to flip.
-            for (key, val) in cur.iter_dup_of(&addr_bytes)? {
-                if key.len() != AddrScript::VERSIONED_LEN {
-                    return Err(FinalisedStateError::Custom(
-                        "address history key length mismatch".into(),
-                    ));
-                }
-                if val.len() != StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN {
-                    return Err(FinalisedStateError::Custom(
-                        "address history value length mismatch".into(),
-                    ));
-                }
+        let mut cur = txn.open_rw_cursor(self.address_history)?;
 
-                // exact byte-match: val is &[u8], expected_prev_entry_bytes is &[u8]
-                if val != expected_prev_entry_bytes {
-                    continue;
-                }
+        for (key, val) in cur.iter_dup_of(&addr_bytes)? {
+            if key.len() != AddrScript::VERSIONED_LEN {
+                return Err(FinalisedStateError::Custom(
+                    "address history key length mismatch".into(),
+                ));
+            }
+            if val.len() != StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN {
+                return Err(FinalisedStateError::Custom(
+                    "address history value length mismatch".into(),
+                ));
+            }
 
-                // we've located the exact duplicate bytes we built earlier.
-                let mut hist_record = [0u8; StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN];
-                hist_record.copy_from_slice(val);
+            if val != expected_prev_entry_bytes {
+                continue;
+            }
 
-                // Sanity: the record we intend to mark should be a mined output (not an input).
-                let flags = hist_record[10];
-                if (flags & AddrHistRecord::FLAG_IS_INPUT) != 0 {
-                    return Err(FinalisedStateError::Custom(
-                        "attempt to mark an input-row as spent".into(),
-                    ));
-                }
+            let mut hist_record = [0u8; StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN];
+            hist_record.copy_from_slice(val);
 
-                // If it's already spent, treat as successful (idempotent).
-                if (flags & AddrHistRecord::FLAG_SPENT) != 0 {
-                    drop(cur);
-                    txn.commit()?;
-                    return Ok(true);
-                }
-
-                // If the record is not marked MINED, that's an invariant failure.
-                // We surface it rather than silently overwriting/creating a spent-only record.
-                if (flags & AddrHistRecord::FLAG_MINED) == 0 {
-                    return Err(FinalisedStateError::Custom(
-                        "attempt to mark non-mined addrhist record as spent".into(),
-                    ));
-                }
-
-                // Preserve all existing flags (including MINED), and add SPENT.
-                hist_record[10] |= AddrHistRecord::FLAG_SPENT;
-
-                // Recompute checksum over entry header + payload (bytes 1..19).
-                let checksum = StoredEntryFixed::<AddrEventBytes>::blake2b256(
-                    &[&addr_bytes, &hist_record[1..19]].concat(),
-                );
-                hist_record[19..51].copy_from_slice(&checksum);
-
-                // Write back in place for the exact duplicate we matched.
-                cur.put(&addr_bytes, &hist_record, WriteFlags::CURRENT)?;
-                drop(cur);
-                txn.commit()?;
-
+            let flags = hist_record[10];
+            if (flags & AddrHistRecord::FLAG_IS_INPUT) != 0 {
+                return Err(FinalisedStateError::Custom(
+                    "attempt to mark an input-row as spent".into(),
+                ));
+            }
+            // idempotent
+            if (flags & AddrHistRecord::FLAG_SPENT) != 0 {
                 return Ok(true);
             }
+
+            if (flags & AddrHistRecord::FLAG_MINED) == 0 {
+                return Err(FinalisedStateError::Custom(
+                    "attempt to mark non-mined addrhist record as spent".into(),
+                ));
+            }
+
+            hist_record[10] |= AddrHistRecord::FLAG_SPENT;
+
+            let checksum = StoredEntryFixed::<AddrEventBytes>::blake2b256(
+                &[&addr_bytes, &hist_record[1..19]].concat(),
+            );
+            hist_record[19..51].copy_from_slice(&checksum);
+
+            cur.put(&addr_bytes, &hist_record, WriteFlags::CURRENT)?;
+            return Ok(true);
         }
 
-        // not found
-        txn.commit()?;
         Ok(false)
     }
 
@@ -5716,85 +5687,78 @@ impl DbV1 {
     ///
     /// Returns Ok(true) if a record was updated, Ok(false) if not found, or Err on DB error.
     ///
-    /// WARNING: This is a blocking function and **MUST** be called within a blocking thread / task.
-    fn mark_addr_hist_record_unspent_blocking(
+    /// WARNING: This operates *inside* an existing RW txn and must **not** commit it.
+    fn mark_addr_hist_record_unspent_in_txn(
         &self,
+        txn: &mut lmdb::RwTransaction<'_>,
         addr_script: &AddrScript,
+
         expected_prev_entry_bytes: &[u8],
     ) -> Result<bool, FinalisedStateError> {
         let addr_bytes = addr_script.to_bytes()?;
-        let mut txn = self.env.begin_rw_txn()?;
-        {
-            let mut cur = txn.open_rw_cursor(self.address_history)?;
 
-            // iterate duplicates for the address, but do an exact-value comparison
-            // to find *the* duplicate we intend to flip.
-            for (key, val) in cur.iter_dup_of(&addr_bytes)? {
-                if key.len() != AddrScript::VERSIONED_LEN {
-                    return Err(FinalisedStateError::Custom(
-                        "address history key length mismatch".into(),
-                    ));
-                }
-                if val.len() != StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN {
-                    return Err(FinalisedStateError::Custom(
-                        "address history value length mismatch".into(),
-                    ));
-                }
+        let mut cur = txn.open_rw_cursor(self.address_history)?;
 
-                // exact byte-match: val is &[u8], expected_prev_entry_bytes is &[u8]
-                if val != expected_prev_entry_bytes {
-                    continue;
-                }
+        for (key, val) in cur.iter_dup_of(&addr_bytes)? {
+            if key.len() != AddrScript::VERSIONED_LEN {
+                return Err(FinalisedStateError::Custom(
+                    "address history key length mismatch".into(),
+                ));
+            }
+            if val.len() != StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN {
+                return Err(FinalisedStateError::Custom(
+                    "address history value length mismatch".into(),
+                ));
+            }
 
-                // we've located the exact duplicate bytes we built earlier.
-                let mut hist_record = [0u8; StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN];
-                hist_record.copy_from_slice(val);
+            if val != expected_prev_entry_bytes {
+                continue;
+            }
 
-                // parse flags (located at byte index 10 in the StoredEntry layout)
-                let flags = hist_record[10];
+            // we've located the exact duplicate bytes we built earlier.
+            let mut hist_record = [0u8; StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN];
+            hist_record.copy_from_slice(val);
 
-                // Sanity: the record we intend to mark should be a mined output (not an input).
-                if (flags & AddrHistRecord::FLAG_IS_INPUT) != 0 {
-                    return Err(FinalisedStateError::Custom(
-                        "attempt to mark an input-row as unspent".into(),
-                    ));
-                }
+            // parse flags (located at byte index 10 in the StoredEntry layout)
+            let flags = hist_record[10];
 
-                // If it's already unspent, treat as successful (idempotent).
-                if (flags & AddrHistRecord::FLAG_SPENT) == 0 {
-                    drop(cur);
-                    txn.commit()?;
-                    return Ok(true);
-                }
+            // Sanity: the record we intend to mark should be a mined output (not an input).
+            if (flags & AddrHistRecord::FLAG_IS_INPUT) != 0 {
+                return Err(FinalisedStateError::Custom(
+                    "attempt to mark an input-row as unspent".into(),
+                ));
+            }
 
-                // If the record is not marked MINED, that's an invariant failure.
-                // We surface it rather than producing a non-mined record.
-                if (flags & AddrHistRecord::FLAG_MINED) == 0 {
-                    return Err(FinalisedStateError::Custom(
-                        "attempt to mark non-mined addrhist record as unspent".into(),
-                    ));
-                }
-
-                // Preserve all existing flags (including MINED), and remove SPENT.
-                hist_record[10] &= !AddrHistRecord::FLAG_SPENT;
-
-                // Recompute checksum over entry header + payload (bytes 1..19).
-                let checksum = StoredEntryFixed::<AddrEventBytes>::blake2b256(
-                    &[&addr_bytes, &hist_record[1..19]].concat(),
-                );
-                hist_record[19..51].copy_from_slice(&checksum);
-
-                // Write back in place for the exact duplicate we matched.
-                cur.put(&addr_bytes, &hist_record, WriteFlags::CURRENT)?;
+            // If it's already unspent, treat as successful (idempotent).
+            if (flags & AddrHistRecord::FLAG_SPENT) == 0 {
                 drop(cur);
-                txn.commit()?;
-
                 return Ok(true);
             }
+
+            // If the record is not marked MINED, that's an invariant failure.
+            // We surface it rather than producing a non-mined record.
+            if (flags & AddrHistRecord::FLAG_MINED) == 0 {
+                return Err(FinalisedStateError::Custom(
+                    "attempt to mark non-mined addrhist record as unspent".into(),
+                ));
+            }
+
+            // Preserve all existing flags (including MINED), and remove SPENT.
+            hist_record[10] &= !AddrHistRecord::FLAG_SPENT;
+
+            // Recompute checksum over entry header + payload (bytes 1..19).
+            let checksum = StoredEntryFixed::<AddrEventBytes>::blake2b256(
+                &[&addr_bytes, &hist_record[1..19]].concat(),
+            );
+            hist_record[19..51].copy_from_slice(&checksum);
+
+            // Write back in place for the exact duplicate we matched.
+            cur.put(&addr_bytes, &hist_record, WriteFlags::CURRENT)?;
+            drop(cur);
+
+            return Ok(true);
         }
 
-        // not found
-        txn.commit()?;
         Ok(false)
     }
 

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -1762,7 +1762,6 @@ impl DbV1 {
                 // Mark outputs spent in this block as unspent
                 for (_record, (prev_output_script, prev_output_record)) in records {
                     {
-                        // mark corresponding output as unspent
                         let prev_addr_bytes = prev_output_script.to_bytes()?;
                         let packed_prev =
                             AddrEventBytes::from_record(prev_output_record).map_err(|e| {
@@ -1770,12 +1769,27 @@ impl DbV1 {
                                     "AddrEventBytes pack error: {e:?}"
                                 ))
                             })?;
+
+                        // Build the *spent* form of the stored entry so it matches the DB
+                        // (mark_addr_hist_record_spent_blocking sets FLAG_SPENT and
+                        // recomputes the checksum).  We must pass the spent bytes here
+                        // because the DB currently contains the spent version.
                         let prev_entry_bytes =
                             StoredEntryFixed::new(&prev_addr_bytes, packed_prev).to_bytes()?;
 
+                        // Turn the mined-entry into the spent-entry (mutate flags + checksum)
+                        let mut spent_prev_entry = prev_entry_bytes.clone();
+                        // Set SPENT flag (flags byte is at index 10 in StoredEntry layout)
+                        spent_prev_entry[10] |= AddrHistRecord::FLAG_SPENT;
+                        // Recompute checksum over bytes 1..19 as StoredEntryFixed expects.
+                        let checksum = StoredEntryFixed::<AddrEventBytes>::blake2b256(
+                            &[&prev_addr_bytes, &spent_prev_entry[1..19]].concat(),
+                        );
+                        spent_prev_entry[19..51].copy_from_slice(&checksum);
+
                         let updated = zaino_db.mark_addr_hist_record_unspent_blocking(
                             prev_output_script,
-                            &prev_entry_bytes,
+                            &spent_prev_entry,
                         )?;
 
                         if !updated {

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -1441,6 +1441,10 @@ impl DbV1 {
                     }
                     Err(e) => {
                         warn!("Error writing block to DB: {e}");
+                        warn!(
+                            "Deleting corrupt block from DB at height: {} with hash: {}",
+                            block_height.0, block_hash.0
+                        );
 
                         let _ = self.delete_block(&block).await;
                         tokio::task::block_in_place(|| self.env.sync(true)).map_err(|e| {
@@ -1458,6 +1462,10 @@ impl DbV1 {
             }
             Err(e) => {
                 warn!("Error writing block to DB: {e}");
+                warn!(
+                    "Deleting corrupt block from DB at height: {} with hash: {}",
+                    block_height.0, block_hash.0
+                );
 
                 let _ = self.delete_block(&block).await;
                 tokio::task::block_in_place(|| self.env.sync(true))

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -1325,12 +1325,32 @@ impl DbV1 {
                         WriteFlags::empty(),
                     )?;
                     txn.commit()?;
+
                     // mark corresponding output as spent
-                    let _updated = zaino_db.mark_addr_hist_record_spent_blocking(
+                    let prev_addr_bytes = prev_output_script.to_bytes()?;
+                    let packed_prev =
+                        AddrEventBytes::from_record(&prev_output_record).map_err(|e| {
+                            FinalisedStateError::Custom(format!("AddrEventBytes pack error: {e:?}"))
+                        })?;
+                    let prev_entry_bytes =
+                        StoredEntryFixed::new(&prev_addr_bytes, packed_prev).to_bytes()?;
+                    let updated = zaino_db.mark_addr_hist_record_spent_blocking(
                         &prev_output_script,
-                        prev_output_record.tx_location(),
-                        prev_output_record.out_index(),
+                        &prev_entry_bytes,
                     )?;
+                    if !updated {
+                        // Log and treat as invalid block — marking the prev-output must succeed.
+                        return Err(FinalisedStateError::InvalidBlock {
+                            height: block_height.0,
+                            hash: block_hash,
+                            reason: format!(
+                                "failed to mark prev-output spent: addr={} tloc={:?} vout={}",
+                                hex::encode(addr_bytes),
+                                prev_output_record.tx_location(),
+                                prev_output_record.out_index()
+                            ),
+                        });
+                    }
                 }
             }
 
@@ -1703,22 +1723,40 @@ impl DbV1 {
 
             // Delete addrhist input data and mark old outputs spent in this block as unspent
             for (addr_script, records) in &addrhist_inputs_map {
+                let addr_bytes = addr_script.to_bytes()?;
+
                 // Mark outputs spent in this block as unspent
                 for (_record, (prev_output_script, prev_output_record)) in records {
                     {
-                        let _updated = zaino_db
-                            .mark_addr_hist_record_unspent_blocking(
-                                prev_output_script,
-                                prev_output_record.tx_location(),
-                                prev_output_record.out_index(),
-                            )
-                            // TODO: check internals to propagate important errors.
-                            .map_err(|_| FinalisedStateError::InvalidBlock {
+                        // mark corresponding output as unspent
+                        let prev_addr_bytes = prev_output_script.to_bytes()?;
+                        let packed_prev =
+                            AddrEventBytes::from_record(prev_output_record).map_err(|e| {
+                                FinalisedStateError::Custom(format!(
+                                    "AddrEventBytes pack error: {e:?}"
+                                ))
+                            })?;
+                        let prev_entry_bytes =
+                            StoredEntryFixed::new(&prev_addr_bytes, packed_prev).to_bytes()?;
+
+                        let updated = zaino_db.mark_addr_hist_record_unspent_blocking(
+                            prev_output_script,
+                            &prev_entry_bytes,
+                        )?;
+
+                        if !updated {
+                            // Log and treat as invalid block — marking the prev-output must succeed.
+                            return Err(FinalisedStateError::InvalidBlock {
                                 height: block_height.0,
                                 hash: block_hash,
-                                reason: "Corrupt block data: failed to mark output unspent"
-                                    .to_string(),
-                            })?;
+                                reason: format!(
+                                    "failed to mark prev-output spent: addr={} tloc={:?} vout={}",
+                                    hex::encode(addr_bytes),
+                                    prev_output_record.tx_location(),
+                                    prev_output_record.out_index()
+                                ),
+                            });
+                        }
                     }
                 }
 
@@ -4802,7 +4840,7 @@ impl DbV1 {
             }
 
             // Inputs: check spent + addrhist input record
-            for input in tx.inputs() {
+            for (input_index, input) in tx.inputs().iter().enumerate() {
                 // Continue if coinbase.
                 if input.is_null_prevout() {
                     continue;
@@ -4843,9 +4881,10 @@ impl DbV1 {
                     // - [19..=50] checksum
 
                     let flags = val[10];
-                    let vout = u16::from_be_bytes([val[8], val[9]]);
+                    let stored_vout = u16::from_be_bytes([val[8], val[9]]);
+
                     (flags & AddrEventBytes::FLAG_IS_INPUT) != 0
-                        && vout == input.prevout_index() as u16
+                        && stored_vout == input_index as u16
                 });
 
                 if !matched {
@@ -5358,12 +5397,14 @@ impl DbV1 {
 
         for (key, val) in cursor.iter_dup_of(&addr_script_bytes)? {
             if key.len() != AddrScript::VERSIONED_LEN {
-                // TODO: Return error?
-                break;
+                return Err(FinalisedStateError::Custom(
+                    "address history key length mismatch".into(),
+                ));
             }
             if val.len() != StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN {
-                // TODO: Return error?
-                break;
+                return Err(FinalisedStateError::Custom(
+                    "address history value length mismatch".into(),
+                ));
             }
 
             // Check tx_location match without deserializing
@@ -5545,76 +5586,78 @@ impl DbV1 {
     fn mark_addr_hist_record_spent_blocking(
         &self,
         addr_script: &AddrScript,
-        tx_location: TxLocation,
-        vout: u16,
+        expected_prev_entry_bytes: &[u8],
     ) -> Result<bool, FinalisedStateError> {
         let addr_bytes = addr_script.to_bytes()?;
         let mut txn = self.env.begin_rw_txn()?;
         {
             let mut cur = txn.open_rw_cursor(self.address_history)?;
 
+            // iterate duplicates for the address, but do an exact-value comparison
+            // to find *the* duplicate we intend to flip.
             for (key, val) in cur.iter_dup_of(&addr_bytes)? {
                 if key.len() != AddrScript::VERSIONED_LEN {
-                    // TODO: Return error?
-                    break;
+                    return Err(FinalisedStateError::Custom(
+                        "address history key length mismatch".into(),
+                    ));
                 }
                 if val.len() != StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN {
-                    // TODO: Return error?
-                    break;
+                    return Err(FinalisedStateError::Custom(
+                        "address history value length mismatch".into(),
+                    ));
                 }
-                let mut hist_record = [0u8; StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN];
-                hist_record.copy_from_slice(val);
 
-                // Parse the tx_location out of arr:
-                // - [0] StoredEntry tag
-                // - [1] record tag
-                // - [2..=5] height
-                // - [6..=7] tx_index
-                // - [8..=9] vout
-                // - [10] flags
-                // - [11..=18] value
-                // - [19..=50] checksum
-
-                let block_height = u32::from_be_bytes([
-                    hist_record[2],
-                    hist_record[3],
-                    hist_record[4],
-                    hist_record[5],
-                ]);
-                let tx_idx = u16::from_be_bytes([hist_record[6], hist_record[7]]);
-                let rec_vout = u16::from_be_bytes([hist_record[8], hist_record[9]]);
-                let flags = hist_record[10];
-
-                // Skip if this row is an input or already marked spent.
-                if flags & AddrHistRecord::FLAG_IS_INPUT != 0
-                    || flags & AddrHistRecord::FLAG_SPENT != 0
-                {
+                // exact byte-match: val is &[u8], expected_prev_entry_bytes is &[u8]
+                if val != expected_prev_entry_bytes {
                     continue;
                 }
 
-                // Match on (height, tx_location, vout).
-                if block_height == tx_location.block_height()
-                    && tx_idx == tx_location.tx_index()
-                    && rec_vout == vout
-                {
-                    // Flip FLAG_SPENT.
-                    hist_record[10] |= AddrHistRecord::FLAG_SPENT;
+                // we've located the exact duplicate bytes we built earlier.
+                let mut hist_record = [0u8; StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN];
+                hist_record.copy_from_slice(val);
 
-                    // Recompute checksum over entry header + payload (bytes 1‥19).
-                    let checksum = StoredEntryFixed::<AddrEventBytes>::blake2b256(
-                        &[&addr_bytes, &hist_record[1..19]].concat(),
-                    );
-                    hist_record[19..51].copy_from_slice(&checksum);
+                // Sanity: the record we intend to mark should be a mined output (not an input).
+                let flags = hist_record[10];
+                if (flags & AddrHistRecord::FLAG_IS_INPUT) != 0 {
+                    return Err(FinalisedStateError::Custom(
+                        "attempt to mark an input-row as spent".into(),
+                    ));
+                }
 
-                    // Write back in place.
-                    cur.put(&addr_bytes, &hist_record, WriteFlags::CURRENT)?;
+                // If it's already spent, treat as successful (idempotent).
+                if (flags & AddrHistRecord::FLAG_SPENT) != 0 {
                     drop(cur);
                     txn.commit()?;
-
                     return Ok(true);
                 }
+
+                // If the record is not marked MINED, that's an invariant failure.
+                // We surface it rather than silently overwriting/creating a spent-only record.
+                if (flags & AddrHistRecord::FLAG_MINED) == 0 {
+                    return Err(FinalisedStateError::Custom(
+                        "attempt to mark non-mined addrhist record as spent".into(),
+                    ));
+                }
+
+                // Preserve all existing flags (including MINED), and add SPENT.
+                hist_record[10] |= AddrHistRecord::FLAG_SPENT;
+
+                // Recompute checksum over entry header + payload (bytes 1..19).
+                let checksum = StoredEntryFixed::<AddrEventBytes>::blake2b256(
+                    &[&addr_bytes, &hist_record[1..19]].concat(),
+                );
+                hist_record[19..51].copy_from_slice(&checksum);
+
+                // Write back in place for the exact duplicate we matched.
+                cur.put(&addr_bytes, &hist_record, WriteFlags::CURRENT)?;
+                drop(cur);
+                txn.commit()?;
+
+                return Ok(true);
             }
         }
+
+        // not found
         txn.commit()?;
         Ok(false)
     }
@@ -5628,76 +5671,80 @@ impl DbV1 {
     fn mark_addr_hist_record_unspent_blocking(
         &self,
         addr_script: &AddrScript,
-        tx_location: TxLocation,
-        vout: u16,
+        expected_prev_entry_bytes: &[u8],
     ) -> Result<bool, FinalisedStateError> {
         let addr_bytes = addr_script.to_bytes()?;
         let mut txn = self.env.begin_rw_txn()?;
         {
             let mut cur = txn.open_rw_cursor(self.address_history)?;
 
+            // iterate duplicates for the address, but do an exact-value comparison
+            // to find *the* duplicate we intend to flip.
             for (key, val) in cur.iter_dup_of(&addr_bytes)? {
                 if key.len() != AddrScript::VERSIONED_LEN {
-                    // TODO: Return error?
-                    break;
+                    return Err(FinalisedStateError::Custom(
+                        "address history key length mismatch".into(),
+                    ));
                 }
                 if val.len() != StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN {
-                    // TODO: Return error?
-                    break;
+                    return Err(FinalisedStateError::Custom(
+                        "address history value length mismatch".into(),
+                    ));
                 }
-                let mut hist_record = [0u8; StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN];
-                hist_record.copy_from_slice(val);
 
-                // Parse the tx_location out of arr:
-                // - [0] StoredEntry tag
-                // - [1] record tag
-                // - [2..=5] height
-                // - [6..=7] tx_index
-                // - [8..=9] vout
-                // - [10] flags
-                // - [11..=18] value
-                // - [19..=50] checksum
-
-                let block_height = u32::from_be_bytes([
-                    hist_record[2],
-                    hist_record[3],
-                    hist_record[4],
-                    hist_record[5],
-                ]);
-                let tx_idx = u16::from_be_bytes([hist_record[6], hist_record[7]]);
-                let rec_vout = u16::from_be_bytes([hist_record[8], hist_record[9]]);
-                let flags = hist_record[10];
-
-                // Skip if this row is an input or already marked unspent.
-                if (flags & AddrHistRecord::FLAG_IS_INPUT) != 0
-                    || (flags & AddrHistRecord::FLAG_SPENT) == 0
-                {
+                // exact byte-match: val is &[u8], expected_prev_entry_bytes is &[u8]
+                if val != expected_prev_entry_bytes {
                     continue;
                 }
 
-                // Match on (height, tx_location, vout).
-                if block_height == tx_location.block_height()
-                    && tx_idx == tx_location.tx_index()
-                    && rec_vout == vout
-                {
-                    // Flip FLAG_SPENT.
-                    hist_record[10] &= !AddrHistRecord::FLAG_SPENT;
+                // we've located the exact duplicate bytes we built earlier.
+                let mut hist_record = [0u8; StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN];
+                hist_record.copy_from_slice(val);
 
-                    // Recompute checksum over entry header + payload (bytes 1‥19).
-                    let checksum = StoredEntryFixed::<AddrEventBytes>::blake2b256(
-                        &[&addr_bytes, &hist_record[1..19]].concat(),
-                    );
-                    hist_record[19..51].copy_from_slice(&checksum);
+                // parse flags (located at byte index 10 in the StoredEntry layout)
+                let flags = hist_record[10];
 
-                    // Write back in place.
-                    cur.put(&addr_bytes, &hist_record, WriteFlags::CURRENT)?;
+                // Sanity: the record we intend to mark should be a mined output (not an input).
+                if (flags & AddrHistRecord::FLAG_IS_INPUT) != 0 {
+                    return Err(FinalisedStateError::Custom(
+                        "attempt to mark an input-row as unspent".into(),
+                    ));
+                }
+
+                // If it's already unspent, treat as successful (idempotent).
+                if (flags & AddrHistRecord::FLAG_SPENT) == 0 {
                     drop(cur);
                     txn.commit()?;
-
                     return Ok(true);
                 }
+
+                // If the record is not marked MINED, that's an invariant failure.
+                // We surface it rather than producing a non-mined record.
+                if (flags & AddrHistRecord::FLAG_MINED) == 0 {
+                    return Err(FinalisedStateError::Custom(
+                        "attempt to mark non-mined addrhist record as unspent".into(),
+                    ));
+                }
+
+                // Preserve all existing flags (including MINED), and remove SPENT.
+                hist_record[10] &= !AddrHistRecord::FLAG_SPENT;
+
+                // Recompute checksum over entry header + payload (bytes 1..19).
+                let checksum = StoredEntryFixed::<AddrEventBytes>::blake2b256(
+                    &[&addr_bytes, &hist_record[1..19]].concat(),
+                );
+                hist_record[19..51].copy_from_slice(&checksum);
+
+                // Write back in place for the exact duplicate we matched.
+                cur.put(&addr_bytes, &hist_record, WriteFlags::CURRENT)?;
+                drop(cur);
+                txn.commit()?;
+
+                return Ok(true);
             }
         }
+
+        // not found
         txn.commit()?;
         Ok(false)
     }

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -1442,7 +1442,7 @@ impl DbV1 {
                     Err(e) => {
                         warn!("Error writing block to DB: {e}");
                         warn!(
-                            "Deleting corrupt block from DB at height: {} with hash: {}",
+                            "Deleting corrupt block from DB at height: {} with hash: {:?}",
                             block_height.0, block_hash.0
                         );
 
@@ -1463,7 +1463,7 @@ impl DbV1 {
             Err(e) => {
                 warn!("Error writing block to DB: {e}");
                 warn!(
-                    "Deleting corrupt block from DB at height: {} with hash: {}",
+                    "Deleting corrupt block from DB at height: {} with hash: {:?}",
                     block_height.0, block_hash.0
                 );
 

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -1354,6 +1354,7 @@ impl DbV1 {
                 }
             }
 
+            zaino_db.env.sync(true).ok();
             zaino_db.validate_block_blocking(block_height, block_hash)?;
 
             Ok::<_, FinalisedStateError>(())
@@ -4680,6 +4681,7 @@ impl DbV1 {
             reason: reason.to_owned(),
         };
 
+        self.env.sync(true).ok();
         let ro = self.env.begin_ro_txn()?;
 
         // *** header ***

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -1346,12 +1346,19 @@ impl DbV1 {
                 tokio::task::block_in_place(|| self.env.sync(true))
                     .map_err(|e| FinalisedStateError::Custom(format!("LMDB sync failed: {e}")))?;
                 self.status.store(StatusType::Ready);
-
-                info!(
-                    "Successfully committed block {} at height {} to ZainoDB.",
-                    &block.index().hash(),
-                    &block.index().height()
-                );
+                if block.index().height().0 % 100 == 0 {
+                    info!(
+                        "Successfully committed block {} at height {} to ZainoDB.",
+                        &block.index().hash(),
+                        &block.index().height()
+                    );
+                } else {
+                    tracing::debug!(
+                        "Successfully committed block {} at height {} to ZainoDB.",
+                        &block.index().hash(),
+                        &block.index().height()
+                    );
+                }
 
                 Ok(())
             }

--- a/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -1191,8 +1191,8 @@ impl DbV1 {
             status: self.status.clone(),
             config: self.config.clone(),
         };
-        let post_result = tokio::task::spawn_blocking(move || {
-            // let post_result: Result<(), FinalisedStateError> = (async {
+        let join_handle = tokio::task::spawn_blocking(move || {
+            // let post_result = tokio::task::spawn_blocking(move || {
             // Write block to ZainoDB
             let mut txn = zaino_db.env.begin_rw_txn()?;
 
@@ -1354,13 +1354,31 @@ impl DbV1 {
                 }
             }
 
-            zaino_db.env.sync(true).ok();
+            zaino_db.env.sync(true).map_err(|e| {
+                FinalisedStateError::Custom(format!("LMDB sync failed before validation: {e}"))
+            })?;
+
             zaino_db.validate_block_blocking(block_height, block_hash)?;
 
             Ok::<_, FinalisedStateError>(())
-        })
-        .await
-        .map_err(|e| FinalisedStateError::Custom(format!("Tokio task error: {e}")))?;
+        });
+
+        // Wait for the join and handle panic / cancellation explicitly so we can
+        // attempt to remove any partially written block.
+        let post_result = match join_handle.await {
+            Ok(inner_res) => inner_res,
+            Err(join_err) => {
+                warn!("Tokio task error (spawn_blocking join error): {}", join_err);
+
+                // Best-effort delete of partially written block; ignore delete result.
+                let _ = self.delete_block(&block).await;
+
+                return Err(FinalisedStateError::Custom(format!(
+                    "Tokio task error: {}",
+                    join_err
+                )));
+            }
+        };
 
         match post_result {
             Ok(_) => {

--- a/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/zaino-state/src/chain_index/non_finalised_state.rs
@@ -153,20 +153,17 @@ pub enum InitError {
 /// This is the core of the concurrent block cache.
 impl BestTip {
     /// Create a BestTip from an IndexedBlock
-    fn from_block(block: &IndexedBlock) -> Result<Self, InitError> {
+    fn from_block(block: &IndexedBlock) -> Self {
         let height = block.height();
         let blockhash = *block.hash();
-        Ok(Self { height, blockhash })
+        Self { height, blockhash }
     }
 }
 
 impl NonfinalizedBlockCacheSnapshot {
     /// Create initial snapshot from a single block
-    fn from_initial_block(
-        block: IndexedBlock,
-        validator_finalized_height: Height,
-    ) -> Result<Self, InitError> {
-        let best_tip = BestTip::from_block(&block)?;
+    fn from_initial_block(block: IndexedBlock, validator_finalized_height: Height) -> Self {
+        let best_tip = BestTip::from_block(&block);
         let hash = *block.hash();
         let height = best_tip.height;
 
@@ -176,12 +173,12 @@ impl NonfinalizedBlockCacheSnapshot {
         blocks.insert(hash, block);
         heights_to_hashes.insert(height, hash);
 
-        Ok(Self {
+        Self {
             blocks,
             heights_to_hashes,
             best_tip,
             validator_finalized_height,
-        })
+        }
     }
 
     fn add_block_new_chaintip(&mut self, block: IndexedBlock) {
@@ -243,7 +240,7 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
         let snapshot = NonfinalizedBlockCacheSnapshot::from_initial_block(
             initial_block,
             Height(validator_tip.0.saturating_sub(100)),
-        )?;
+        );
 
         // Set up optional listener
         let nfs_change_listener = Self::setup_listener(&source).await;
@@ -331,6 +328,27 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
     /// sync to the top of the chain, trimming to the finalised tip.
     pub(super) async fn sync(&self, finalized_db: Arc<ZainoDB>) -> Result<(), SyncError> {
         let mut initial_state = self.get_snapshot();
+        let local_finalized_tip = finalized_db
+            .to_reader()
+            .db_height()
+            .await
+            .map_err(|_e| SyncError::CannotReadFinalizedState)?;
+        if Some(initial_state.best_tip.height) < local_finalized_tip {
+            self.current.swap(Arc::new(
+                NonfinalizedBlockCacheSnapshot::from_initial_block(
+                    finalized_db
+                        .to_reader()
+                        .get_chain_block(
+                            local_finalized_tip.expect("known to be some due to above if"),
+                        )
+                        .await
+                        .map_err(|_e| SyncError::CannotReadFinalizedState)?
+                        .ok_or(SyncError::CannotReadFinalizedState)?,
+                    local_finalized_tip.unwrap(),
+                ),
+            ));
+            initial_state = self.get_snapshot()
+        }
         let mut working_snapshot = initial_state.as_ref().clone();
 
         // currently this only gets main-chain blocks

--- a/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/zaino-state/src/chain_index/non_finalised_state.rs
@@ -90,23 +90,28 @@ impl std::fmt::Display for MissingBlockError {
 
 impl std::error::Error for MissingBlockError {}
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 /// An error occurred during sync of the NonFinalized State.
 pub enum SyncError {
     /// The backing validator node returned corrupt, invalid, or incomplete data
     /// TODO: This may not be correctly disambibuated from temporary network issues
     /// in the fetchservice case.
+    #[error("failed to connect to validator: {0:?}")]
     ValidatorConnectionError(NodeConnectionError),
     /// The channel used to store new blocks has been closed. This should only happen
     /// during shutdown.
+    #[error("staging channel closed. Shutdown in progress")]
     StagingChannelClosed,
     /// Sync has been called multiple times in parallel, or another process has
     /// written to the block snapshot.
+    #[error("multiple sync processes running")]
     CompetingSyncProcess,
     /// Sync attempted a reorg, and something went wrong.
+    #[error("reorg failed: {0}")]
     ReorgFailure(String),
     /// UnrecoverableFinalizedStateError
-    CannotReadFinalizedState,
+    #[error("error reading nonfinalized state")]
+    CannotReadFinalizedState(#[from] FinalisedStateError),
 }
 
 impl From<UpdateError> for SyncError {
@@ -114,7 +119,9 @@ impl From<UpdateError> for SyncError {
         match value {
             UpdateError::ReceiverDisconnected => SyncError::StagingChannelClosed,
             UpdateError::StaleSnapshot => SyncError::CompetingSyncProcess,
-            UpdateError::FinalizedStateCorruption => SyncError::CannotReadFinalizedState,
+            UpdateError::FinalizedStateCorruption => SyncError::CannotReadFinalizedState(
+                FinalisedStateError::Custom("mystery update failure".to_string()),
+            ),
             UpdateError::DatabaseHole => {
                 SyncError::ReorgFailure(String::from("could not determine best chain"))
             }
@@ -328,11 +335,7 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
     /// sync to the top of the chain, trimming to the finalised tip.
     pub(super) async fn sync(&self, finalized_db: Arc<ZainoDB>) -> Result<(), SyncError> {
         let mut initial_state = self.get_snapshot();
-        let local_finalized_tip = finalized_db
-            .to_reader()
-            .db_height()
-            .await
-            .map_err(|_e| SyncError::CannotReadFinalizedState)?;
+        let local_finalized_tip = finalized_db.to_reader().db_height().await?;
         if Some(initial_state.best_tip.height) < local_finalized_tip {
             self.current.swap(Arc::new(
                 NonfinalizedBlockCacheSnapshot::from_initial_block(
@@ -341,9 +344,11 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
                         .get_chain_block(
                             local_finalized_tip.expect("known to be some due to above if"),
                         )
-                        .await
-                        .map_err(|_e| SyncError::CannotReadFinalizedState)?
-                        .ok_or(SyncError::CannotReadFinalizedState)?,
+                        .await?
+                        .ok_or(FinalisedStateError::DataUnavailable(format!(
+                            "Missing block {}",
+                            local_finalized_tip.unwrap().0
+                        )))?,
                     local_finalized_tip.unwrap(),
                 ),
             ));

--- a/zaino-state/src/chain_index/tests/finalised_state/v0.rs
+++ b/zaino-state/src/chain_index/tests/finalised_state/v0.rs
@@ -86,7 +86,7 @@ async fn sync_to_height() {
 
     let (_db_dir, zaino_db) = spawn_v0_zaino_db(source.clone()).await.unwrap();
 
-    zaino_db.sync_to_height(Height(200), source).await.unwrap();
+    zaino_db.sync_to_height(Height(200), &source).await.unwrap();
 
     zaino_db.wait_until_ready().await;
     dbg!(zaino_db.status());

--- a/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -91,7 +91,7 @@ async fn sync_to_height() {
 
     let (_db_dir, zaino_db) = spawn_v1_zaino_db(source.clone()).await.unwrap();
 
-    zaino_db.sync_to_height(Height(200), source).await.unwrap();
+    zaino_db.sync_to_height(Height(200), &source).await.unwrap();
 
     zaino_db.wait_until_ready().await;
     dbg!(zaino_db.status());

--- a/zaino-state/src/chain_index/types/db/legacy.rs
+++ b/zaino-state/src/chain_index/types/db/legacy.rs
@@ -2452,8 +2452,8 @@ impl FixedEncodedLen for TxLocation {
 pub struct AddrHistRecord {
     tx_location: TxLocation,
     out_index: u16,
-    value: u64,
     flags: u8,
+    value: u64,
 }
 
 /* ----- flag helpers ----- */
@@ -2472,8 +2472,8 @@ impl AddrHistRecord {
         Self {
             tx_location,
             out_index,
-            value,
             flags,
+            value,
         }
     }
 
@@ -2519,8 +2519,8 @@ impl ZainoVersionedSerde for AddrHistRecord {
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
         self.tx_location.serialize(&mut *w)?;
         write_u16_be(&mut *w, self.out_index)?;
-        write_u64_le(&mut *w, self.value)?;
-        w.write_all(&[self.flags])
+        w.write_all(&[self.flags])?;
+        write_u64_le(&mut *w, self.value)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -2530,9 +2530,9 @@ impl ZainoVersionedSerde for AddrHistRecord {
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
         let tx_location = TxLocation::deserialize(&mut *r)?;
         let out_index = read_u16_be(&mut *r)?;
-        let value = read_u64_le(&mut *r)?;
         let mut flag = [0u8; 1];
         r.read_exact(&mut flag)?;
+        let value = read_u64_le(&mut *r)?;
 
         Ok(AddrHistRecord::new(tx_location, out_index, value, flag[0]))
     }


### PR DESCRIPTION
**UPDATED PR COMMENT**

This PR fixes several bugs in the ChainIndex that are blocker to release. The following is a summary of the bugs encountered testing ZainoD with testnet and the fixes implemented.

**BUG 1**
Bug:
 NodeBackedChainIndex::start_sync_loop tries to fully sync the non-finalised state before syncing the finalised state. This leads to ZainoD trying to store the whole chain in memory before starting to move block to disk, this is because the non-finalised state sync loop is implemented to always hold blocks down to the finalised tip.

Fixes:
This PR changes this behaviour so that the finalised_state is synced first, then the non_finalised state is synced.

Additional changes:
- finalised state assumed sapling / orchard commitment trees exist, this is not the case before the relevant network upgrades are active. the finalised state now stores empty commitment tree data when below the relevant height.
- NodeBackedChainIndex now uses ZainoDB::sync_to_height instead of write block.


**BUG 2**
Bug:
Non-finalised state initialises ether from the finalised tip or genesis if not present, then in sync it starts syncing from this point. This is an issue on first time startup, leading to the non-finalised state syncing from genesis, not the finalised tip.

Fixes:
Non-finalised state sync now checks the finalised tip in loop.

**BUG 3**
Bug: 
ZainoDB is intermittently hitting an error when writing blocks to the DB: The database is not finding the correct output that a tx in the current block spent. This leads to block write failing due to the block looking invalid from the batadase's point of view. This was not causing write failure however, just a warning.

This was actually made up of several bugs:
Bug 3a:
Write_block was not failing and deleting corrupt data from the DB, leading to a corrupt DB fle.

Cause:
In write_block the write failures were not properly propagated and were mixed with tokio task errors leading to missed failed writes.

Fix:
Properly handle tokio task error.

Bug 3b:
Write_block was randomly failing when given valid data.

Cause: 
The write_block method used multiple LMDB transactions to write the given block to the DB, the problem was that one of these writes sometimes required data from the current block to already be written to the DB, and there was a race condition happening where sometimes the previous write transaction that included the required data had not yet properly synced to the DB, meaning that the required data was not present.

This race condition could happen when a tx in a block spent an output that was created in the same block.

Fix:
Write_block (and delete_block) now uses a single LMDB transaction to write (or delete) all block data, removing this race.

Additional updates:
In several places explicit errors are now returned where before they were not, hardening the database implementation.

Several extra warn debugs were added (on deleting corrupt block data).

The mark_spent and mark_unspent were updated to use more explicit byte matching.