### PR TITLE
Fix db block write for zero value shielded transactions

### DIFF
--- a/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -166,15 +166,16 @@ impl DbV1 {
             transparent.push(transparent_data);
 
             // Sapling transactions
-            let sapling_data = if tx.sapling().value().is_none() {
-                None
-            } else {
-                Some(tx.sapling().clone())
-            };
+            let sapling_data =
+                if tx.sapling().spends().is_empty() && tx.sapling().outputs().is_empty() {
+                    None
+                } else {
+                    Some(tx.sapling().clone())
+                };
             sapling.push(sapling_data);
 
             // Orchard transactions
-            let orchard_data = if tx.orchard().value().is_none() {
+            let orchard_data = if tx.orchard().actions().is_empty() {
                 None
             } else {
                 Some(tx.orchard().clone())


### PR DESCRIPTION
 - Issue: Shielded transaction were being filtered based on value rather than actions / inputs and outputs. This lead to some transactions being omitted from Compact Blocks. 

**This was leading to the incorrect tree size bug seen in zingolib.**


Blocked by: (this Pr is built on the following PRs):
- https://github.com/zingolabs/zaino/pull/914
- https://github.com/zingolabs/zaino/pull/915
- https://github.com/zingolabs/zaino/pull/913
- https://github.com/zingolabs/zaino/pull/917