### PR TITLE
Run container tests without final-stage root

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -132,6 +132,7 @@ script.post = ""
 
 [tasks.init-podman-volumes]
 description = "Initialize named podman volumes for container builds"
+script_runner = "bash"
 script = '''
 for vol in zaino-container-target zaino-cargo-git zaino-cargo-registry; do
     if ! podman volume inspect "$vol" >/dev/null 2>&1; then
@@ -178,6 +179,7 @@ echo "CONTAINER_DIR_HASH=$HASH"
 [tasks.ensure-image-exists]
 description = "Ensure the image exists locally, building if needed"
 dependencies = ["init-podman-volumes"]
+script_runner = "bash"
 extend = "base-script"
 script.main = '''
 if ! podman image inspect ${IMAGE_NAME}:${TAG} > /dev/null 2>&1; then

--- a/integration-tests/test_environment/Containerfile
+++ b/integration-tests/test_environment/Containerfile
@@ -67,6 +67,7 @@ ARG CARGO_HOME
 
 ENV CARGO_HOME=${CARGO_HOME}
 ENV CARGO_TERM_COLOR=always
+ENV PATH="${CARGO_HOME}/bin:${PATH}"
 ENV PROTOC=/usr/bin/protoc
 ENV ROCKSDB_LIB_DIR=/usr/lib/x86_64-linux-gnu
 
@@ -99,15 +100,14 @@ RUN rustup toolchain install ${RUST_VERSION} --profile minimal \
         --component rustfmt --component clippy && \
     rustup default ${RUST_VERSION}
 
-# Create artifacts directory
-RUN mkdir -p /home/container_user/artifacts
+# Create user-owned runtime directories
+RUN mkdir -p ${HOME}/artifacts ${HOME}/bin ${CARGO_HOME} && \
+    chown -R ${UID}:${GID} ${HOME} ${CARGO_HOME}
 
 # Copy and prepare entrypoint script
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+COPY --chown=${UID}:${GID} --chmod=0755 entrypoint.sh ${HOME}/bin/entrypoint.sh
 
 WORKDIR ${HOME}/zaino
-RUN chown -R ${UID}:${GID} ${HOME}
 USER ${USER}
 
 ########################
@@ -119,15 +119,13 @@ ARG ZCASH_VERSION
 ARG ZEBRA_VERSION
 LABEL org.zaino.test-artifacts.versions.zcashd="${ZCASH_VERSION}"
 LABEL org.zaino.test-artifacts.versions.zebra="${ZEBRA_VERSION}"
-USER root
-COPY --from=zcashd-downloader /usr/local/bin/zcashd ${HOME}/artifacts/
-COPY --from=zcashd-downloader /usr/local/bin/zcash-cli ${HOME}/artifacts/
-COPY --from=zebra-downloader /usr/local/bin/zebrad ${HOME}/artifacts/
-RUN chmod +x ${HOME}/artifacts/zcashd ${HOME}/artifacts/zcash-cli ${HOME}/artifacts/zebrad
-RUN cargo install cargo-nextest --locked --verbose --root /usr/local && \
-    cargo install rust-script --locked --verbose --root /usr/local
+COPY --chown=container_user:container_user --chmod=0755 --from=zcashd-downloader /usr/local/bin/zcashd /home/container_user/artifacts/
+COPY --chown=container_user:container_user --chmod=0755 --from=zcashd-downloader /usr/local/bin/zcash-cli /home/container_user/artifacts/
+COPY --chown=container_user:container_user --chmod=0755 --from=zebra-downloader /usr/local/bin/zebrad /home/container_user/artifacts/
+RUN cargo install cargo-nextest --locked --verbose --root ${CARGO_HOME} && \
+    cargo install rust-script --locked --verbose --root ${CARGO_HOME}
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/home/container_user/bin/entrypoint.sh"]
 CMD ["/bin/bash"]
 
 FROM base AS final-zcashd-source
@@ -135,15 +133,13 @@ ARG ZCASH_VERSION
 ARG ZEBRA_VERSION
 LABEL org.zaino.test-artifacts.versions.zcashd="${ZCASH_VERSION}"
 LABEL org.zaino.test-artifacts.versions.zebra="${ZEBRA_VERSION}"
-USER root
-COPY --from=zcashd-builder /tmp/zcashd ${HOME}/artifacts/
-COPY --from=zcashd-builder /tmp/zcash-cli ${HOME}/artifacts/
-COPY --from=zebra-downloader /usr/local/bin/zebrad ${HOME}/artifacts/
-RUN chmod +x ${HOME}/artifacts/zcashd ${HOME}/artifacts/zcash-cli ${HOME}/artifacts/zebrad
-RUN cargo install cargo-nextest --locked --verbose --root /usr/local && \
-    cargo install rust-script --locked --verbose --root /usr/local
+COPY --chown=container_user:container_user --chmod=0755 --from=zcashd-builder /tmp/zcashd /home/container_user/artifacts/
+COPY --chown=container_user:container_user --chmod=0755 --from=zcashd-builder /tmp/zcash-cli /home/container_user/artifacts/
+COPY --chown=container_user:container_user --chmod=0755 --from=zebra-downloader /usr/local/bin/zebrad /home/container_user/artifacts/
+RUN cargo install cargo-nextest --locked --verbose --root ${CARGO_HOME} && \
+    cargo install rust-script --locked --verbose --root ${CARGO_HOME}
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/home/container_user/bin/entrypoint.sh"]
 CMD ["/bin/bash"]
 
 FROM base AS final-zebrad-source
@@ -151,15 +147,13 @@ ARG ZCASH_VERSION
 ARG ZEBRA_VERSION
 LABEL org.zaino.test-artifacts.versions.zcashd="${ZCASH_VERSION}"
 LABEL org.zaino.test-artifacts.versions.zebra="${ZEBRA_VERSION}"
-USER root
-COPY --from=zcashd-downloader /usr/local/bin/zcashd ${HOME}/artifacts/
-COPY --from=zcashd-downloader /usr/local/bin/zcash-cli ${HOME}/artifacts/
-COPY --from=zebra-builder /tmp/zebrad ${HOME}/artifacts/
-RUN chmod +x ${HOME}/artifacts/zcashd ${HOME}/artifacts/zcash-cli ${HOME}/artifacts/zebrad
-RUN cargo install cargo-nextest --locked --verbose --root /usr/local && \
-    cargo install rust-script --locked --verbose --root /usr/local
+COPY --chown=container_user:container_user --chmod=0755 --from=zcashd-downloader /usr/local/bin/zcashd /home/container_user/artifacts/
+COPY --chown=container_user:container_user --chmod=0755 --from=zcashd-downloader /usr/local/bin/zcash-cli /home/container_user/artifacts/
+COPY --chown=container_user:container_user --chmod=0755 --from=zebra-builder /tmp/zebrad /home/container_user/artifacts/
+RUN cargo install cargo-nextest --locked --verbose --root ${CARGO_HOME} && \
+    cargo install rust-script --locked --verbose --root ${CARGO_HOME}
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/home/container_user/bin/entrypoint.sh"]
 CMD ["/bin/bash"]
 
 FROM base AS final-all-source
@@ -167,13 +161,11 @@ ARG ZCASH_VERSION
 ARG ZEBRA_VERSION
 LABEL org.zaino.test-artifacts.versions.zcashd="${ZCASH_VERSION}"
 LABEL org.zaino.test-artifacts.versions.zebra="${ZEBRA_VERSION}"
-USER root
-COPY --from=zcashd-builder /tmp/zcashd ${HOME}/artifacts/
-COPY --from=zcashd-builder /tmp/zcash-cli ${HOME}/artifacts/
-COPY --from=zebra-builder /tmp/zebrad ${HOME}/artifacts/
-RUN chmod +x ${HOME}/artifacts/zcashd ${HOME}/artifacts/zcash-cli ${HOME}/artifacts/zebrad
-RUN cargo install cargo-nextest --locked --verbose --root /usr/local && \
-    cargo install rust-script --locked --verbose --root /usr/local
+COPY --chown=container_user:container_user --chmod=0755 --from=zcashd-builder /tmp/zcashd /home/container_user/artifacts/
+COPY --chown=container_user:container_user --chmod=0755 --from=zcashd-builder /tmp/zcash-cli /home/container_user/artifacts/
+COPY --chown=container_user:container_user --chmod=0755 --from=zebra-builder /tmp/zebrad /home/container_user/artifacts/
+RUN cargo install cargo-nextest --locked --verbose --root ${CARGO_HOME} && \
+    cargo install rust-script --locked --verbose --root ${CARGO_HOME}
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/home/container_user/bin/entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -2,7 +2,8 @@
 
 #[cfg(feature = "transparent_address_history_experimental")]
 use hex::ToHex;
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 use zaino_common::network::ActivationHeights;
 use zaino_common::{DatabaseConfig, Network, StorageConfig};
@@ -26,6 +27,22 @@ use crate::{BlockCacheConfig, BlockMetadata, BlockWithMetadata, ChainWork, Heigh
 
 #[cfg(feature = "transparent_address_history_experimental")]
 use crate::{AddrScript, Outpoint};
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let dst_path = dst.join(entry.file_name());
+
+        if file_type.is_dir() {
+            copy_dir_recursive(&entry.path(), &dst_path)?;
+        } else {
+            fs::copy(entry.path(), dst_path)?;
+        }
+    }
+    Ok(())
+}
 
 pub(crate) async fn spawn_v1_zaino_db(
     source: MockchainSource,
@@ -216,12 +233,16 @@ async fn save_db_to_file_and_reload() {
 async fn load_db_backend_from_file() {
     init_tracing();
 
-    let db_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    let fixture_db_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("src")
         .join("chain_index")
         .join("tests")
         .join("vectors")
         .join("v1_test_db");
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("v1_test_db");
+    copy_dir_recursive(&fixture_db_path, &db_path).unwrap();
+
     let config = BlockCacheConfig {
         storage: StorageConfig {
             database: DatabaseConfig {


### PR DESCRIPTION
## Summary

Fix `makers container-test` so the test container setup follows the non-root container policy and the test suite no longer depends on mutating checked-in LMDB fixtures.

This PR:

- Adds `script_runner = "bash"` to cargo-make tasks that use Bash syntax or inherit a Bash-only prelude.
- Keeps the final test-image targets on `container_user` instead of switching back to `USER root`.
- Copies test artifacts and the entrypoint with `COPY --chown=container_user:container_user --chmod=0755` instead of copying as root and chmodding afterwards.
- Installs `cargo-nextest` and `rust-script` into the configured cargo home, made writable before switching to `container_user`.
- Copies the v1 LMDB fixture to a temp directory before opening it, avoiding writes beside checked-in fixture files.

## Validation

```text
makers container-test
```

Result:

```text
232 tests run: 232 passed, 2 skipped
```

closes #1077