### PR TITLE
HOTFIX: updated db max size (gb) default to fit mainnet cache

### DIFF
--- a/zaino-common/src/config/storage.rs
+++ b/zaino-common/src/config/storage.rs
@@ -45,7 +45,7 @@ pub struct DatabaseSize(pub usize);
 
 impl Default for DatabaseSize {
     fn default() -> Self {
-        DatabaseSize(128) // Default to 128 GB
+        DatabaseSize(384) // Default to 384 GB
     }
 }
 


### PR DESCRIPTION
- closes #904 

Updates the default max db size from 128GB to 384GB to ensure that it can fit the full mainnet cache.