### PR TITLE
HOTFIX: update testnet config for zebrad

### DIFF
--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -246,7 +246,11 @@ impl ZcashService for StateService {
                 RpcError::new_from_legacycode(LegacyCode::Misc, "no blocks in chain"),
             )?;
 
-            if server_height.0 == syncer_height.0 {
+            // Currently the ReadStateService and JsonRPC interface in zebra are 1 block out of sync.
+            // For this reason we cannot wait for a direct match, but wait for the syncer to be "close"
+            // to the validator's tip.
+            let diff = server_height.0.abs_diff(syncer_height.0);
+            if diff <= 5 {
                 break;
             } else {
                 info!(" - ReadStateService syncing with Zebra. Syncer chain height: {}, Validator chain height: {}",

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -246,11 +246,7 @@ impl ZcashService for StateService {
                 RpcError::new_from_legacycode(LegacyCode::Misc, "no blocks in chain"),
             )?;
 
-            // Currently the ReadStateService and JsonRPC interface in zebra are 1 block out of sync.
-            // For this reason we cannot wait for a direct match, but wait for the syncer to be "close"
-            // to the validator's tip.
-            let diff = server_height.0.abs_diff(syncer_height.0);
-            if diff <= 5 {
+            if server_height.0 == syncer_height.0 {
                 break;
             } else {
                 info!(" - ReadStateService syncing with Zebra. Syncer chain height: {}, Validator chain height: {}",

--- a/zainod/zebrad.toml
+++ b/zainod/zebrad.toml
@@ -1,3 +1,101 @@
-network.network = "Testnet"
-rpc.listen_addr = '127.0.0.1:18232'
-rpc.enable_cookie_auth = false
+# Default configuration for zebrad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zebrad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
+#
+# CONFIGURATION SOURCES (in order of precedence, highest to lowest):
+#
+# 1. Environment variables with ZEBRA_ prefix (highest precedence)
+#    - Format: ZEBRA_SECTION__KEY (double underscore for nested keys)
+#    - Examples:
+#      - ZEBRA_NETWORK__NETWORK=Testnet
+#      - ZEBRA_RPC__LISTEN_ADDR=127.0.0.1:8232
+#      - ZEBRA_STATE__CACHE_DIR=/path/to/cache
+#      - ZEBRA_TRACING__FILTER=debug
+#      - ZEBRA_METRICS__ENDPOINT_ADDR=0.0.0.0:9999
+#
+# 2. Configuration file (TOML format)
+#    - At the path specified via -c flag, e.g. `zebrad -c myconfig.toml start`, or
+#    - At the default path in the user's preference directory (platform-dependent, see below)
+#
+# 3. Hard-coded defaults (lowest precedence)
+#
+# The user's preference directory and the default path to the `zebrad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zebrad.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zebrad.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zebrad.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[health]
+enforce_on_test_networks = false
+min_connected_peers = 1
+ready_max_blocks_behind = 2
+ready_max_tip_age = "5m"
+
+[mempool]
+eviction_memory_time = "1h"
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+internal_miner = false
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+initial_mainnet_peers = [
+    "dnsseed.z.cash:8233",
+    "dnsseed.str4d.xyz:8233",
+    "mainnet.seeder.zfnd.org:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+]
+listen_addr = "[::]:8233"
+max_connections_per_ip = 1
+network = "Testnet"
+peerset_initial_target_size = 25
+
+[rpc]
+debug_force_finished_sync = false
+enable_cookie_auth = false
+max_response_body_size = 52428800
+parallel_cpu_threads = 0
+listen_addr = '127.0.0.1:18232'
+indexer_listen_addr = '127.0.0.1:18230'
+
+[state]
+delete_old_database = true
+ephemeral = false
+should_backup_non_finalized_state = true
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 50
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false


### PR DESCRIPTION
This PR fixes the provided testnet zebrad config, enabling users to use the state service backend to connect with the backing zebrad.

 - NOTE: this PR has exposed a separate issue: https://github.com/zingolabs/zaino/issues/903