### PR TITLE
[#1058] CompactBlock in GetBlockRange reports different version from LightWalletD

### DIFF
--- a/packages/zaino-fetch/src/chain/block.rs
+++ b/packages/zaino-fetch/src/chain/block.rs
@@ -409,7 +409,7 @@ impl FullBlock {
         let header = Vec::new();
 
         let compact_block = CompactBlock {
-            proto_version: 4,
+            proto_version: 0,
             height: self.height as u64,
             hash: self.hdr.cached_hash.clone(),
             prev_hash: self.hdr.raw_block_header.hash_prev_block.clone(),


### PR DESCRIPTION
closes #1058

