### PR TITLE
fix initial sync error hang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,7 +2987,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "core2 0.4.0",
@@ -8626,7 +8626,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-common"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-fetch"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64",
  "byteorder",
@@ -8663,7 +8663,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-proto"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -8678,7 +8678,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-serve"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -8698,7 +8698,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-state"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -8752,7 +8752,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-testutils"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "http",
  "lazy_static",
@@ -8785,14 +8785,14 @@ dependencies = [
 
 [[package]]
 name = "zaino-testvectors"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "zainod"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "clap",
  "config",

--- a/zaino-state/src/backends/fetch.rs
+++ b/zaino-state/src/backends/fetch.rs
@@ -145,8 +145,19 @@ impl ZcashService for FetchService {
             config,
         };
 
-        while fetch_service.status() != StatusType::Ready {
-            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        // wait for sync to complete, return error on sync fail.
+        loop {
+            match fetch_service.status() {
+                StatusType::Ready | StatusType::Closing => break,
+                StatusType::CriticalError => {
+                    return Err(FetchServiceError::Critical(
+                        "ChainIndex initial sync failed, check full log for details.".to_string(),
+                    ));
+                }
+                _ => {
+                    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                }
+            }
         }
 
         Ok(fetch_service)

--- a/zaino-state/src/backends/state.rs
+++ b/zaino-state/src/backends/state.rs
@@ -258,12 +258,6 @@ impl ZcashService for StateService {
             }
         }
 
-        // let block_cache = BlockCache::spawn(
-        //     &rpc_client,
-        //     Some(&read_state_service),
-        //     config.clone().into(),
-        // )
-        // .await?;
         let mempool_source = ValidatorConnector::State(crate::chain_index::source::State {
             read_state_service: read_state_service.clone(),
             mempool_fetcher: rpc_client.clone(),
@@ -295,7 +289,24 @@ impl ZcashService for StateService {
             status: AtomicStatus::new(StatusType::Spawning),
         };
 
-        state_service.status.store(StatusType::Ready);
+        // wait for sync to complete, return error on sync fail.
+        loop {
+            match state_service.status() {
+                StatusType::Ready => {
+                    state_service.status.store(StatusType::Ready);
+                    break;
+                }
+                StatusType::CriticalError => {
+                    return Err(StateServiceError::Critical(
+                        "Chain index sync failed".to_string(),
+                    ));
+                }
+                StatusType::Closing => break,
+                _ => {
+                    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+                }
+            }
+        }
 
         Ok(state_service)
     }

--- a/zaino-state/src/chain_index.rs
+++ b/zaino-state/src/chain_index.rs
@@ -587,9 +587,11 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
 
             // If the sync loop exited unexpectedly with an error, set CriticalError
             // so that liveness checks can detect the failure.
-            if let Err(ref e) = result {
+            if let Err(e) = result {
                 tracing::error!("Sync loop exited with error: {e:?}");
                 status.store(StatusType::CriticalError);
+
+                return Err(e);
             }
 
             result

--- a/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -589,7 +589,18 @@ impl DbV1 {
                 let _ = self.delete_block(&block).await;
                 tokio::task::block_in_place(|| self.env.sync(true))
                     .map_err(|e| FinalisedStateError::Custom(format!("LMDB sync failed: {e}")))?;
+
+                // NOTE: this does not need to be critical if we implement self healing,
+                // which we have the tools to do.
                 self.status.store(StatusType::CriticalError);
+
+                if e.to_string().contains("MDB_MAP_FULL") {
+                    warn!("Configured max database size exceeded, update `storage.database.size` in zaino's config.");
+                    return Err(FinalisedStateError::Custom(format!(
+                        "Database configuration error: {e}"
+                    )));
+                }
+
                 Err(FinalisedStateError::InvalidBlock {
                     height: block_height.0,
                     hash: block_hash,

--- a/zaino-state/src/error.rs
+++ b/zaino-state/src/error.rs
@@ -14,6 +14,10 @@ use zaino_proto::proto::utils::GetBlockRangeError;
 // #[deprecated]
 #[derive(Debug, thiserror::Error)]
 pub enum StateServiceError {
+    /// Critical Errors, Restart Zaino.
+    #[error("Critical error: {0}")]
+    Critical(String),
+
     /// An rpc-specific error we haven't accounted for
     #[error("unhandled fallible RPC call {0}")]
     UnhandledRpcError(String),
@@ -110,6 +114,7 @@ impl From<GetBlockRangeError> for StateServiceError {
 impl From<StateServiceError> for tonic::Status {
     fn from(error: StateServiceError) -> Self {
         match error {
+            StateServiceError::Critical(message) => tonic::Status::internal(message),
             StateServiceError::Custom(message) => tonic::Status::internal(message),
             StateServiceError::JoinError(err) => {
                 tonic::Status::internal(format!("Join error: {err}"))


### PR DESCRIPTION
This PR fixes a bug where the IndexerService in zaino-state would hang indefinitely on an initial sync error. Currenly the error returned is generic due to [ https://github.com/zingolabs/zaino/issues/923 ], with a more specific log printed, this should be updated in the future so consumers of zaino-state can better handle these errors.

- Closes https://github.com/zingolabs/zaino/issues/919