### PR TITLE
this uses a tokio_watch to update a status (NamedAtomicStatus)

### DIFF
--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -1013,6 +1013,16 @@ impl<Source: BlockchainSource> NodeBackedChainIndexSubscriber<Source> {
         combined_status
     }
 
+    /// Returns a [`tokio::sync::watch::Receiver`] that wakes on every
+    /// transition of the chain-index sync loop's status.
+    ///
+    /// Used by tests to await a specific state (e.g. first transition to
+    /// [`StatusType::Ready`]) without busy-polling.
+    #[cfg(test)]
+    pub(crate) fn status_subscribe(&self) -> tokio::sync::watch::Receiver<StatusType> {
+        self.status.subscribe()
+    }
+
     /// Returns the number of transparent outputs of `txid` that are currently unspent in the
     /// finalised state. Returns 0 if `txid` is not indexed by the finalised state.
     ///

--- a/packages/zaino-state/src/chain_index/tests.rs
+++ b/packages/zaino-state/src/chain_index/tests.rs
@@ -25,7 +25,6 @@ pub(crate) fn init_tracing() {
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 use tokio::sync::OnceCell;
-use tokio::time::Duration;
 use zaino_common::{network::ActivationHeights, DatabaseConfig, Network, StorageConfig};
 
 use crate::{
@@ -68,17 +67,7 @@ async fn load_test_vectors_and_sync_chain_index(
     NodeBackedChainIndexSubscriber<MockchainSource>,
     MockchainSource,
 ) {
-    // 25 ms setup-poll interval mirrors `_with_timings`. The previous 2 s
-    // value was load-bearing for the teardown race tracked in #1098: most
-    // callers (mockchain_tests, mempool, poll, proptest_blockgen) drop the
-    // indexer without calling `shutdown()`, and the old worker needed to
-    // be parked in its post-success interval-sleep before runtime teardown
-    // raced a mid-iter LMDB write. With `Drop for NodeBackedChainIndex`
-    // firing `cancel_token.cancel()` and the worker's iter body wrapped in
-    // `tokio::select!` against that token, the worker now exits at its
-    // next await checkpoint on drop — the harness no longer needs to
-    // bait the timing.
-    load_with_settings(mode, SyncTimings::default(), Duration::from_millis(25)).await
+    load_with_settings(mode, SyncTimings::default()).await
 }
 
 async fn load_test_vectors_and_sync_chain_index_with_timings(
@@ -90,13 +79,12 @@ async fn load_test_vectors_and_sync_chain_index_with_timings(
     NodeBackedChainIndexSubscriber<MockchainSource>,
     MockchainSource,
 ) {
-    load_with_settings(mode, sync_timings, Duration::from_millis(25)).await
+    load_with_settings(mode, sync_timings).await
 }
 
 async fn load_with_settings(
     mode: MockchainMode,
     sync_timings: SyncTimings,
-    setup_poll_interval: Duration,
 ) -> (
     Vec<vectors::TestVectorBlockData>,
     NodeBackedChainIndex<MockchainSource>,
@@ -151,7 +139,15 @@ async fn load_with_settings(
     // at `source.active_height()` implies the finalised DB has reached its
     // floor — the sync loop only initialises NFS after `sync_to_height`
     // succeeds — so this condition subsumes the old one.
+    //
+    // The wait is woken by the sync loop's status watch channel rather than a
+    // fixed-cadence poll: each status transition is the earliest point at
+    // which a new NFS tip can be observed. Teardown no longer needs a timing
+    // shim — `Drop for NodeBackedChainIndex` cancels the worker's
+    // `cancel_token`, so the worker exits at its next await checkpoint when a
+    // test drops the indexer without calling `shutdown()`.
     let expected_nfs_tip = source.active_height();
+    let mut status = index_reader.status_subscribe();
     loop {
         let nfs_ready = match index_reader.snapshot_nonfinalized_state().await {
             Ok(snap) => snap
@@ -162,7 +158,10 @@ async fn load_with_settings(
         if nfs_ready {
             break;
         }
-        tokio::time::sleep(setup_poll_interval).await;
+        status
+            .changed()
+            .await
+            .expect("ChainIndex status sender dropped before reaching Ready");
     }
 
     (blocks, indexer, index_reader, source)

--- a/packages/zaino-state/src/chain_index/tests/mockchain_tests.rs
+++ b/packages/zaino-state/src/chain_index/tests/mockchain_tests.rs
@@ -1,17 +1,14 @@
-use super::{load_test_vectors_and_sync_chain_index, MockchainMode};
+use super::{load_test_vectors_and_sync_chain_index, poll::poll_until, MockchainMode};
 use crate::{
     chain_index::{
         source::mockchain_source::MockchainSource,
-        tests::{
-            poll::poll_until,
-            vectors::{load_test_vectors, TestVectorBlockData},
-        },
+        tests::vectors::{load_test_vectors, TestVectorBlockData},
         types::{BestChainLocation, TransactionHash},
         ChainIndex, NodeBackedChainIndexSubscriber,
     },
-    BlockchainSource as _,
+    BlockchainSource as _, StatusType,
 };
-use tokio::time::{sleep, Duration};
+use tokio::time::{sleep, timeout, Duration};
 use tokio_stream::StreamExt as _;
 use zaino_fetch::jsonrpsee::response::address_deltas::{
     GetAddressDeltasParams, GetAddressDeltasResponse,
@@ -19,34 +16,41 @@ use zaino_fetch::jsonrpsee::response::address_deltas::{
 use zebra_chain::serialization::ZcashDeserializeInto;
 use zebra_rpc::client::{GetAddressBalanceRequest, GetAddressTxIdsRequest};
 
-/// Polls the indexer's nonfinalized-state snapshot until its best-tip height
-/// equals `expected`, or panics after a 10 s budget.
+/// Waits until the indexer's nonfinalized-state best-tip height equals
+/// `expected`, or panics after a 10 s budget.
 ///
-/// Use this wherever a test previously relied on a fixed `sleep` to hope the
-/// indexer's sync task had caught up with the mockchain tip: the indexer
-/// publishes new tips asynchronously via its background loop, and under
-/// full-suite parallel load those updates can lag well past 2 s.
+/// Wakes on every transition of the chain-index sync loop's status (via
+/// [`NodeBackedChainIndexSubscriber::status_subscribe`]) and re-checks the
+/// snapshot. The sync loop transitions to [`StatusType::Ready`] only after a
+/// successful iteration has updated the tip, so each Ready transition is the
+/// earliest moment the test can observe a new tip — no fixed-cadence polling
+/// required.
 async fn wait_for_indexer_tip(
     index_reader: &NodeBackedChainIndexSubscriber<MockchainSource>,
     expected: u32,
 ) {
-    poll_until(
-        "indexer tip to match expected height",
-        Duration::from_secs(10),
-        Duration::from_millis(25),
-        || async {
-            let tip = index_reader
-                .snapshot_nonfinalized_state()
+    let mut status = index_reader.status_subscribe();
+    let work = async {
+        loop {
+            if *status.borrow_and_update() == StatusType::Ready {
+                let tip = index_reader
+                    .snapshot_nonfinalized_state()
+                    .await
+                    .ok()
+                    .and_then(|s| s.get_nfs_snapshot().map(|n| n.best_tip.height.0));
+                if tip == Some(expected) {
+                    return;
+                }
+            }
+            status
+                .changed()
                 .await
-                .ok()?
-                .get_nfs_snapshot()?
-                .best_tip
-                .height
-                .0;
-            (tip == expected).then_some(())
-        },
-    )
-    .await;
+                .expect("ChainIndex status sender dropped before reaching expected tip");
+        }
+    };
+    timeout(Duration::from_secs(10), work)
+        .await
+        .unwrap_or_else(|_| panic!("indexer tip never reached {expected} within 10 s"));
 }
 
 fn faucet_transparent_address() -> String {

--- a/packages/zaino-state/src/status.rs
+++ b/packages/zaino-state/src/status.rs
@@ -1,13 +1,15 @@
 //! Thread-safe status wrapper.
 //!
 //! This module provides [`AtomicStatus`], a thread-safe wrapper for [`StatusType`],
-//! and [`NamedAtomicStatus`], a variant that logs status transitions.
+//! and [`NamedAtomicStatus`], a variant that logs status transitions and supports
+//! awaiting transitions via [`NamedAtomicStatus::subscribe`].
 
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
 };
 
+use tokio::sync::watch;
 use tracing::debug;
 
 pub use zaino_common::status::{Status, StatusType};
@@ -45,21 +47,23 @@ impl Status for AtomicStatus {
 
 /// Thread-safe status wrapper with component name for observability.
 ///
-/// Unlike [`AtomicStatus`], this variant logs all status transitions,
-/// making it easier to trace component lifecycle during debugging.
+/// Backed by a [`tokio::sync::watch`] channel: every transition is logged and
+/// every subscriber wakes via [`watch::Receiver::changed`]. Identical-value
+/// stores are no-ops — neither logged nor broadcast.
 #[derive(Debug, Clone)]
 pub struct NamedAtomicStatus {
     name: &'static str,
-    inner: Arc<AtomicUsize>,
+    inner: Arc<watch::Sender<StatusType>>,
 }
 
 impl NamedAtomicStatus {
     /// Creates a new NamedAtomicStatus with the given component name and initial status.
     pub fn new(name: &'static str, status: StatusType) -> Self {
         debug!(component = name, status = %status, "[STATUS] initial");
+        let (tx, _rx) = watch::channel(status);
         Self {
             name,
-            inner: Arc::new(AtomicUsize::new(status.into())),
+            inner: Arc::new(tx),
         }
     }
 
@@ -70,10 +74,11 @@ impl NamedAtomicStatus {
 
     /// Loads the value held in the NamedAtomicStatus.
     pub fn load(&self) -> StatusType {
-        StatusType::from(self.inner.load(Ordering::SeqCst))
+        *self.inner.borrow()
     }
 
-    /// Sets the value held in the NamedAtomicStatus, logging the transition.
+    /// Sets the value held in the NamedAtomicStatus, logging and broadcasting
+    /// the transition. Storing the current value is a no-op.
     pub fn store(&self, status: StatusType) {
         let old = self.load();
         if old != status {
@@ -83,8 +88,18 @@ impl NamedAtomicStatus {
                 to = %status,
                 "[STATUS] transition"
             );
+            self.inner.send_replace(status);
         }
-        self.inner.store(status.into(), Ordering::SeqCst);
+    }
+
+    /// Returns a [`watch::Receiver`] that observes every status transition.
+    ///
+    /// Use this to wait for a specific state with
+    /// [`watch::Receiver::changed`] / [`watch::Receiver::borrow_and_update`]
+    /// instead of busy-polling [`Self::load`].
+    #[cfg(test)]
+    pub(crate) fn subscribe(&self) -> watch::Receiver<StatusType> {
+        self.inner.subscribe()
     }
 }
 


### PR DESCRIPTION
It makes progress towards fixing #1037 but does not fix it fully.   Claude's commit message provides a detailed description of the change.

This code was originally inspired by code reviewed as part of #1055.
