### PR TITLE
Add getspentinfo JSON-RPC support

### DIFF
--- a/.env.testing-artifacts
+++ b/.env.testing-artifacts
@@ -3,7 +3,7 @@
 # tools/scripts/get-rust-version.sh.
 
 # zcashd Git tag (https://github.com/zcash/zcash/releases)
-ZCASH_VERSION=6.12.1
+ZCASH_VERSION=6.12.2
 
 # zebrad version tag for pulling zfnd/zebra:<version>
-ZEBRA_VERSION=4.3.1
+ZEBRA_VERSION=4.4.1

--- a/packages/zaino-fetch/src/jsonrpsee/connector.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/connector.rs
@@ -36,9 +36,10 @@ use crate::jsonrpsee::{
         z_validate_address::{ZValidateAddressError, ZValidateAddressResponse},
         GetBalanceError, GetBalanceResponse, GetBlockCountResponse, GetBlockError, GetBlockHash,
         GetBlockResponse, GetBlockchainInfoResponse, GetInfoResponse, GetMempoolInfoResponse,
-        GetSubtreesError, GetSubtreesResponse, GetTransactionResponse, GetTreestateError,
-        GetTreestateResponse, GetTxOutResponse, GetUtxosError, GetUtxosResponse,
-        SendTransactionError, SendTransactionResponse, TxidsError, TxidsResponse,
+        GetSpentInfoError, GetSpentInfoRequest, GetSpentInfoResponse, GetSubtreesError,
+        GetSubtreesResponse, GetTransactionResponse, GetTreestateError, GetTreestateResponse,
+        GetTxOutResponse, GetUtxosError, GetUtxosResponse, SendTransactionError,
+        SendTransactionResponse, TxidsError, TxidsResponse,
     },
 };
 
@@ -806,6 +807,22 @@ impl JsonRpSeeConnector {
         };
 
         self.send_request("gettxout", params).await
+    }
+
+    /// Returns the transaction id, input index, and block height where an output is spent.
+    ///
+    /// zcashd reference: [`getspentinfo`](https://zcash.github.io/rpc/getspentinfo.html)
+    /// method: post
+    /// tags: blockchain
+    ///
+    /// zcashd 6.12.2 also returns an undocumented `height` field.
+    pub async fn get_spent_info(
+        &self,
+        request: GetSpentInfoRequest,
+    ) -> Result<GetSpentInfoResponse, RpcRequestError<GetSpentInfoError>> {
+        let params = vec![serde_json::to_value(request).map_err(RpcRequestError::JsonRpc)?];
+
+        self.send_request("getspentinfo", params).await
     }
 
     /// Returns the transaction ids made by the provided transparent addresses.

--- a/packages/zaino-fetch/src/jsonrpsee/response.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response.rs
@@ -120,6 +120,74 @@ impl ResponseToError for GetTxOutResponse {
     type RpcError = Infallible;
 }
 
+/// Request parameters for the `getspentinfo` RPC request.
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct GetSpentInfoRequest {
+    /// The hex string of the transaction id containing the output.
+    pub txid: String,
+    /// The output index in the previous transaction's `vout` array.
+    pub index: u32,
+}
+
+impl GetSpentInfoRequest {
+    /// Creates a new `getspentinfo` request.
+    pub fn new(txid: String, index: u32) -> Self {
+        Self { txid, index }
+    }
+}
+
+/// Response to a `getspentinfo` RPC request.
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct GetSpentInfoResponse {
+    /// Transaction id of the transaction that spent the requested output.
+    pub txid: String,
+    /// Input index in the spending transaction's `vin` array.
+    pub index: u32,
+    /// Height of the block containing the spending transaction.
+    ///
+    /// This field is returned by zcashd 6.12.2 but omitted from the public 6.2.0 RPC page.
+    pub height: u32,
+}
+
+impl GetSpentInfoResponse {
+    /// Creates a new `getspentinfo` response.
+    pub fn new(txid: String, index: u32, height: u32) -> Self {
+        Self {
+            txid,
+            index,
+            height,
+        }
+    }
+}
+
+/// Error type for the `getspentinfo` RPC request.
+#[derive(Debug, thiserror::Error)]
+pub enum GetSpentInfoError {
+    /// The requested output is not known as spent.
+    #[error("{0}")]
+    UnableToGetSpentInfo(String),
+
+    /// The request parameters were invalid.
+    #[error("{0}")]
+    InvalidParameter(String),
+}
+
+impl ResponseToError for GetSpentInfoResponse {
+    type RpcError = GetSpentInfoError;
+}
+
+impl TryFrom<super::connector::RpcError> for GetSpentInfoError {
+    type Error = super::connector::RpcError;
+
+    fn try_from(value: super::connector::RpcError) -> Result<Self, Self::Error> {
+        match value.code {
+            -5 => Ok(Self::UnableToGetSpentInfo(value.message)),
+            -8 => Ok(Self::InvalidParameter(value.message)),
+            _ => Err(value),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(untagged)]
 /// A wrapper to allow both types of error timestamp

--- a/packages/zaino-fetch/src/jsonrpsee/response.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response.rs
@@ -129,13 +129,6 @@ pub struct GetSpentInfoRequest {
     pub index: u32,
 }
 
-impl GetSpentInfoRequest {
-    /// Creates a new `getspentinfo` request.
-    pub fn new(txid: String, index: u32) -> Self {
-        Self { txid, index }
-    }
-}
-
 /// Response to a `getspentinfo` RPC request.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct GetSpentInfoResponse {
@@ -147,17 +140,6 @@ pub struct GetSpentInfoResponse {
     ///
     /// This field is returned by zcashd 6.12.2 but omitted from the public 6.2.0 RPC page.
     pub height: u32,
-}
-
-impl GetSpentInfoResponse {
-    /// Creates a new `getspentinfo` response.
-    pub fn new(txid: String, index: u32, height: u32) -> Self {
-        Self {
-            txid,
-            index,
-            height,
-        }
-    }
 }
 
 /// Error type for the `getspentinfo` RPC request.
@@ -185,6 +167,104 @@ impl TryFrom<super::connector::RpcError> for GetSpentInfoError {
             -8 => Ok(Self::InvalidParameter(value.message)),
             _ => Err(value),
         }
+    }
+}
+
+#[cfg(test)]
+mod get_spent_info {
+    use super::{GetSpentInfoError, GetSpentInfoRequest, GetSpentInfoResponse};
+    use crate::jsonrpsee::connector::RpcError;
+    use serde_json::json;
+
+    fn rpc_error(code: i64, message: &str) -> RpcError {
+        RpcError {
+            code,
+            message: message.to_string(),
+            data: None,
+        }
+    }
+
+    #[test]
+    fn request_serializes_as_single_object_with_txid_and_index() {
+        let request = GetSpentInfoRequest {
+            txid: "deadbeef".to_string(),
+            index: 7,
+        };
+        let json_value = serde_json::to_value(&request).expect("serialize request");
+        assert_eq!(json_value, json!({ "txid": "deadbeef", "index": 7 }));
+    }
+
+    #[test]
+    fn request_round_trips_through_json() {
+        let request = GetSpentInfoRequest {
+            txid: "abcd1234".to_string(),
+            index: 0,
+        };
+        let json_value = serde_json::to_value(&request).expect("serialize request");
+        let round_tripped: GetSpentInfoRequest =
+            serde_json::from_value(json_value).expect("deserialize request");
+        assert_eq!(round_tripped, request);
+    }
+
+    // zcashd 6.12.2 returns the undocumented `height` field alongside txid/index.
+    // This test pins that wire shape so a regression breaks loudly.
+    #[test]
+    fn response_deserializes_zcashd_payload_with_height() {
+        let json_value = json!({
+            "txid": "feed1234",
+            "index": 3,
+            "height": 1_234_567,
+        });
+        let response: GetSpentInfoResponse =
+            serde_json::from_value(json_value).expect("deserialize response");
+        assert_eq!(response.txid, "feed1234");
+        assert_eq!(response.index, 3);
+        assert_eq!(response.height, 1_234_567);
+    }
+
+    #[test]
+    fn response_round_trips_through_json() {
+        let response = GetSpentInfoResponse {
+            txid: "cafebabe".to_string(),
+            index: 1,
+            height: 42,
+        };
+        let json_value = serde_json::to_value(&response).expect("serialize response");
+        let round_tripped: GetSpentInfoResponse =
+            serde_json::from_value(json_value).expect("deserialize response");
+        assert_eq!(round_tripped, response);
+    }
+
+    #[test]
+    fn error_maps_minus_five_to_unable_to_get_spent_info() {
+        let mapped = GetSpentInfoError::try_from(rpc_error(-5, "Unable to get spent info"))
+            .expect("expected UnableToGetSpentInfo");
+        match mapped {
+            GetSpentInfoError::UnableToGetSpentInfo(message) => {
+                assert_eq!(message, "Unable to get spent info");
+            }
+            other => panic!("expected UnableToGetSpentInfo, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn error_maps_minus_eight_to_invalid_parameter() {
+        let mapped = GetSpentInfoError::try_from(rpc_error(-8, "Invalid parameter"))
+            .expect("expected InvalidParameter");
+        match mapped {
+            GetSpentInfoError::InvalidParameter(message) => {
+                assert_eq!(message, "Invalid parameter");
+            }
+            other => panic!("expected InvalidParameter, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn error_returns_original_rpc_error_for_unknown_code() {
+        let returned = GetSpentInfoError::try_from(rpc_error(-32603, "Internal error"))
+            .expect_err("unknown code must Err with the original RpcError");
+        assert_eq!(returned.code, -32603);
+        assert_eq!(returned.message, "Internal error");
     }
 }
 

--- a/packages/zaino-serve/src/rpc/jsonrpc/service.rs
+++ b/packages/zaino-serve/src/rpc/jsonrpc/service.rs
@@ -10,7 +10,8 @@ use zaino_fetch::jsonrpsee::response::z_validate_address::{
     ZValidateAddressResponse, DEPRECATION_NOTICE as Z_VALIDATE_DEPRECATION,
 };
 use zaino_fetch::jsonrpsee::response::{
-    GetMempoolInfoResponse, GetNetworkSolPsResponse, GetTxOutResponse,
+    GetMempoolInfoResponse, GetNetworkSolPsResponse, GetSpentInfoRequest, GetSpentInfoResponse,
+    GetTxOutResponse,
 };
 use zaino_state::{LightWalletIndexer, ZcashIndexer};
 
@@ -385,6 +386,26 @@ pub trait ZcashIndexerRpc {
         n: u32,
         include_mempool: Option<bool>,
     ) -> Result<GetTxOutResponse, ErrorObjectOwned>;
+
+    /// Returns the txid, input index, and block height where an output is spent.
+    ///
+    /// zcashd reference: [`getspentinfo`](https://zcash.github.io/rpc/getspentinfo.html)
+    /// method: post
+    /// tags: blockchain
+    ///
+    /// # Parameters
+    ///
+    /// - `request`: (object, required) with `txid` and `index`.
+    ///
+    /// # Notes
+    ///
+    /// zcashd 6.12.2 returns an undocumented `height` field in addition to
+    /// the documented `txid` and `index` fields.
+    #[method(name = "getspentinfo")]
+    async fn get_spent_info(
+        &self,
+        request: GetSpentInfoRequest,
+    ) -> Result<GetSpentInfoResponse, ErrorObjectOwned>;
 
     /// Returns the transaction ids made by the provided transparent addresses.
     ///
@@ -816,6 +837,23 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
         self.service_subscriber
             .inner_ref()
             .get_tx_out(txid, n, include_mempool)
+            .await
+            .map_err(|e| {
+                ErrorObjectOwned::owned(
+                    ErrorCode::InvalidParams.code(),
+                    "Internal server error",
+                    Some(e.to_string()),
+                )
+            })
+    }
+
+    async fn get_spent_info(
+        &self,
+        request: GetSpentInfoRequest,
+    ) -> Result<GetSpentInfoResponse, ErrorObjectOwned> {
+        self.service_subscriber
+            .inner_ref()
+            .get_spent_info(request)
             .await
             .map_err(|e| {
                 ErrorObjectOwned::owned(

--- a/packages/zaino-state/src/backends/fetch.rs
+++ b/packages/zaino-state/src/backends/fetch.rs
@@ -37,7 +37,8 @@ use zaino_fetch::{
             z_validate_address::{
                 ZValidateAddressResponse, DEPRECATION_NOTICE as Z_VALIDATE_DEPRECATION,
             },
-            GetMempoolInfoResponse, GetNetworkSolPsResponse, GetTxOutResponse,
+            GetMempoolInfoResponse, GetNetworkSolPsResponse, GetSpentInfoRequest,
+            GetSpentInfoResponse, GetTxOutResponse,
         },
     },
 };
@@ -775,6 +776,13 @@ impl ZcashIndexer for FetchServiceSubscriber {
         include_mempool: Option<bool>,
     ) -> Result<GetTxOutResponse, Self::Error> {
         Ok(self.fetcher.get_tx_out(txid, n, include_mempool).await?)
+    }
+
+    async fn get_spent_info(
+        &self,
+        request: GetSpentInfoRequest,
+    ) -> Result<GetSpentInfoResponse, Self::Error> {
+        Ok(self.fetcher.get_spent_info(request).await?)
     }
 
     async fn chain_height(&self) -> Result<Height, Self::Error> {

--- a/packages/zaino-state/src/backends/state.rs
+++ b/packages/zaino-state/src/backends/state.rs
@@ -41,7 +41,8 @@ use zaino_fetch::{
                 InvalidZValidateAddress, KnownZValidateAddress, ZValidateAddressResponse,
                 DEPRECATION_NOTICE as Z_VALIDATE_DEPRECATION,
             },
-            GetMempoolInfoResponse, GetNetworkSolPsResponse, GetSubtreesResponse, GetTxOutResponse,
+            GetMempoolInfoResponse, GetNetworkSolPsResponse, GetSpentInfoRequest,
+            GetSpentInfoResponse, GetSubtreesResponse, GetTxOutResponse,
         },
     },
 };
@@ -1737,6 +1738,13 @@ impl ZcashIndexer for StateServiceSubscriber {
         include_mempool: Option<bool>,
     ) -> Result<GetTxOutResponse, Self::Error> {
         Ok(self.rpc_client.get_tx_out(txid, n, include_mempool).await?)
+    }
+
+    async fn get_spent_info(
+        &self,
+        request: GetSpentInfoRequest,
+    ) -> Result<GetSpentInfoResponse, Self::Error> {
+        Ok(self.rpc_client.get_spent_info(request).await?)
     }
 
     async fn get_address_tx_ids(

--- a/packages/zaino-state/src/indexer.rs
+++ b/packages/zaino-state/src/indexer.rs
@@ -13,7 +13,7 @@ use zaino_fetch::jsonrpsee::response::{
     mining_info::GetMiningInfoWire,
     peer_info::GetPeerInfo,
     z_validate_address::ZValidateAddressResponse,
-    GetMempoolInfoResponse, GetNetworkSolPsResponse,
+    GetMempoolInfoResponse, GetNetworkSolPsResponse, GetSpentInfoRequest, GetSpentInfoResponse,
 };
 use zaino_proto::proto::{
     compact_formats::CompactBlock,
@@ -493,6 +493,25 @@ pub trait ZcashIndexer: Send + Sync + 'static {
         n: u32,
         include_mempool: Option<bool>,
     ) -> Result<zaino_fetch::jsonrpsee::response::GetTxOutResponse, Self::Error>;
+
+    /// Returns the txid, input index, and block height where an output is spent.
+    ///
+    /// zcashd reference: [`getspentinfo`](https://zcash.github.io/rpc/getspentinfo.html)
+    /// method: post
+    /// tags: blockchain
+    ///
+    /// # Parameters
+    ///
+    /// - `request`: (object, required) with `txid` and `index`.
+    ///
+    /// # Notes
+    ///
+    /// zcashd 6.12.2 returns an undocumented `height` field in addition to
+    /// the documented `txid` and `index` fields.
+    async fn get_spent_info(
+        &self,
+        request: GetSpentInfoRequest,
+    ) -> Result<GetSpentInfoResponse, Self::Error>;
 
     /// Returns the transaction ids made by the provided transparent addresses.
     ///


### PR DESCRIPTION
## Summary
- add typed getspentinfo request/response handling
- expose getspentinfo through Zaino's JSON-RPC service and indexer trait
- route getspentinfo through the validator JSON-RPC connector
- preserve zcashd 6.12.2's undocumented height field in the response

## zcashd compatibility notes
- public docs list txid and index in the response
- zcashd 6.12.2 also returns height for the spending transaction's block
- zcashd expects a single object parameter with txid and index

## Testing
- cargo test -p zaino-fetch -p zaino-state -p zaino-serve --no-run

Closes https://github.com/zingolabs/zaino/issues/207