### PR TITLE
update NodeBackedChainIndex::get_compact_block_stream() out_of_range behaviour to match lwd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8700,7 +8700,6 @@ version = "0.2.0"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
- "zcash_local_net",
  "zebra-chain",
  "zingo_common_components",
 ]

--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -775,11 +775,6 @@ async fn fetch_service_get_block_subsidy<V: ValidatorExt>(validator: &ValidatorK
         test_manager
             .generate_blocks_and_poll_indexer(1, &fetch_service_subscriber)
             .await;
-        // Zebrad does not support the founders' reward block subsidy
-        if i < first_halving_height.0 && validator == &ValidatorKind::Zebrad {
-            assert!(fetch_service_subscriber.get_block_subsidy(i).await.is_err());
-            continue;
-        }
         let fetch_service_get_block_subsidy =
             fetch_service_subscriber.get_block_subsidy(i).await.unwrap();
 

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -962,9 +962,17 @@ async fn state_service_get_block_range_out_of_range_test_upper_bound<V: Validato
         .expect("Clients are not initialized");
     clients.faucet.sync_and_await().await.unwrap();
 
+    // Test manager generates blocks on startup, check current height to ensure we only generate up to height 100
+    let chain_height = state_service_subscriber
+        .get_latest_block()
+        .await
+        .unwrap()
+        .height as u32;
+    let block_required_height_100 = 100 - chain_height;
+
     if matches!(validator, ValidatorKind::Zebrad) {
         generate_blocks_and_poll_all_chain_indexes(
-            100,
+            block_required_height_100,
             &test_manager,
             fetch_service_subscriber.clone(),
             state_service_subscriber.clone(),
@@ -1064,9 +1072,17 @@ async fn state_service_get_block_range_out_of_range_test_lower_bound<V: Validato
         .expect("Clients are not initialized");
     clients.faucet.sync_and_await().await.unwrap();
 
+    // Test manager generates blocks on startup, check current height to ensure we only generate up to height 100
+    let chain_height = state_service_subscriber
+        .get_latest_block()
+        .await
+        .unwrap()
+        .height as u32;
+    let block_required_height_100 = 100 - chain_height;
+
     if matches!(validator, ValidatorKind::Zebrad) {
         generate_blocks_and_poll_all_chain_indexes(
-            100,
+            block_required_height_100,
             &test_manager,
             fetch_service_subscriber.clone(),
             state_service_subscriber.clone(),

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -943,7 +943,7 @@ async fn state_service_get_block_range_returns_all_pools<V: ValidatorExt>(
     test_manager.close().await;
 }
 
-// tests whether the `GetBlockRange` returns all blocks until the first requested block in the 
+// tests whether the `GetBlockRange` returns all blocks until the first requested block in the
 // range can't be bound
 async fn state_service_get_block_range_out_of_range_test_upper_bound<V: ValidatorExt>(
     validator: &ValidatorKind,
@@ -973,7 +973,6 @@ async fn state_service_get_block_range_out_of_range_test_upper_bound<V: Validato
         clients.faucet.sync_and_await().await.unwrap();
     };
 
-
     let start_height: u64 = 1;
     let end_height: u64 = 106;
 
@@ -1001,10 +1000,13 @@ async fn state_service_get_block_range_out_of_range_test_upper_bound<V: Validato
     let mut fetch_service_blocks = Vec::new();
     let mut fetch_service_terminal_error = None;
 
-     while let Some(item) = fetch_service_stream.next().await {
+    while let Some(item) = fetch_service_stream.next().await {
         match item {
             Ok(block) => fetch_service_blocks.push(block),
-            Err(e) => { fetch_service_terminal_error = Some(e); break; }
+            Err(e) => {
+                fetch_service_terminal_error = Some(e);
+                break;
+            }
         }
     }
 
@@ -1019,7 +1021,10 @@ async fn state_service_get_block_range_out_of_range_test_upper_bound<V: Validato
     while let Some(item) = state_service_stream.next().await {
         match item {
             Ok(block) => state_service_blocks.push(block),
-            Err(e) => { state_service_terminal_error = Some(e); break; }
+            Err(e) => {
+                state_service_terminal_error = Some(e);
+                break;
+            }
         }
     }
     // check that the block range is the same
@@ -1032,13 +1037,15 @@ async fn state_service_get_block_range_out_of_range_test_upper_bound<V: Validato
     assert_eq!(fetch_service_blocks.len(), 100);
 
     // Assert – then an error, not a clean end-of-stream
-    let _ = state_service_terminal_error.expect("state service stream should terminate with an error, not cleanly");
-    let _ = fetch_service_terminal_error.expect("fetch service stream should terminate with an error, not cleanly");
+    let _ = state_service_terminal_error
+        .expect("state service stream should terminate with an error, not cleanly");
+    let _ = fetch_service_terminal_error
+        .expect("fetch service stream should terminate with an error, not cleanly");
 
     test_manager.close().await;
 }
 
-// tests whether the `GetBlockRange` returns all blocks until the first requested block in the 
+// tests whether the `GetBlockRange` returns all blocks until the first requested block in the
 // range can't be bound
 async fn state_service_get_block_range_out_of_range_test_lower_bound<V: ValidatorExt>(
     validator: &ValidatorKind,
@@ -1068,7 +1075,6 @@ async fn state_service_get_block_range_out_of_range_test_lower_bound<V: Validato
         clients.faucet.sync_and_await().await.unwrap();
     };
 
-
     let start_height: u64 = 106;
     let end_height: u64 = 1;
 
@@ -1096,10 +1102,13 @@ async fn state_service_get_block_range_out_of_range_test_lower_bound<V: Validato
     let mut fetch_service_blocks = Vec::new();
     let mut fetch_service_terminal_error = None;
 
-     while let Some(item) = fetch_service_stream.next().await {
+    while let Some(item) = fetch_service_stream.next().await {
         match item {
             Ok(block) => fetch_service_blocks.push(block),
-            Err(e) => { fetch_service_terminal_error = Some(e); break; }
+            Err(e) => {
+                fetch_service_terminal_error = Some(e);
+                break;
+            }
         }
     }
 
@@ -1114,18 +1123,22 @@ async fn state_service_get_block_range_out_of_range_test_lower_bound<V: Validato
     while let Some(item) = state_service_stream.next().await {
         match item {
             Ok(block) => state_service_blocks.push(block),
-            Err(e) => { state_service_terminal_error = Some(e); break; }
+            Err(e) => {
+                state_service_terminal_error = Some(e);
+                break;
+            }
         }
     }
     // check that the block range is the same
     assert_eq!(fetch_service_blocks, state_service_blocks);
 
-
     assert!(fetch_service_blocks.is_empty());
 
     // Assert – then an error, not a clean end-of-stream
-    let _ = state_service_terminal_error.expect("state service stream should terminate with an error, not cleanly");
-    let _ = fetch_service_terminal_error.expect("fetch service stream should terminate with an error, not cleanly");
+    let _ = state_service_terminal_error
+        .expect("state service stream should terminate with an error, not cleanly");
+    let _ = fetch_service_terminal_error
+        .expect("fetch service stream should terminate with an error, not cleanly");
     // assert!(
     //     matches!(err, ZainoStateError::BlockOutOfRange { .. }),
     //     "unexpected error variant: {err:?}"
@@ -2190,43 +2203,6 @@ mod zebra {
             test_manager.close().await;
         }
 
-        #[tokio::test(flavor = "multi_thread")]
-        async fn block_subsidy_fails_before_first_halving() {
-            let (
-                test_manager,
-                _fetch_service,
-                fetch_service_subscriber,
-                _state_service,
-                state_service_subscriber,
-            ) = create_test_manager_and_services::<Zebrad>(
-                &ValidatorKind::Zebrad,
-                None,
-                true,
-                false,
-                Some(NetworkKind::Regtest),
-            )
-            .await;
-
-            const BLOCK_LIMIT: u32 = 10;
-
-            for i in 0..BLOCK_LIMIT {
-                generate_blocks_and_poll_all_chain_indexes(
-                    1,
-                    &test_manager,
-                    fetch_service_subscriber.clone(),
-                    state_service_subscriber.clone(),
-                )
-                .await;
-                let fetch_service_block_subsidy =
-                    fetch_service_subscriber.get_block_subsidy(i).await;
-
-                let state_service_block_subsidy =
-                    state_service_subscriber.get_block_subsidy(i).await;
-                assert!(fetch_service_block_subsidy.is_err());
-                assert!(state_service_block_subsidy.is_err());
-            }
-        }
-
         mod z {
             use zcash_local_net::validator::zebrad::Zebrad;
 
@@ -2248,14 +2224,18 @@ mod zebra {
 
             #[tokio::test(flavor = "multi_thread")]
             pub(crate) async fn get_block_range_out_of_range_test_upper_bound_regtest() {
-                state_service_get_block_range_out_of_range_test_upper_bound::<Zebrad>(&ValidatorKind::Zebrad)
-                    .await;
+                state_service_get_block_range_out_of_range_test_upper_bound::<Zebrad>(
+                    &ValidatorKind::Zebrad,
+                )
+                .await;
             }
 
             #[tokio::test(flavor = "multi_thread")]
             pub(crate) async fn get_block_range_out_of_range_test_lower_bound_regtest() {
-                state_service_get_block_range_out_of_range_test_lower_bound::<Zebrad>(&ValidatorKind::Zebrad)
-                    .await;
+                state_service_get_block_range_out_of_range_test_lower_bound::<Zebrad>(
+                    &ValidatorKind::Zebrad,
+                )
+                .await;
             }
 
             #[tokio::test(flavor = "multi_thread")]

--- a/zaino-state/src/chain_index.rs
+++ b/zaino-state/src/chain_index.rs
@@ -934,7 +934,9 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
 
     /// Streams *compact* blocks for an inclusive height range.
     ///
-    /// Returns `None` if either requested height is greater than the snapshot's tip.
+    /// Returns `Ok(None)` if the request is descending and `start_height` exceeds the chain tip.
+    /// For ascending requests that exceed the tip, returns a stream that ends with an
+    /// `out_of_range` error after all available blocks have been sent.
     ///
     /// - The stream covers `[start_height, end_height]` (inclusive).
     /// - If `start_height <= end_height` the stream is ascending; otherwise it is descending.
@@ -962,14 +964,28 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
 
         let is_ascending = start_height <= end_height;
 
+        // Descending: the first block we'd try to return is already above the tip → error immediately.
+        if !is_ascending && start_height > chain_tip_height {
+            return Ok(None);
+        }
+
         let pool_types_vector = pool_types.to_pool_types_vector();
+
+        // For ascending requests that extend past the tip: cap the streaming range at the tip,
+        // then append a trailing out_of_range error after all valid blocks have been sent.
+        let needs_out_of_range = is_ascending && end_height > chain_tip_height;
+        let capped_end_height = if needs_out_of_range {
+            chain_tip_height
+        } else {
+            end_height
+        };
 
         // Pre-create any finalized-state stream(s) we will need so that errors are returned
         // from this method (not deferred into the spawned task).
         let finalized_stream: Option<CompactBlockStream> = if is_ascending {
             if start_height < lowest_nonfinalized_height {
                 let finalized_end_height = types::Height(std::cmp::min(
-                    end_height.0,
+                    capped_end_height.0,
                     lowest_nonfinalized_height.0.saturating_sub(1),
                 ));
 
@@ -1013,7 +1029,7 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
         };
 
         let nonfinalized_snapshot = nonfinalized_snapshot.clone();
-        // TODO: Investigate whether channel size should be changed, added to config, or set dynamically base on resources.
+        // TODO: Investigate whether channel size should be changed, added to config, or set dynamically based on resources.
         let (channel_sender, channel_receiver) = tokio::sync::mpsc::channel(128);
 
         tokio::spawn(async move {
@@ -1031,7 +1047,7 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
                 let nonfinalized_start_height =
                     types::Height(std::cmp::max(start_height.0, lowest_nonfinalized_height.0));
 
-                for height_value in nonfinalized_start_height.0..=end_height.0 {
+                for height_value in nonfinalized_start_height.0..=capped_end_height.0 {
                     let Some(indexed_block) = nonfinalized_snapshot
                         .get_chainblock_by_height(&types::Height(height_value))
                     else {
@@ -1049,6 +1065,15 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
                     if channel_sender.send(Ok(compact_block)).await.is_err() {
                         return;
                     }
+                }
+                // If the original end_height was above the tip, signal out_of_range after all valid blocks.
+                if needs_out_of_range {
+                    let _ = channel_sender
+                          .send(Err(tonic::Status::out_of_range(format!(
+                              "Error: Height out of range [{}]. Height requested is greater than the best chain tip [{}].",
+                              end_height.0, chain_tip_height.0,
+                          ))))
+                          .await;
                 }
             } else {
                 // 1) Nonfinalized segment, descending.


### PR DESCRIPTION
Updates NodeBackedChainIndex::get_compact_block_stream() out_of_range behaviour to match lwd.

- Required for https://github.com/zingolabs/zaino/issues/933