### PR TITLE
Add security vulnerability gate to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/architecture.yaml
+++ b/.github/ISSUE_TEMPLATE/architecture.yaml
@@ -9,6 +9,20 @@ body:
 
         These issues help track technical debt and guide future development.
 
+  # Security gate — do NOT remove.
+  # Vulnerabilities must be reported privately via https://github.com/zingolabs/zaino/security
+  - type: checkboxes
+    id: not_a_vulnerability
+    attributes:
+      label: Security check
+      description: >
+        If this is a security vulnerability, **stop here** and
+        [report it privately](https://github.com/zingolabs/zaino/security) instead.
+        Public issues must not contain vulnerability details.
+      options:
+        - label: This issue is **not** a security vulnerability.
+          required: true
+
   - type: textarea
     id: observation
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -9,6 +9,20 @@ body:
 
         **Before submitting**, please check if a similar issue already exists.
 
+  # Security gate — do NOT remove.
+  # Vulnerabilities must be reported privately via https://github.com/zingolabs/zaino/security
+  - type: checkboxes
+    id: not_a_vulnerability
+    attributes:
+      label: Security check
+      description: >
+        If this is a security vulnerability, **stop here** and
+        [report it privately](https://github.com/zingolabs/zaino/security) instead.
+        Public issues must not contain vulnerability details.
+      options:
+        - label: This issue is **not** a security vulnerability.
+          required: true
+
   - type: dropdown
     id: usage
     attributes:

--- a/.github/ISSUE_TEMPLATE/code_smell.yaml
+++ b/.github/ISSUE_TEMPLATE/code_smell.yaml
@@ -9,6 +9,20 @@ body:
 
         Code smells are indicators of deeper issues - they may or may not need immediate action.
 
+  # Security gate — do NOT remove.
+  # Vulnerabilities must be reported privately via https://github.com/zingolabs/zaino/security
+  - type: checkboxes
+    id: not_a_vulnerability
+    attributes:
+      label: Security check
+      description: >
+        If this is a security vulnerability, **stop here** and
+        [report it privately](https://github.com/zingolabs/zaino/security) instead.
+        Public issues must not contain vulnerability details.
+      options:
+        - label: This issue is **not** a security vulnerability.
+          required: true
+
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/zingolabs/zaino/security
+    about: Found a security vulnerability? Report it privately — do NOT open a public issue.
   - name: Questions & Discussion
     url: https://github.com/zingolabs/zaino/discussions
     about: Ask questions or start a discussion (if Discussions is enabled)

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -9,6 +9,20 @@ body:
 
         Feature requests help us understand what the community needs.
 
+  # Security gate — do NOT remove.
+  # Vulnerabilities must be reported privately via https://github.com/zingolabs/zaino/security
+  - type: checkboxes
+    id: not_a_vulnerability
+    attributes:
+      label: Security check
+      description: >
+        If this is a security vulnerability, **stop here** and
+        [report it privately](https://github.com/zingolabs/zaino/security) instead.
+        Public issues must not contain vulnerability details.
+      options:
+        - label: This issue is **not** a security vulnerability.
+          required: true
+
   - type: dropdown
     id: usage
     attributes:

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -9,6 +9,20 @@ body:
 
         Tasks are actionable items with a clear definition of done.
 
+  # Security gate — do NOT remove.
+  # Vulnerabilities must be reported privately via https://github.com/zingolabs/zaino/security
+  - type: checkboxes
+    id: not_a_vulnerability
+    attributes:
+      label: Security check
+      description: >
+        If this is a security vulnerability, **stop here** and
+        [report it privately](https://github.com/zingolabs/zaino/security) instead.
+        Public issues must not contain vulnerability details.
+      options:
+        - label: This issue is **not** a security vulnerability.
+          required: true
+
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
## Summary
- Adds a "Security Vulnerability" contact link in `config.yml` that redirects users to the [private security advisory page](https://github.com/zingolabs/zaino/security) instead of opening a public issue
- Adds a required "This issue is **not** a security vulnerability" checkbox to all 5 issue templates (bug report, feature request, code smell, task, architecture) so users must explicitly confirm before submitting

## Test plan
- [ ] Open the [new issue chooser](https://github.com/zingolabs/zaino/issues/new/choose) and verify the "Security Vulnerability" entry appears and links to the security page
- [ ] Open each issue template and verify the security checkbox appears and is required