### PR TITLE
Zallet regtest fixes + downstream indexer service fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- [943] Zallet regtest fixes
+
+### Added 
+### Changed
+- `JsonRpSeeConnector::get_tree_state` now returns a `GetTreestateResponse`
+  whose `sapling` and `orchard` fields are optional. In regtest mode, these
+  fields may be omitted when the corresponding network upgrade activation
+  height is not configured.
+### Removed
+### Deprecated
+
+## [v0.2.0] - 2026-03-25
 - [808] Adopt lightclient-protocol v0.4.0
 
 ### Added 
@@ -18,7 +30,7 @@ and this library adheres to Rust's notion of
 ### Deprecated
 - `zaino-fetch::chain:to_compact` in favor of `to_compact_tx` which takes an 
   optional height and a `PoolTypeFilter` (see zaino-proto changes)
-- 
+
 ## [v0.4.0] - 2025-12-03
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", rev
 
 
 # Librustzcash
+incrementalmerkletree = "0.8"
 zcash_address = "0.10"
 zcash_keys = "0.12"
 zcash_protocol = "0.7.2"

--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -395,8 +395,10 @@ async fn fetch_service_z_get_treestate<V: ValidatorExt>(validator: &ValidatorKin
         .generate_blocks_and_poll_indexer(1, &fetch_service_subscriber)
         .await;
 
+    let chain_height = dbg!(fetch_service_subscriber.chain_height().await.unwrap()).0;
+
     dbg!(fetch_service_subscriber
-        .z_get_treestate("2".to_string())
+        .z_get_treestate(chain_height.to_string())
         .await
         .unwrap());
 
@@ -1865,8 +1867,10 @@ async fn fetch_service_get_tree_state<V: ValidatorExt>(validator: &ValidatorKind
 
     let fetch_service_subscriber = test_manager.service_subscriber.take().unwrap();
 
+    let chain_height = dbg!(fetch_service_subscriber.chain_height().await.unwrap()).0;
+
     let block_id = BlockId {
-        height: 1,
+        height: chain_height as u64,
         hash: Vec::new(),
     };
 

--- a/integration-tests/tests/json_server.rs
+++ b/integration-tests/tests/json_server.rs
@@ -506,13 +506,15 @@ async fn z_get_treestate_inner() {
     )
     .await;
 
+    let chain_height = dbg!(zaino_subscriber.chain_height().await.unwrap()).0;
+
     let zcashd_treestate = dbg!(zcashd_subscriber
-        .z_get_treestate("2".to_string())
+        .z_get_treestate(chain_height.to_string())
         .await
         .unwrap());
 
     let zaino_treestate = dbg!(zaino_subscriber
-        .z_get_treestate("2".to_string())
+        .z_get_treestate(chain_height.to_string())
         .await
         .unwrap());
 

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -1211,13 +1211,15 @@ async fn state_service_z_get_treestate<V: ValidatorExt>(validator: &ValidatorKin
     )
     .await;
 
+    let chain_height = dbg!(state_service_subscriber.chain_height().await.unwrap()).0;
+
     let fetch_service_treestate = dbg!(fetch_service_subscriber
-        .z_get_treestate("2".to_string())
+        .z_get_treestate(chain_height.to_string())
         .await
         .unwrap());
 
     let state_service_treestate = dbg!(state_service_subscriber
-        .z_get_treestate("2".to_string())
+        .z_get_treestate(chain_height.to_string())
         .await
         .unwrap());
 
@@ -2611,8 +2613,10 @@ mod zebra {
             )
             .await;
 
+            let chain_height = dbg!(state_service_subscriber.chain_height().await.unwrap()).0;
+
             let second_treestate_by_height = BlockId {
-                height: 2,
+                height: chain_height as u64,
                 hash: vec![],
             };
             let fetch_service_treestate_by_height = dbg!(fetch_service_subscriber

--- a/packages/zaino-fetch/CHANGELOG.md
+++ b/packages/zaino-fetch/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to this library will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this library adheres to Rust's notion of
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+- [943] Zallet regtest fixes
+
+### Added 
+### Changed
+- `JsonRpSeeConnector::get_tree_state` now returns a `GetTreestateResponse`
+  whose `sapling` and `orchard` fields are optional. In regtest mode, these
+  fields may be omitted when the corresponding network upgrade activation
+  height is not configured.
+### Removed
+### Deprecated

--- a/packages/zaino-fetch/src/jsonrpsee/response.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response.rs
@@ -1000,10 +1000,18 @@ pub struct GetTreestateResponse {
     pub time: u32,
 
     /// A treestate containing a Sapling note commitment tree, hex-encoded.
-    pub sapling: zebra_rpc::client::Treestate,
+    ///
+    /// Omitted if an activation height for the Sapling network upgrade is not configured
+    /// (i.e. in regtest mode).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sapling: Option<zebra_rpc::client::Treestate>,
 
     /// A treestate containing an Orchard note commitment tree, hex-encoded.
-    pub orchard: zebra_rpc::client::Treestate,
+    ///
+    /// Omitted if an activation height for the NU5 network upgrade is not configured
+    /// (i.e. in regtest mode).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub orchard: Option<zebra_rpc::client::Treestate>,
 }
 
 /// Error type for the `get_treestate` RPC request.
@@ -1035,11 +1043,15 @@ impl TryFrom<GetTreestateResponse> for zebra_rpc::client::GetTreestateResponse {
             zebra_chain::serialization::SerializationError::Parse("negative block height")
         })?;
 
-        let sapling_bytes = value.sapling.commitments().final_state().clone();
-        let sapling = Treestate::new(Commitments::new(None, sapling_bytes));
+        let sapling = value
+            .sapling
+            .clone()
+            .unwrap_or_else(|| Treestate::new(Commitments::new(None, None)));
 
-        let orchard_bytes = value.orchard.commitments().final_state().clone();
-        let orchard = Treestate::new(Commitments::new(None, orchard_bytes));
+        let orchard = value
+            .orchard
+            .clone()
+            .unwrap_or_else(|| Treestate::new(Commitments::new(None, None)));
 
         Ok(zebra_rpc::client::GetTreestateResponse::new(
             parsed_hash,

--- a/packages/zaino-state/Cargo.toml
+++ b/packages/zaino-state/Cargo.toml
@@ -29,6 +29,7 @@ zaino-fetch = { workspace = true }
 zaino-proto = { workspace = true }
 
 # LibRustZcash
+incrementalmerkletree = { workspace = true }
 zcash_address = { workspace = true }
 zcash_keys = { workspace = true }
 zcash_primitives = { workspace = true }

--- a/packages/zaino-state/src/backends/fetch.rs
+++ b/packages/zaino-state/src/backends/fetch.rs
@@ -2,7 +2,7 @@
 
 use futures::StreamExt;
 use hex::FromHex;
-use std::{io::Cursor, time};
+use std::{io::Cursor, str::FromStr, time};
 use tokio::{sync::mpsc, time::timeout};
 use tonic::async_trait;
 use tracing::{info, instrument, warn};
@@ -83,6 +83,8 @@ use crate::{ChainIndex, NodeBackedChainIndex, NodeBackedChainIndexSubscriber};
 #[deprecated = "Will be eventually replaced by `BlockchainSource`"]
 pub struct FetchService {
     /// JsonRPC Client.
+    ///
+    /// NOTE: DEPRCATED, USE INDEXER OR VALIDATOR_CONNECTOR.
     fetcher: JsonRpSeeConnector,
     /// Core indexer.
     indexer: NodeBackedChainIndex,
@@ -199,7 +201,9 @@ impl Drop for FetchService {
 #[allow(deprecated)]
 pub struct FetchServiceSubscriber {
     /// JsonRPC Client.
-    pub fetcher: JsonRpSeeConnector,
+    ///
+    /// NOTE: DEPRCATED, USE INDEXER OR VALIDATOR_CONNECTOR.
+    fetcher: JsonRpSeeConnector,
     /// Core indexer.
     pub indexer: NodeBackedChainIndexSubscriber,
     /// Service metadata.
@@ -540,15 +544,81 @@ impl ZcashIndexer for FetchServiceSubscriber {
     /// negative where -1 is the last known valid block". On the other hand,
     /// `lightwalletd` only uses positive heights, so Zebra does not support
     /// negative heights.
+    ///
+    /// NOTE: This method currently has to fetch data from 2 places (get_treestate and get_indexed_block_by_*),
+    ///       If `ValidatorConnector::GetTreeState` was updated to return the additional information
+    ///       required, this second call could be removed, improving the performance of this method.
     async fn z_get_treestate(
         &self,
         hash_or_height: String,
     ) -> Result<GetTreestateResponse, Self::Error> {
-        Ok(self
-            .fetcher
-            .get_treestate(hash_or_height)
-            .await?
-            .try_into()?)
+        let hash_or_height_struct: HashOrHeight = HashOrHeight::from_str(&hash_or_height)?;
+        let snapshot = self.indexer.snapshot_nonfinalized_state();
+
+        let block_data = match hash_or_height_struct {
+            HashOrHeight::Hash(hash) => self
+                .indexer
+                .get_indexed_block_by_hash(&snapshot, &hash.into())
+                .await
+                .map_err(|_error| {
+                    FetchServiceError::RpcError(RpcError::new_from_legacycode(
+                        zebra_rpc::server::error::LegacyCode::InvalidParameter,
+                        "Failed to fetch block data.",
+                    ))
+                })?
+                .ok_or(FetchServiceError::RpcError(
+                    RpcError::new_from_legacycode(
+                        zebra_rpc::server::error::LegacyCode::InvalidParameter,
+                        "Failed to fetch block data.",
+                    )
+                ))?,
+            HashOrHeight::Height(height) => self
+                .indexer
+                .get_indexed_block_by_height(&snapshot, &height.into())
+                .await
+                .map_err(|_error| {
+                    FetchServiceError::RpcError(RpcError::new_from_legacycode(
+                        zebra_rpc::server::error::LegacyCode::InvalidParameter,
+                        "Failed to fetch block data.",
+                    ))
+                })?
+                .ok_or(FetchServiceError::RpcError(
+                    RpcError::new_from_legacycode(
+                        zebra_rpc::server::error::LegacyCode::InvalidParameter,
+                        "Failed to fetch block data.",
+                    )
+                ))?
+        };
+
+        let (sapling, orchard) = self
+        .indexer
+        .get_treestate(block_data.hash())
+        .await
+        .map_err(|_error| {
+            FetchServiceError::RpcError(RpcError::new_from_legacycode(
+                zebra_rpc::server::error::LegacyCode::InvalidParameter,
+                "Failed to fetch treestate.",
+            ))
+        })?;
+        let time: u32 = block_data
+            .data()
+            .time()
+            .try_into()
+            .map_err(|_error| {
+                FetchServiceError::RpcError(RpcError::new_from_legacycode(
+                    zebra_rpc::server::error::LegacyCode::InvalidParameter,
+                    "Block time is out of range for u32.",
+                ))
+            })?;
+
+        #[allow(deprecated)]
+        Ok(GetTreestateResponse::from_parts(
+            (*block_data.hash()).into(),
+            block_data.height().into(),
+            time,
+            sapling,
+            orchard,
+        ))
     }
 
     /// Returns information about a range of Sapling or Orchard subtrees.
@@ -1522,78 +1592,38 @@ impl LightWalletIndexer for FetchServiceSubscriber {
     /// values also (even though they can be obtained using GetBlock).
     /// The block can be specified by either height or hash.
     async fn get_tree_state(&self, request: BlockId) -> Result<TreeState, Self::Error> {
-        let chain_info = self.get_blockchain_info().await?;
-        let hash_or_height = if request.height != 0 {
-            match u32::try_from(request.height) {
-                Ok(height) => {
-                    if height > chain_info.blocks().0 {
-                        return Err(FetchServiceError::TonicStatusError(tonic::Status::out_of_range(
-                            format!(
-                                "Error: Height out of range [{}]. Height requested is greater than the best chain tip [{}].",
-                                height, chain_info.blocks().0,
-                            ))
-                        ));
-                    } else {
-                        height.to_string()
-                    }
-                }
-                Err(_) => {
-                    return Err(FetchServiceError::TonicStatusError(
-                        tonic::Status::invalid_argument(
-                            "Error: Height out of range. Failed to convert to u32.",
-                        ),
-                    ));
-                }
-            }
-        } else {
-            hex::encode(request.hash)
-        };
-        match self.z_get_treestate(hash_or_height).await {
-            Ok(state) => {
-                let (hash, height, time, sapling, orchard) = state.into_parts();
-                Ok(TreeState {
-                    network: chain_info.chain().clone(),
-                    height: height.0 as u64,
-                    hash: hash.to_string(),
-                    time,
-                    sapling_tree: sapling.map(hex::encode).unwrap_or_default(),
-                    orchard_tree: orchard.map(hex::encode).unwrap_or_default(),
-                })
-            }
-            Err(e) => {
-                // TODO: Hide server error from clients before release. Currently useful for dev purposes.
-                Err(FetchServiceError::TonicStatusError(tonic::Status::unknown(
-                    format!("Error: Failed to retrieve treestate from node. Server Error: {e}",),
-                )))
-            }
-        }
+        let hash_or_height = blockid_to_hashorheight(request).ok_or(
+            crate::error::FetchServiceError::TonicStatusError(tonic::Status::invalid_argument(
+                "Invalid hash or height",
+            )),
+        )?;
+        
+        #[allow(deprecated)]
+        let (hash, height, time, sapling, orchard) =
+            <FetchServiceSubscriber as ZcashIndexer>::z_get_treestate(
+                self,
+                hash_or_height.to_string(),
+            )
+            .await?
+            .into_parts();
+        Ok(TreeState {
+            network: self.config.network.to_zebra_network().bip70_network_name(),
+            height: height.0 as u64,
+            hash: hash.to_string(),
+            time,
+            sapling_tree: sapling.map(hex::encode).unwrap_or_default(),
+            orchard_tree: orchard.map(hex::encode).unwrap_or_default(),
+        })
     }
 
     /// GetLatestTreeState returns the note commitment tree state corresponding to the chain tip.
     async fn get_latest_tree_state(&self) -> Result<TreeState, Self::Error> {
-        let chain_info = self.get_blockchain_info().await?;
-        match self
-            .z_get_treestate(chain_info.blocks().0.to_string())
-            .await
-        {
-            Ok(state) => {
-                let (hash, height, time, sapling, orchard) = state.into_parts();
-                Ok(TreeState {
-                    network: chain_info.chain().clone(),
-                    height: height.0 as u64,
-                    hash: hash.to_string(),
-                    time,
-                    sapling_tree: sapling.map(hex::encode).unwrap_or_default(),
-                    orchard_tree: orchard.map(hex::encode).unwrap_or_default(),
-                })
-            }
-            Err(e) => {
-                // TODO: Hide server error from clients before release. Currently useful for dev purposes.
-                Err(FetchServiceError::TonicStatusError(tonic::Status::unknown(
-                    format!("Error: Failed to retrieve treestate from node. Server Error: {e}",),
-                )))
-            }
-        }
+        let latest_block = self.chain_height().await?;
+        self.get_tree_state(BlockId {
+            height: latest_block.0 as u64,
+            hash: vec![],
+        })
+        .await
     }
 
     #[allow(deprecated)]

--- a/packages/zaino-state/src/backends/state.rs
+++ b/packages/zaino-state/src/backends/state.rs
@@ -1474,62 +1474,69 @@ impl ZcashIndexer for StateServiceSubscriber {
             .collect())
     }
 
+    /// NOTE: This method currently has to fetch data from 2 places (get_treestate and get_indexed_block_by_*),
+    ///       If `ValidatorConnector::GetTreeState` was updated to return the additional information
+    ///       required, this second call could be removed, improving the performance of this method.
     async fn z_get_treestate(
         &self,
         hash_or_height: String,
     ) -> Result<GetTreestateResponse, Self::Error> {
-        let mut state = self.read_state_service.clone();
+        let hash_or_height_struct: HashOrHeight = HashOrHeight::from_str(&hash_or_height)?;
+        let snapshot = self.indexer.snapshot_nonfinalized_state();
 
-        let hash_or_height = HashOrHeight::from_str(&hash_or_height)?;
-        let block_header_response = state
-            .ready()
-            .and_then(|service| service.call(ReadRequest::BlockHeader(hash_or_height)))
-            .await?;
-        let (header, hash, height) = match block_header_response {
-            ReadResponse::BlockHeader {
-                header,
-                hash,
-                height,
-                ..
-            } => (header, hash, height),
-            unexpected => {
-                unreachable!("Unexpected response from state service: {unexpected:?}")
-            }
+        let block_data = match hash_or_height_struct {
+            HashOrHeight::Hash(hash) => self
+                .indexer
+                .get_indexed_block_by_hash(&snapshot, &hash.into())
+                .await
+                .map_err(|_error| {
+                    StateServiceError::RpcError(RpcError::new_from_legacycode(
+                        zebra_rpc::server::error::LegacyCode::InvalidParameter,
+                        "Failed to fetch block data.",
+                    ))
+                })?
+                .ok_or(StateServiceError::RpcError(RpcError::new_from_legacycode(
+                    zebra_rpc::server::error::LegacyCode::InvalidParameter,
+                    "Failed to fetch block data.",
+                )))?,
+            HashOrHeight::Height(height) => self
+                .indexer
+                .get_indexed_block_by_height(&snapshot, &height.into())
+                .await
+                .map_err(|_error| {
+                    StateServiceError::RpcError(RpcError::new_from_legacycode(
+                        zebra_rpc::server::error::LegacyCode::InvalidParameter,
+                        "Failed to fetch block data.",
+                    ))
+                })?
+                .ok_or(StateServiceError::RpcError(RpcError::new_from_legacycode(
+                    zebra_rpc::server::error::LegacyCode::InvalidParameter,
+                    "Failed to fetch block data.",
+                )))?,
         };
 
-        let sapling =
-            match NetworkUpgrade::Sapling.activation_height(&self.config.network.into()) {
-                Some(activation_height) if height >= activation_height => Some(
-                    state
-                        .ready()
-                        .and_then(|service| service.call(ReadRequest::SaplingTree(hash_or_height)))
-                        .await?,
-                ),
-                _ => None,
-            }
-            .and_then(|sap_response| {
-                expected_read_response!(sap_response, SaplingTree).map(|tree| tree.to_rpc_bytes())
-            });
-
-        let orchard = match NetworkUpgrade::Nu5.activation_height(&self.config.network.into()) {
-            Some(activation_height) if height >= activation_height => Some(
-                state
-                    .ready()
-                    .and_then(|service| service.call(ReadRequest::OrchardTree(hash_or_height)))
-                    .await?,
-            ),
-            _ => None,
-        }
-        .and_then(|orch_response| {
-            expected_read_response!(orch_response, OrchardTree).map(|tree| tree.to_rpc_bytes())
-        });
+        let (sapling, orchard) = self
+            .indexer
+            .get_treestate(block_data.hash())
+            .await
+            .map_err(|_error| {
+                StateServiceError::RpcError(RpcError::new_from_legacycode(
+                    zebra_rpc::server::error::LegacyCode::InvalidParameter,
+                    "Failed to fetch treestate.",
+                ))
+            })?;
+        let time: u32 = block_data.data().time().try_into().map_err(|_error| {
+            StateServiceError::RpcError(RpcError::new_from_legacycode(
+                zebra_rpc::server::error::LegacyCode::InvalidParameter,
+                "Block time is out of range for u32.",
+            ))
+        })?;
 
         #[allow(deprecated)]
         Ok(GetTreestateResponse::from_parts(
-            hash,
-            height,
-            // If the timestamp is pre-unix epoch, something has gone terribly wrong
-            u32::try_from(header.time.timestamp()).unwrap(),
+            (*block_data.hash()).into(),
+            block_data.height().into(),
+            time,
             sapling,
             orchard,
         ))

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -192,11 +192,43 @@ pub trait ChainIndex {
         hash: types::BlockHash,
     ) -> impl std::future::Future<Output = Result<Option<types::Height>, Self::Error>>;
 
+    /// Returns Some(BlockHash) for the given block height.in the best chain.
+    ///
+    /// Returns None if the specified block height is above the best chain tip.
+    fn get_block_hash(
+        &self,
+        snapshot: &Self::Snapshot,
+        hash: types::Height,
+    ) -> impl std::future::Future<Output = Result<Option<types::BlockHash>, Self::Error>>;
+
+    /// Returns Some(IndexedBlock) for the given block hash.
+    ///
+    /// Returns None if the specified block is not found.
+    ///
+    /// **NOTE: This Method is currently not "passthrough aware", cumulative
+    /// chain work must be made optional to enable this.**
+    fn get_indexed_block_by_hash(
+        &self,
+        snapshot: &Self::Snapshot,
+        target_hash: &types::BlockHash,
+    ) -> impl std::future::Future<Output = Result<Option<IndexedBlock>, Self::Error>>;
+
+    /// Returns Some(IndexedBlock) for the given block height.in the best chain.
+    ///
+    /// Returns None if the specified block height is above the best chain tip.
+    ///
+    /// **NOTE: This Method is currently not "passthrough aware", cumulative
+    /// chain work must be made optional to enable this.**
+    fn get_indexed_block_by_height(
+        &self,
+        snapshot: &Self::Snapshot,
+        target_height: &types::Height,
+    ) -> impl std::future::Future<Output = Result<Option<IndexedBlock>, Self::Error>>;
+
     /// Given inclusive start and end heights, stream all blocks
     /// between the given heights.
     /// Returns None if the specified end height
     /// is greater than the snapshot's tip
-    // TO-TEST
     #[allow(clippy::type_complexity)]
     fn get_block_range(
         &self,
@@ -827,6 +859,76 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
         }
     }
 
+    /// Returns Some(BlockHash) for the given block height.in the best chain.
+    ///
+    /// Returns None if the specified block height is above the best chain tip.
+    async fn get_block_hash(
+        &self,
+        snapshot: &Self::Snapshot,
+        height: types::Height,
+    ) -> Result<Option<types::BlockHash>, Self::Error> {
+        // First check non-finalised state.
+        match snapshot.heights_to_hashes.get(&height).copied() {
+            Some(block_hash) => Ok(Some(block_hash)),
+            // If not found check finalised state.
+            None => match self.finalized_state.get_block_hash(height).await? {
+                Some(hash) => Ok(Some(hash)),
+                None => {
+                    // If not found try to fetch from backing validator (*passthrough*).
+                    //
+                    // Note this requires fetching the full block from the backing node.
+                    match self
+                        .source()
+                        .get_block(HashOrHeight::Height(height.into()))
+                        .await
+                        .map_err(ChainIndexError::backing_validator)?
+                    {
+                        Some(block) => Ok(Some(block.hash().into())),
+                        None => Ok(None),
+                    }
+                }
+            },
+        }
+    }
+
+    /// Returns Some(IndexedBlock) for the given block hash.
+    ///
+    /// Returns None if the specified block is not found.
+    ///
+    /// **NOTE: This Method is currently not "passthrough aware", cumulative
+    /// chain work must be made optional to enable this.**
+    async fn get_indexed_block_by_hash(
+        &self,
+        snapshot: &Self::Snapshot,
+        target_hash: &types::BlockHash,
+    ) -> Result<Option<IndexedBlock>, Self::Error> {
+        match snapshot.get_chainblock_by_hash(target_hash) {
+            Some(block) => Ok(Some(block.clone())),
+            None => match self.get_block_height(snapshot, *target_hash).await {
+                Ok(Some(height)) => Ok(self.finalized_state.get_chain_block(height).await?),
+                Ok(None) => Ok(None),
+                Err(e) => Err(e),
+            },
+        }
+    }
+
+    /// Returns Some(IndexedBlock) for the given block height.in the best chain.
+    ///
+    /// Returns None if the specified block height is above the best chain tip.
+    ///
+    /// **NOTE: This Method is currently not "passthrough aware", cumulative
+    /// chain work must be made optional to enable this.**
+    async fn get_indexed_block_by_height(
+        &self,
+        snapshot: &Self::Snapshot,
+        target_height: &types::Height,
+    ) -> Result<Option<IndexedBlock>, Self::Error> {
+        match snapshot.get_chainblock_by_height(target_height) {
+            Some(block) => Ok(Some(block.clone())),
+            None => Ok(self.finalized_state.get_chain_block(*target_height).await?),
+        }
+    }
+
     /// Given inclusive start and end heights, stream all blocks
     /// between the given heights.
     /// Returns None if the specified start height
@@ -911,6 +1013,9 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
     ///
     /// Returns None if the specified height
     /// is greater than the snapshot's tip
+    ///
+    /// **NOTE: This Method is currently not "passthrough aware", this should be added by
+    /// fetching block data from the backing validator when not locally available.**
     async fn get_compact_block(
         &self,
         nonfinalized_snapshot: &Self::Snapshot,
@@ -957,6 +1062,9 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
     ///   The original transaction index is preserved in `CompactTx.index`.
     /// - `PoolTypeFilter::default()` preserves the legacy behaviour (only Sapling and Orchard
     ///   components are populated).
+    ///
+    /// **NOTE: This Method is currently not "passthrough aware", this should be added by
+    /// fetching block data from the backing validator when not locally available.**
     #[allow(clippy::type_complexity)]
     async fn get_compact_block_stream(
         &self,

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -518,9 +518,8 @@ impl ZainoDB {
         let sapling_activation_height = zebra_chain::parameters::NetworkUpgrade::Sapling
             .activation_height(&zebra_network)
             .expect("Sapling activation height must be set");
-        let nu5_activation_height = zebra_chain::parameters::NetworkUpgrade::Nu5
-            .activation_height(&zebra_network)
-            .expect("NU5 activation height must be set");
+        let nu5_activation_height =
+            zebra_chain::parameters::NetworkUpgrade::Nu5.activation_height(&zebra_network);
 
         let mut parent_chainwork = if db_height_opt.is_none() {
             ChainWork::from_u256(0.into())
@@ -602,7 +601,10 @@ impl ZainoDB {
                 let (sapling_opt, orchard_opt) =
                     source.get_commitment_tree_roots(block_hash).await?;
                 let is_sapling_active = height_int >= sapling_activation_height.0;
-                let is_orchard_active = height_int >= nu5_activation_height.0;
+                let is_orchard_active = nu5_activation_height
+                    .map_or(false, |nu5_activation_height| {
+                        height_int >= nu5_activation_height.0
+                    });
                 let (sapling_root, sapling_size) = if is_sapling_active {
                     sapling_opt.ok_or_else(|| {
                         FinalisedStateError::BlockchainSourceError(

--- a/packages/zaino-state/src/chain_index/source.rs
+++ b/packages/zaino-state/src/chain_index/source.rs
@@ -8,13 +8,14 @@ use crate::chain_index::{
 };
 use async_trait::async_trait;
 use futures::{future::join, TryFutureExt as _};
+use incrementalmerkletree::frontier::CommitmentTree;
 use tower::{Service, ServiceExt as _};
 use zaino_common::Network;
 use zaino_fetch::jsonrpsee::{
     connector::{JsonRpSeeConnector, RpcRequestError},
     response::{GetBlockError, GetBlockResponse, GetTransactionResponse, GetTreestateResponse},
 };
-use zcash_primitives::merkle_tree::read_commitment_tree;
+use zcash_primitives::merkle_tree::{read_commitment_tree, write_commitment_tree};
 use zebra_chain::{
     block::TryIntoHeight, serialization::ZcashDeserialize, subtree::NoteCommitmentSubtreeIndex,
 };
@@ -271,23 +272,29 @@ impl BlockchainSource for ValidatorConnector {
                     sapling, orchard, ..
                 } = tree_responses;
                 let sapling_frontier = sapling
-                    .commitments()
-                    .final_state()
-                    .as_ref()
-                    .map(|final_state| {
-                        read_commitment_tree::<sapling_crypto::Node, _, 32>(final_state.as_slice())
-                    })
+                    .map_or_else(
+                        || Some(Ok(CommitmentTree::empty())),
+                        |t| {
+                            t.commitments().final_state().as_ref().map(|final_state| {
+                                read_commitment_tree::<sapling_crypto::Node, _, 32>(
+                                    final_state.as_slice(),
+                                )
+                            })
+                        },
+                    )
                     .transpose()
                     .map_err(|e| BlockchainSourceError::Unrecoverable(format!("io error: {e}")))?;
                 let orchard_frontier = orchard
-                    .commitments()
-                    .final_state()
-                    .as_ref()
-                    .map(|final_state| {
-                        read_commitment_tree::<zebra_chain::orchard::tree::Node, _, 32>(
-                            final_state.as_slice(),
-                        )
-                    })
+                    .map_or_else(
+                        || Some(Ok(CommitmentTree::empty())),
+                        |t| {
+                            t.commitments().final_state().as_ref().map(|final_state| {
+                                read_commitment_tree::<zebra_chain::orchard::tree::Node, _, 32>(
+                                    final_state.as_slice(),
+                                )
+                            })
+                        },
+                    )
                     .transpose()
                     .map_err(|e| BlockchainSourceError::Unrecoverable(format!("io error: {e}")))?;
                 let sapling_root = sapling_frontier
@@ -413,11 +420,30 @@ impl BlockchainSource for ValidatorConnector {
                         )
                     })?;
 
-                let sapling = treestate.sapling.commitments().final_state();
+                let sapling = treestate.sapling.map_or_else(
+                    || {
+                        let mut tree = vec![];
+                        write_commitment_tree(&sapling_crypto::CommitmentTree::empty(), &mut tree)
+                            .expect("can write to Vec");
+                        Some(tree)
+                    },
+                    |t| t.commitments().final_state().clone(),
+                );
 
-                let orchard = treestate.orchard.commitments().final_state();
+                let orchard = treestate.orchard.map_or_else(
+                    || {
+                        let mut tree = vec![];
+                        write_commitment_tree(
+                            &CommitmentTree::<zebra_chain::orchard::tree::Node, 32>::empty(),
+                            &mut tree,
+                        )
+                        .expect("can write to Vec");
+                        Some(tree)
+                    },
+                    |t| t.commitments().final_state().clone(),
+                );
 
-                Ok((sapling.clone(), orchard.clone()))
+                Ok((sapling, orchard))
             }
         }
     }


### PR DESCRIPTION
This PR contains both the treestate regtest fixes in the ChainIndex required by Zallet (originally in #943 ) and the downstream fixes required to properly propagate this change and keep zainod's behaviour consistent (see below).

Changes added on top of #943 (which has already been reviewed and approved):
- StateService and FetchService implementations of `z_get_treestate`, `get_tree_state` and `get_latest_tree_state` diverged, all implementations have been updated to use the chain index rather than fetching data directly with the `JsonRpSeeConnector` or `ReadStateService`, keeping implementations consistent across backends, readying them for the planned merge of the `StateService` and `FetchService.`
- Updatd tests to be less flaky: they now use the actual chain height to query data rather than a set height that may not have synced through the stack at call time.
- Rebases commits on top of dev to avoid merge conflicts.

** Replaces #943 **