### PR TITLE
BUG FIX: chain_index shutdown race condition final fix

### DIFF
--- a/zaino-state/src/chain_index.rs
+++ b/zaino-state/src/chain_index.rs
@@ -510,9 +510,9 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
     /// an error indicates a failure to cleanly shutdown. Dropping the
     /// chain index should still stop everything
     pub async fn shutdown(&self) -> Result<(), FinalisedStateError> {
+        self.status.store(StatusType::Closing);
         self.finalized_db.shutdown().await?;
         self.mempool.close();
-        self.status.store(StatusType::Closing);
         Ok(())
     }
 


### PR DESCRIPTION
- Closes https://github.com/zingolabs/zaino/issues/498

The fist part of this work has already been completed, by implementing and using a combine method to ensure high priority statuses are not lost. The last fix required is to set the chain index's status to closing as soon as the shutdown signal is received so that a running status is never returned during the shutdown process.

This PR adds that last change.