### PR TITLE
Enable building with Rust 1.85

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,7 +2987,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "core2 0.4.0",
@@ -8626,7 +8626,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-common"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -8635,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-fetch"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "base64",
  "byteorder",
@@ -8663,7 +8663,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-proto"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -8678,7 +8678,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-serve"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -8698,7 +8698,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-state"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -8752,7 +8752,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-testutils"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "http",
  "lazy_static",
@@ -8785,14 +8785,14 @@ dependencies = [
 
 [[package]]
 name = "zaino-testvectors"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "zainod"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "clap",
  "config",

--- a/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -478,7 +478,7 @@ impl DbV1 {
                 tokio::task::block_in_place(|| self.env.sync(true))
                     .map_err(|e| FinalisedStateError::Custom(format!("LMDB sync failed: {e}")))?;
                 self.status.store(StatusType::Ready);
-                if block.index().height().0.is_multiple_of(100) {
+                if block.index().height().0 % 100 == 0 {
                     info!(
                         "Successfully committed block {} at height {} to ZainoDB.",
                         &block.index().hash(),


### PR DESCRIPTION
This matches the current MSRV of Zallet (and the Zebra crates that Zaino depends on after #821).