### PR TITLE
fix: add explicit docker.io registry to all container image references

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: arc-sh-runners
     needs: compute-tag
     container:
-      image: zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
+      image: docker.io/zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -55,7 +55,7 @@ jobs:
     runs-on: arc-sh-runners
     needs: compute-tag
     container:
-      image: zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
+      image: docker.io/zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -80,7 +80,7 @@ jobs:
     runs-on: arc-sh-runners
     needs: compute-tag
     container:
-      image: zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
+      image: docker.io/zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -105,7 +105,7 @@ jobs:
     runs-on: arc-sh-runners
     needs: compute-tag
     container:
-      image: zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
+      image: docker.io/zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -130,7 +130,7 @@ jobs:
     runs-on: arc-sh-runners
     needs: compute-tag
     container:
-      image: zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
+      image: docker.io/zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -142,7 +142,7 @@ jobs:
     name: Cargo Hack Check
     needs: compute-tag
     container:
-      image: zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
+      image: docker.io/zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
     runs-on: arc-sh-runners
     steps:
       - name: Checkout repository
@@ -177,7 +177,7 @@ jobs:
     name: Cargo Hack Build
     needs: compute-tag
     container:
-      image: zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
+      image: docker.io/zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
     runs-on: arc-sh-runners
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     name: Build test artifacts
     needs: compute-tag
     container:
-      image: zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
+      image: docker.io/zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
     runs-on: arc-sh-runners
     # Skip on PRs until self-hosted runner is available
     if: github.event_name != 'pull_request' && github.event.pull_request.draft == false
@@ -83,7 +83,7 @@ jobs:
     needs: [compute-tag, build-test-artifacts]
     runs-on: arc-sh-runners
     container:
-      image: zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
+      image: docker.io/zingodevops/zaino-ci:${{ needs.compute-tag.outputs.image-tag }}
     strategy:
       fail-fast: false
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG HOME=/home/container_user
 ############################
 # Builder
 ############################
-FROM rust:${RUST_VERSION}-bookworm AS builder
+FROM docker.io/library/rust:${RUST_VERSION}-bookworm AS builder
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 WORKDIR /app
 
@@ -42,7 +42,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 ############################
 # Runtime
 ############################
-FROM debian:bookworm-slim AS runtime
+FROM docker.io/library/debian:bookworm-slim AS runtime
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ARG UID

--- a/integration-tests/test_environment/Containerfile
+++ b/integration-tests/test_environment/Containerfile
@@ -25,7 +25,7 @@ FROM docker.io/zodlinc/zcash:v${ZCASH_VERSION} AS zcashd-downloader
 # === BUILDERS ===
 ########################
 
-FROM rust:${RUST_VERSION}-trixie AS zebra-builder
+FROM docker.io/library/rust:${RUST_VERSION}-trixie AS zebra-builder
 
 ARG ZEBRA_VERSION
 RUN apt-get update
@@ -40,7 +40,7 @@ RUN git checkout "${ZEBRA_VERSION}"
 RUN cargo build --release --bin zebrad
 RUN cp target/release/zebrad /tmp/zebrad
 
-FROM debian:trixie AS zcashd-builder
+FROM docker.io/library/debian:trixie AS zcashd-builder
 
 ARG ZCASH_VERSION
 RUN apt-get update && apt-get install -y \
@@ -56,7 +56,7 @@ RUN cp src/zcashd src/zcash-cli /tmp/
 # === BASE RUNTIME IMAGE ===
 ########################
 
-FROM rust:${RUST_VERSION}-trixie AS base
+FROM docker.io/library/rust:${RUST_VERSION}-trixie AS base
 
 ARG UID
 ARG GID

--- a/integration-tests/test_environment/Containerfile
+++ b/integration-tests/test_environment/Containerfile
@@ -17,8 +17,9 @@ ARG CARGO_HOME="/usr/local/cargo"
 # === DOWNLOADERS ===
 ########################
 
-FROM zfnd/zebra:${ZEBRA_VERSION} AS zebra-downloader
-FROM zodlinc/zcash:v${ZCASH_VERSION} AS zcashd-downloader
+FROM docker.io/zfnd/zebra:${ZEBRA_VERSION} AS zebra-downloader
+FROM docker.io/zodlinc/zcash:v${ZCASH_VERSION} AS zcashd-downloader
+
 
 ########################
 # === BUILDERS ===


### PR DESCRIPTION
Unqualified image references in FROM lines and CI workflow container
definitions rely on the runtime's default registry search order, which
differs between Docker and Podman. This adds the explicit `docker.io/`
(or `docker.io/library/` for official images) prefix to every image
reference across the Dockerfile, the integration-test Containerfile,
and both CI workflow files, so builds resolve identically regardless
of which container runtime is used.