### PR TITLE
makes optional deps MORE optional and default

### DIFF
--- a/zaino-proto/Cargo.toml
+++ b/zaino-proto/Cargo.toml
@@ -8,9 +8,13 @@ edition = { workspace = true }
 license = { workspace = true }
 version = { workspace = true }
 
+[features]
+default = ["zebra"]
+zebra = ["dep:zebra-state", "dep:zebra-chain", "dep:which"]
+
 [dependencies]
-zebra-state = { workspace = true }
-zebra-chain = { workspace = true }
+zebra-state = { workspace = true, optional = true }
+zebra-chain = { workspace = true, optional = true }
 
 # Miscellaneous Workspace
 tonic = { workspace = true }
@@ -20,4 +24,4 @@ prost = { workspace = true }
 
 [build-dependencies]
 tonic-build = { workspace = true, features = ["prost"] }
-which = { workspace = true }
+which = { workspace = true, optional = true }

--- a/zaino-proto/Cargo.toml
+++ b/zaino-proto/Cargo.toml
@@ -9,8 +9,8 @@ license = { workspace = true }
 version = { workspace = true }
 
 [features]
-default = ["zebra"]
-zebra = ["dep:zebra-state", "dep:zebra-chain", "dep:which"]
+default = ["heavy"]
+heavy = ["dep:zebra-state", "dep:zebra-chain", "dep:which"]
 
 [dependencies]
 zebra-state = { workspace = true, optional = true }

--- a/zaino-proto/build.rs
+++ b/zaino-proto/build.rs
@@ -7,14 +7,20 @@ const COMPACT_FORMATS_PROTO: &str = "proto/compact_formats.proto";
 const PROPOSAL_PROTO: &str = "proto/proposal.proto";
 const SERVICE_PROTO: &str = "proto/service.proto";
 
+fn protoc_available() -> bool {
+    if env::var_os("PROTOC").is_some() {
+        return true;
+    }
+    #[cfg(feature = "zebra")]
+    if which::which("protoc").is_ok() {
+        return true;
+    }
+    false
+}
+
 fn main() -> io::Result<()> {
     // Check and compile proto files if needed
-    if Path::new(COMPACT_FORMATS_PROTO).exists()
-        && env::var_os("PROTOC")
-            .map(PathBuf::from)
-            .or_else(|| which::which("protoc").ok())
-            .is_some()
-    {
+    if Path::new(COMPACT_FORMATS_PROTO).exists() && protoc_available() {
         build()?;
     }
 

--- a/zaino-proto/build.rs
+++ b/zaino-proto/build.rs
@@ -11,7 +11,7 @@ fn protoc_available() -> bool {
     if env::var_os("PROTOC").is_some() {
         return true;
     }
-    #[cfg(feature = "zebra")]
+    #[cfg(feature = "heavy")]
     if which::which("protoc").is_ok() {
         return true;
     }

--- a/zaino-proto/src/proto/utils.rs
+++ b/zaino-proto/src/proto/utils.rs
@@ -2,9 +2,9 @@ use crate::proto::{
     compact_formats::{ChainMetadata, CompactBlock, CompactOrchardAction},
     service::{BlockId, BlockRange, PoolType},
 };
-#[cfg(feature = "zebra")]
+#[cfg(feature = "heavy")]
 use zebra_chain::block::Height;
-#[cfg(feature = "zebra")]
+#[cfg(feature = "heavy")]
 use zebra_state::HashOrHeight;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -288,7 +288,7 @@ impl PoolTypeFilter {
     }
 }
 
-#[cfg(feature = "zebra")]
+#[cfg(feature = "heavy")]
 /// Converts [`BlockId`] into [`HashOrHeight`] Zebra type
 pub fn blockid_to_hashorheight(block_id: BlockId) -> Option<HashOrHeight> {
     <[u8; 32]>::try_from(block_id.hash)

--- a/zaino-proto/src/proto/utils.rs
+++ b/zaino-proto/src/proto/utils.rs
@@ -2,7 +2,9 @@ use crate::proto::{
     compact_formats::{ChainMetadata, CompactBlock, CompactOrchardAction},
     service::{BlockId, BlockRange, PoolType},
 };
+#[cfg(feature = "zebra")]
 use zebra_chain::block::Height;
+#[cfg(feature = "zebra")]
 use zebra_state::HashOrHeight;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -286,6 +288,7 @@ impl PoolTypeFilter {
     }
 }
 
+#[cfg(feature = "zebra")]
 /// Converts [`BlockId`] into [`HashOrHeight`] Zebra type
 pub fn blockid_to_hashorheight(block_id: BlockId) -> Option<HashOrHeight> {
     <[u8; 32]>::try_from(block_id.hash)


### PR DESCRIPTION
Addresses:  #907 

This change is backward compatible because optional dependencies are included by default.  The first non-zaino consumer, a test server, will depend on zaino-proto with default-features=false.

The upshot is unification of interface in a back-compatible way.