### PR TITLE
Wire in provisional blocks

### DIFF
--- a/packages/zaino-state/CHANGELOG.md
+++ b/packages/zaino-state/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased not landing in 0.4.0]
+### Added
+- `chain_index::ChainBlock`
+- `chain_index::non_finalized_state::ProvisionalBlock`,
+
+### Changed
+- `chain_index::ChainIndex` methods now return `ChainBlock`s in
+  place of `IndexedBlock`s. ChainBlock enum may not contain ChainWork.
+- `chain_index::NonFinalizedSnapshot` trait methods now return
+- `ProvisionalBlock`s instead of `ChainBlocks`. TODO: Before release,
+  this will return `ChainBlock`s, where they are reified as `IndexedBlocks`
+  after sync completes
+
 ## [Unreleased]
 
 ### Added

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -175,30 +175,36 @@ fn branch_len_to_active_chain(
 /// Interim shape: once the Availability/Resolved work lands, a resolved NFS
 /// block promotes to `IndexedBlock` (via `into_indexed`), and these methods
 /// return `IndexedBlock` directly — see issue #1096.
-pub(crate) enum ChainBlock {
-    Finalized(IndexedBlock),
-    NonFinalized(ProvisionalBlock),
+pub enum ChainBlock {
+    /// We have indexed all blocks from this block down to the genesis block.
+    /// We know the chain's entire cumulative chainwork as of this block.
+    Reified(IndexedBlock),
+    /// We have not indexed some blocks below this block.
+    /// We know the sum of chainwork from this block down to the finalized tip,
+    /// which is sufficient for determining the best chain, but do not know
+    /// the absolute cumulative chainwork.
+    Provisional(ProvisionalBlock),
 }
 
 impl ChainBlock {
     pub(crate) fn hash(&self) -> &types::BlockHash {
         match self {
-            ChainBlock::Finalized(block) => block.hash(),
-            ChainBlock::NonFinalized(block) => block.hash(),
+            ChainBlock::Reified(block) => block.hash(),
+            ChainBlock::Provisional(block) => block.hash(),
         }
     }
 
     pub(crate) fn height(&self) -> types::Height {
         match self {
-            ChainBlock::Finalized(block) => block.height(),
-            ChainBlock::NonFinalized(block) => block.height(),
+            ChainBlock::Reified(block) => block.height(),
+            ChainBlock::Provisional(block) => block.height(),
         }
     }
 
     pub(crate) fn data(&self) -> &types::db::legacy::BlockData {
         match self {
-            ChainBlock::Finalized(block) => block.data(),
-            ChainBlock::NonFinalized(block) => block.data(),
+            ChainBlock::Reified(block) => block.data(),
+            ChainBlock::Provisional(block) => block.data(),
         }
     }
 }
@@ -370,7 +376,6 @@ pub trait ChainIndex {
     // Interim return type while the NFS holds provisional blocks: a finalized
     // hit is an `IndexedBlock`, a non-finalized hit a `ProvisionalBlock`. Once
     // the FS is fully synced (Resolved), these resolve to `IndexedBlock` (#1096).
-    #[allow(private_interfaces)]
     fn get_indexed_block_by_hash(
         &self,
         snapshot: &Self::Snapshot,
@@ -383,7 +388,6 @@ pub trait ChainIndex {
     ///
     /// **NOTE: This Method is currently not "passthrough aware", cumulative
     /// chain work must be made optional to enable this.**
-    #[allow(private_interfaces)]
     fn get_indexed_block_by_height(
         &self,
         snapshot: &Self::Snapshot,
@@ -1259,12 +1263,12 @@ impl<Source: BlockchainSource> NodeBackedChainIndexSubscriber<Source> {
             None => None,
         }
         .into_iter()
-        .map(ChainBlock::Finalized);
+        .map(ChainBlock::Reified);
         let non_finalized_blocks_containing_transaction =
             snapshot.blocks.values().filter_map(move |block| {
                 block.transactions().iter().find_map(|transaction| {
                     if transaction.txid().0 == txid {
-                        Some(ChainBlock::NonFinalized(block.clone()))
+                        Some(ChainBlock::Provisional(block.clone()))
                     } else {
                         None
                     }
@@ -1472,13 +1476,13 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
         target_hash: &types::BlockHash,
     ) -> Result<Option<ChainBlock>, Self::Error> {
         match snapshot.get_chainblock_by_hash(target_hash) {
-            Some(block) => Ok(Some(ChainBlock::NonFinalized(block.clone()))),
+            Some(block) => Ok(Some(ChainBlock::Provisional(block.clone()))),
             None => match self.get_block_height(snapshot, *target_hash).await {
                 Ok(Some(height)) => Ok(self
                     .finalized_state
                     .get_chain_block_by_height(height)
                     .await?
-                    .map(ChainBlock::Finalized)),
+                    .map(ChainBlock::Reified)),
                 Ok(None) => Ok(None),
                 Err(e) => Err(e),
             },
@@ -1497,12 +1501,12 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
         target_height: &types::Height,
     ) -> Result<Option<ChainBlock>, Self::Error> {
         match snapshot.get_chainblock_by_height(target_height) {
-            Some(block) => Ok(Some(ChainBlock::NonFinalized(block.clone()))),
+            Some(block) => Ok(Some(ChainBlock::Provisional(block.clone()))),
             None => Ok(self
                 .finalized_state
                 .get_chain_block_by_height(*target_height)
                 .await?
-                .map(ChainBlock::Finalized)),
+                .map(ChainBlock::Reified)),
         }
     }
 
@@ -2626,7 +2630,7 @@ where
 }
 
 /// A snapshot of the non-finalized state, for consistent queries
-pub(crate) trait NonFinalizedSnapshot {
+pub trait NonFinalizedSnapshot {
     /// Hash -> block
     fn get_chainblock_by_hash(&self, target_hash: &types::BlockHash) -> Option<&ProvisionalBlock>;
     /// Height -> block

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -26,7 +26,7 @@ use std::{sync::Arc, time::Duration};
 use arc_swap::ArcSwapOption;
 use futures::{FutureExt, Stream};
 use hex::FromHex as _;
-use non_finalised_state::NonfinalizedBlockCacheSnapshot;
+use non_finalised_state::{NonfinalizedBlockCacheSnapshot, ProvisionalBlock};
 use source::{BlockchainSource, ValidatorConnector};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
@@ -95,7 +95,7 @@ pub(crate) fn chain_tips_from_nonfinalized_snapshot(
     let parent_hashes = snapshot
         .blocks
         .values()
-        .map(|block| *block.context.parent_hash())
+        .map(|block| *block.parent_hash())
         .collect::<HashSet<_>>();
 
     let mut tip_hashes = snapshot
@@ -142,7 +142,7 @@ pub(crate) fn chain_tips_from_nonfinalized_snapshot(
 
 fn branch_len_to_active_chain(
     snapshot: &NonfinalizedBlockCacheSnapshot,
-    block: &IndexedBlock,
+    block: &ProvisionalBlock,
 ) -> u32 {
     let mut branch_len = 0;
     let mut current = block;
@@ -154,11 +154,48 @@ fn branch_len_to_active_chain(
 
         branch_len += 1;
 
-        let parent_hash = current.context.parent_hash();
+        let parent_hash = current.parent_hash();
         let Some(parent) = snapshot.blocks.get(parent_hash) else {
             return branch_len;
         };
         current = parent;
+    }
+}
+
+/// A block from either chain layer: the finalized state (an [`IndexedBlock`],
+/// carrying absolute chainwork) or the non-finalized state (a
+/// [`ProvisionalBlock`], carrying relative work). Unifies the two for query
+/// methods that may resolve a block from either layer while the NFS holds
+/// provisional blocks.
+///
+/// Interim shape: once the Availability/Resolved work lands, a resolved NFS
+/// block promotes to `IndexedBlock` (via `into_indexed`), and these methods
+/// return `IndexedBlock` directly — see issue #1096.
+pub(crate) enum ChainBlock {
+    Finalized(IndexedBlock),
+    NonFinalized(ProvisionalBlock),
+}
+
+impl ChainBlock {
+    pub(crate) fn hash(&self) -> &types::BlockHash {
+        match self {
+            ChainBlock::Finalized(block) => block.hash(),
+            ChainBlock::NonFinalized(block) => block.hash(),
+        }
+    }
+
+    pub(crate) fn height(&self) -> types::Height {
+        match self {
+            ChainBlock::Finalized(block) => block.height(),
+            ChainBlock::NonFinalized(block) => block.height(),
+        }
+    }
+
+    pub(crate) fn data(&self) -> &types::db::legacy::BlockData {
+        match self {
+            ChainBlock::Finalized(block) => block.data(),
+            ChainBlock::NonFinalized(block) => block.data(),
+        }
     }
 }
 
@@ -326,11 +363,15 @@ pub trait ChainIndex {
     ///
     /// **NOTE: This Method is currently not "passthrough aware", cumulative
     /// chain work must be made optional to enable this.**
+    // Interim return type while the NFS holds provisional blocks: a finalized
+    // hit is an `IndexedBlock`, a non-finalized hit a `ProvisionalBlock`. Once
+    // the FS is fully synced (Resolved), these resolve to `IndexedBlock` (#1096).
+    #[allow(private_interfaces)]
     fn get_indexed_block_by_hash(
         &self,
         snapshot: &Self::Snapshot,
         target_hash: &types::BlockHash,
-    ) -> impl std::future::Future<Output = Result<Option<IndexedBlock>, Self::Error>>;
+    ) -> impl std::future::Future<Output = Result<Option<ChainBlock>, Self::Error>>;
 
     /// Returns Some(IndexedBlock) for the given block height.in the best chain.
     ///
@@ -338,11 +379,12 @@ pub trait ChainIndex {
     ///
     /// **NOTE: This Method is currently not "passthrough aware", cumulative
     /// chain work must be made optional to enable this.**
+    #[allow(private_interfaces)]
     fn get_indexed_block_by_height(
         &self,
         snapshot: &Self::Snapshot,
         target_height: &types::Height,
-    ) -> impl std::future::Future<Output = Result<Option<IndexedBlock>, Self::Error>>;
+    ) -> impl std::future::Future<Output = Result<Option<ChainBlock>, Self::Error>>;
 
     /// Given inclusive start and end heights, stream all blocks
     /// between the given heights.
@@ -1093,7 +1135,7 @@ impl<Source: BlockchainSource> NodeBackedChainIndexSubscriber<Source> {
                 .values()
                 .find(|h| **h == hash)
                 // Canonical height is None for blocks not on the best chain
-                .map(|_| block.context.index.height)),
+                .map(|_| block.height())),
             None => self
                 // ChainIndex step 4:
                 .finalized_state
@@ -1113,7 +1155,7 @@ impl<Source: BlockchainSource> NodeBackedChainIndexSubscriber<Source> {
         &'self_lt self,
         snapshot: &'snapshot NonfinalizedBlockCacheSnapshot,
         txid: [u8; 32],
-    ) -> Result<impl Iterator<Item = IndexedBlock> + use<'iter, Source>, FinalisedStateError>
+    ) -> Result<impl Iterator<Item = ChainBlock> + use<'iter, Source>, FinalisedStateError>
     where
         'snapshot: 'iter,
         'self_lt: 'iter,
@@ -1131,12 +1173,13 @@ impl<Source: BlockchainSource> NodeBackedChainIndexSubscriber<Source> {
 
             None => None,
         }
-        .into_iter();
+        .into_iter()
+        .map(ChainBlock::Finalized);
         let non_finalized_blocks_containing_transaction =
             snapshot.blocks.values().filter_map(move |block| {
                 block.transactions().iter().find_map(|transaction| {
                     if transaction.txid().0 == txid {
-                        Some(block.clone())
+                        Some(ChainBlock::NonFinalized(block.clone()))
                     } else {
                         None
                     }
@@ -1342,14 +1385,15 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
         &self,
         snapshot: &Self::Snapshot,
         target_hash: &types::BlockHash,
-    ) -> Result<Option<IndexedBlock>, Self::Error> {
+    ) -> Result<Option<ChainBlock>, Self::Error> {
         match snapshot.get_chainblock_by_hash(target_hash) {
-            Some(block) => Ok(Some(block.clone())),
+            Some(block) => Ok(Some(ChainBlock::NonFinalized(block.clone()))),
             None => match self.get_block_height(snapshot, *target_hash).await {
                 Ok(Some(height)) => Ok(self
                     .finalized_state
                     .get_chain_block_by_height(height)
-                    .await?),
+                    .await?
+                    .map(ChainBlock::Finalized)),
                 Ok(None) => Ok(None),
                 Err(e) => Err(e),
             },
@@ -1366,13 +1410,14 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
         &self,
         snapshot: &Self::Snapshot,
         target_height: &types::Height,
-    ) -> Result<Option<IndexedBlock>, Self::Error> {
+    ) -> Result<Option<ChainBlock>, Self::Error> {
         match snapshot.get_chainblock_by_height(target_height) {
-            Some(block) => Ok(Some(block.clone())),
+            Some(block) => Ok(Some(ChainBlock::NonFinalized(block.clone()))),
             None => Ok(self
                 .finalized_state
                 .get_chain_block_by_height(*target_height)
-                .await?),
+                .await?
+                .map(ChainBlock::Finalized)),
         }
     }
 
@@ -1742,7 +1787,7 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
                     .await?
                     .next()
                 {
-                    Some(block) => block.context.index.height.into(),
+                    Some(block) => block.height().into(),
                     // As above Ok(None)
                     None => return Ok(None),
                 }
@@ -2024,9 +2069,10 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
                             // The block is in the best chain.
                             Ok(Some((*block.hash(), block.height())))
                         } else {
-                            // Otherwise, it's non-best chain! Grab its parent, and recurse
-                            Box::pin(self.find_fork_point(snapshot, &block.context.parent_hash))
-                                .await
+                            // Otherwise, it's non-best chain! Grab its parent, and recurse.
+                            // NOTE: walks the (provisional-stage UNTRUSTED) prev-hash linkage;
+                            // the Availability step should gate this trust on Resolved (#1096).
+                            Box::pin(self.find_fork_point(snapshot, block.parent_hash())).await
                             // gotta pin recursive async functions to prevent infinite-sized
                             // Future-implementing types
                         }
@@ -2432,11 +2478,11 @@ impl<T> NonFinalizedSnapshot for Arc<T>
 where
     T: NonFinalizedSnapshot,
 {
-    fn get_chainblock_by_hash(&self, target_hash: &types::BlockHash) -> Option<&IndexedBlock> {
+    fn get_chainblock_by_hash(&self, target_hash: &types::BlockHash) -> Option<&ProvisionalBlock> {
         self.as_ref().get_chainblock_by_hash(target_hash)
     }
 
-    fn get_chainblock_by_height(&self, target_height: &types::Height) -> Option<&IndexedBlock> {
+    fn get_chainblock_by_height(&self, target_height: &types::Height) -> Option<&ProvisionalBlock> {
         self.as_ref().get_chainblock_by_height(target_height)
     }
 
@@ -2446,17 +2492,17 @@ where
 }
 
 /// A snapshot of the non-finalized state, for consistent queries
-pub trait NonFinalizedSnapshot {
+pub(crate) trait NonFinalizedSnapshot {
     /// Hash -> block
-    fn get_chainblock_by_hash(&self, target_hash: &types::BlockHash) -> Option<&IndexedBlock>;
+    fn get_chainblock_by_hash(&self, target_hash: &types::BlockHash) -> Option<&ProvisionalBlock>;
     /// Height -> block
-    fn get_chainblock_by_height(&self, target_height: &types::Height) -> Option<&IndexedBlock>;
+    fn get_chainblock_by_height(&self, target_height: &types::Height) -> Option<&ProvisionalBlock>;
     /// The maximum height that this snapshot can serve data for.
     fn max_serviceable_height(&self) -> &types::Height;
 }
 
 impl NonFinalizedSnapshot for NonfinalizedBlockCacheSnapshot {
-    fn get_chainblock_by_hash(&self, target_hash: &types::BlockHash) -> Option<&IndexedBlock> {
+    fn get_chainblock_by_hash(&self, target_hash: &types::BlockHash) -> Option<&ProvisionalBlock> {
         self.blocks.iter().find_map(|(hash, chainblock)| {
             if hash == target_hash {
                 Some(chainblock)
@@ -2465,7 +2511,7 @@ impl NonFinalizedSnapshot for NonfinalizedBlockCacheSnapshot {
             }
         })
     }
-    fn get_chainblock_by_height(&self, target_height: &types::Height) -> Option<&IndexedBlock> {
+    fn get_chainblock_by_height(&self, target_height: &types::Height) -> Option<&ProvisionalBlock> {
         self.heights_to_hashes.iter().find_map(|(height, hash)| {
             if height == target_height {
                 self.get_chainblock_by_hash(hash)
@@ -2481,7 +2527,7 @@ impl NonFinalizedSnapshot for NonfinalizedBlockCacheSnapshot {
 }
 
 impl NonFinalizedSnapshot for ChainIndexSnapshot {
-    fn get_chainblock_by_hash(&self, target_hash: &types::BlockHash) -> Option<&IndexedBlock> {
+    fn get_chainblock_by_hash(&self, target_hash: &types::BlockHash) -> Option<&ProvisionalBlock> {
         match self {
             ChainIndexSnapshot::NonFinalizedStateExists {
                 non_finalized_snapshot,
@@ -2491,7 +2537,7 @@ impl NonFinalizedSnapshot for ChainIndexSnapshot {
         }
     }
 
-    fn get_chainblock_by_height(&self, target_height: &types::Height) -> Option<&IndexedBlock> {
+    fn get_chainblock_by_height(&self, target_height: &types::Height) -> Option<&ProvisionalBlock> {
         match self {
             ChainIndexSnapshot::NonFinalizedStateExists {
                 non_finalized_snapshot,

--- a/packages/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/non_finalised_state.rs
@@ -157,7 +157,7 @@ impl ProvisionalCumulativeWork {
 /// [`IndexedBlock`]'s absolute `chainwork` field, so the two cannot be
 /// misattributed.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ProvisionalBlock {
+pub struct ProvisionalBlock {
     /// Height + hash of this block.
     index: BlockIndex,
     /// Parent block hash as *claimed by this block's header*.

--- a/packages/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/non_finalised_state.rs
@@ -159,23 +159,23 @@ impl ProvisionalCumulativeWork {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProvisionalBlock {
     /// Height + hash of this block.
-    index: BlockIndex,
+    pub index: BlockIndex,
     /// Parent block hash as *claimed by this block's header*.
     ///
     /// UNTRUSTED while the snapshot is provisional: the linkage it asserts is
     /// not validated against the finalized chain until the seam connects, so
     /// it must not be used for trusted chain-walks (e.g. fork-point recursion)
     /// during the provisional stage.
-    parent_hash: BlockHash,
+    pub parent_hash: BlockHash,
     /// Cumulative work relative to the seam, header-derived. Never absolute —
     /// the type enforces that (see [`ProvisionalCumulativeWork`]).
-    provisional_cumulative_work: ProvisionalCumulativeWork,
+    pub(crate) provisional_cumulative_work: ProvisionalCumulativeWork,
     /// Header and auxiliary block data.
-    data: BlockData,
+    pub data: BlockData,
     /// Compact representations of the block's transactions.
-    transactions: Vec<CompactTxData>,
+    pub transactions: Vec<CompactTxData>,
     /// Commitment tree data for the chain after this block is applied.
-    commitment_tree_data: CommitmentTreeData,
+    pub commitment_tree_data: CommitmentTreeData,
 }
 
 impl ProvisionalBlock {

--- a/packages/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/non_finalised_state.rs
@@ -1,7 +1,12 @@
 use super::{finalised_state::ZainoDB, source::BlockchainSource, NON_FINALIZED_DEPTH};
+use crate::chain_index::types::db::{
+    legacy::{BlockData, CompactTxData},
+    CommitmentTreeData,
+};
 use crate::{
     chain_index::types::{
-        self, BlockHash, BlockIndex, BlockMetadata, BlockWithMetadata, Height, TreeRootData,
+        self, BlockContext, BlockHash, BlockIndex, BlockMetadata, BlockWithMetadata, Height,
+        TreeRootData,
     },
     error::FinalisedStateError,
     ChainWork, IndexedBlock,
@@ -92,6 +97,142 @@ pub(crate) struct NonfinalizedBlockCacheSnapshot {
     // best_tip is a BestTip, which contains
     // a Height, and a BlockHash as named fields.
     pub best_tip: BlockIndex,
+}
+
+/// Cumulative work measured *relative to the seam*, header-derived.
+///
+/// A distinct type from [`ChainWork`] (which is ABSOLUTE) precisely so the two
+/// cannot be confused at a call site: passing relative work where absolute is
+/// required — or writing it into an [`IndexedBlock`]'s `chainwork` field — is a
+/// type error, not merely a naming convention. This is the misattribution
+/// guard in the type system.
+///
+/// Relative work is a sound best-tip ordering within the non-finalized window:
+/// under the assumption that no reorg exceeds [`NON_FINALIZED_DEPTH`], the seam
+/// is a stable common ancestor of every competing chain, so relative ordering
+/// matches absolute ordering.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ProvisionalCumulativeWork(ChainWork);
+
+impl ProvisionalCumulativeWork {
+    /// Relative work at the seam: zero by definition (the seam is the base).
+    pub(crate) fn seam() -> Self {
+        Self(ChainWork::from_u256(U256::zero()))
+    }
+
+    /// Accumulate one block's own (header-derived) work onto the running
+    /// relative total.
+    pub(crate) fn add_block_work(&self, block_work: &ChainWork) -> Self {
+        Self(self.0.add(block_work))
+    }
+
+    /// Resolve to ABSOLUTE chainwork given the seam's absolute base
+    /// (`absolute = seam_base + relative`). Only callable once the base is
+    /// known — i.e. at the resolution boundary.
+    pub(crate) fn resolve(&self, seam_base: &ChainWork) -> ChainWork {
+        seam_base.add(&self.0)
+    }
+}
+
+/// A non-finalized block as held by the NFS.
+///
+/// It is deliberately **not** an [`IndexedBlock`]. "Indexed" means the block
+/// has been placed in the validated chain with its *absolute* cumulative
+/// chainwork — and that absolute value is unknowable while the finalized
+/// state has not yet caught up to the seam (the validator does not expose
+/// chainwork, and the finalized DB has not reached the floor). A provisional
+/// block instead carries [`Self::provisional_cumulative_work`]: cumulative
+/// work measured *relative to the seam*, derived from block headers alone.
+///
+/// Relative work is sufficient to choose the best tip within the
+/// non-finalized window: under the assumption that no reorg exceeds
+/// [`NON_FINALIZED_DEPTH`], the seam is a stable common ancestor of every
+/// competing window chain, so ordering by relative work matches ordering by
+/// absolute work.
+///
+/// A provisional block becomes an [`IndexedBlock`] only at the resolution
+/// boundary, via [`Self::into_indexed`], when the seam's absolute work is
+/// known: `absolute = seam_base + provisional_cumulative_work`. The relative
+/// value lives only here and is never written into
+/// [`IndexedBlock`]'s absolute `chainwork` field, so the two cannot be
+/// misattributed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ProvisionalBlock {
+    /// Height + hash of this block.
+    index: BlockIndex,
+    /// Parent block hash as *claimed by this block's header*.
+    ///
+    /// UNTRUSTED while the snapshot is provisional: the linkage it asserts is
+    /// not validated against the finalized chain until the seam connects, so
+    /// it must not be used for trusted chain-walks (e.g. fork-point recursion)
+    /// during the provisional stage.
+    parent_hash: BlockHash,
+    /// Cumulative work relative to the seam, header-derived. Never absolute —
+    /// the type enforces that (see [`ProvisionalCumulativeWork`]).
+    provisional_cumulative_work: ProvisionalCumulativeWork,
+    /// Header and auxiliary block data.
+    data: BlockData,
+    /// Compact representations of the block's transactions.
+    transactions: Vec<CompactTxData>,
+    /// Commitment tree data for the chain after this block is applied.
+    commitment_tree_data: CommitmentTreeData,
+}
+
+impl ProvisionalBlock {
+    /// The block hash.
+    pub(crate) fn hash(&self) -> &BlockHash {
+        &self.index.hash
+    }
+
+    /// The block height.
+    pub(crate) fn height(&self) -> Height {
+        self.index.height
+    }
+
+    /// The parent block hash as claimed by the header. UNTRUSTED while
+    /// provisional — see the field doc; do not use for validated chain-walks.
+    pub(crate) fn parent_hash(&self) -> &BlockHash {
+        &self.parent_hash
+    }
+
+    /// Cumulative work relative to the seam. Use this — never an absolute
+    /// chainwork — for best-tip selection within the non-finalized window.
+    pub(crate) fn provisional_cumulative_work(&self) -> &ProvisionalCumulativeWork {
+        &self.provisional_cumulative_work
+    }
+
+    /// The compact transactions in this block.
+    pub(crate) fn transactions(&self) -> &[CompactTxData] {
+        &self.transactions
+    }
+
+    /// Header and auxiliary block data.
+    pub(crate) fn data(&self) -> &BlockData {
+        &self.data
+    }
+
+    /// Commitment tree data after this block.
+    pub(crate) fn commitment_tree_data(&self) -> &CommitmentTreeData {
+        &self.commitment_tree_data
+    }
+
+    /// Promote to an [`IndexedBlock`] once the seam's absolute cumulative work
+    /// is known (the resolution boundary). The absolute chainwork is
+    /// `seam_base + provisional_cumulative_work`.
+    pub(crate) fn into_indexed(self, seam_base: &ChainWork) -> IndexedBlock {
+        let chainwork = self.provisional_cumulative_work.resolve(seam_base);
+        IndexedBlock::new(
+            BlockContext::new(
+                self.index.hash,
+                self.parent_hash,
+                chainwork,
+                self.index.height,
+            ),
+            self.data,
+            self.transactions,
+            self.commitment_tree_data,
+        )
+    }
 }
 
 #[derive(Debug)]
@@ -621,6 +762,83 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
     /// Get a snapshot of the block cache
     pub(super) fn get_snapshot(&self) -> Arc<NonfinalizedBlockCacheSnapshot> {
         self.current.load_full()
+    }
+
+    /// Build a [`ProvisionalBlock`] from a source block, accumulating its
+    /// header work onto the parent's relative total. Mirrors
+    /// [`Self::block_to_chainblock`] but produces a provisional (not indexed)
+    /// block: no absolute chainwork is computed or required.
+    async fn block_to_provisional_block(
+        &self,
+        parent_work: &ProvisionalCumulativeWork,
+        block: &zebra_chain::block::Block,
+    ) -> Result<ProvisionalBlock, SyncError> {
+        let tree_roots = self
+            .get_tree_roots_from_source(block.hash().into())
+            .await
+            .map_err(|e| {
+                SyncError::ValidatorConnectionError(NodeConnectionError::UnrecoverableError(
+                    Box::new(InvalidData(format!("{}", e))),
+                ))
+            })?;
+
+        Self::provisional_block_from_parts(block, &tree_roots, parent_work, self.network.clone())
+            .map_err(|e| {
+                SyncError::ValidatorConnectionError(NodeConnectionError::UnrecoverableError(
+                    Box::new(InvalidData(e)),
+                ))
+            })
+    }
+
+    /// Assemble a [`ProvisionalBlock`] from already-fetched parts. Reuses the
+    /// shared `BlockWithMetadata` extractors (`extract_block_data`,
+    /// `extract_transactions`, `create_commitment_tree_data`, `block_work`);
+    /// the only divergence from the indexed path is that work is accumulated
+    /// *relative to the seam* instead of into an absolute `BlockContext`.
+    fn provisional_block_from_parts(
+        block: &zebra_chain::block::Block,
+        tree_roots: &TreeRootData,
+        parent_work: &ProvisionalCumulativeWork,
+        network: Network,
+    ) -> Result<ProvisionalBlock, String> {
+        let (sapling_root, sapling_size, orchard_root, orchard_size) =
+            tree_roots.clone().extract_with_defaults();
+
+        // `parent_chainwork` is unused for a provisional block (it feeds only
+        // `create_block_context`, which we never call here); a zero placeholder
+        // keeps the throwaway `BlockMetadata` shape without touching absolute
+        // work. The relative total is tracked separately, below.
+        let metadata = BlockMetadata::new(
+            sapling_root,
+            sapling_size as u32,
+            orchard_root,
+            orchard_size as u32,
+            ChainWork::from_u256(U256::zero()),
+            network,
+        );
+        let block_with_metadata = BlockWithMetadata::new(block, metadata);
+
+        let data = block_with_metadata.extract_block_data()?;
+        let transactions = block_with_metadata.extract_transactions()?;
+        let commitment_tree_data = block_with_metadata.create_commitment_tree_data();
+        let provisional_cumulative_work =
+            parent_work.add_block_work(&block_with_metadata.block_work()?);
+
+        let hash = BlockHash::from(block.hash());
+        let parent_hash = BlockHash::from(block.header.previous_block_hash);
+        let height = block
+            .coinbase_height()
+            .map(|height| Height(height.0))
+            .ok_or_else(|| String::from("Any valid block has a coinbase height"))?;
+
+        Ok(ProvisionalBlock {
+            index: BlockIndex { height, hash },
+            parent_hash,
+            provisional_cumulative_work,
+            data,
+            transactions,
+            commitment_tree_data,
+        })
     }
 
     async fn block_to_chainblock(

--- a/packages/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/non_finalised_state.rs
@@ -1,6 +1,6 @@
 use super::{finalised_state::ZainoDB, source::BlockchainSource, NON_FINALIZED_DEPTH};
 use crate::chain_index::types::db::{
-    legacy::{BlockData, CompactTxData},
+    legacy::{compact_block_from_parts, BlockData, CompactTxData},
     CommitmentTreeData,
 };
 use crate::{
@@ -88,7 +88,7 @@ pub(crate) struct NonfinalizedBlockCacheSnapshot {
     /// this includes all blocks on-chain, as well as
     /// all blocks known to have been on-chain before being
     /// removed by a reorg. Blocks reorged away have no height.
-    pub blocks: HashMap<BlockHash, IndexedBlock>,
+    pub blocks: HashMap<BlockHash, ProvisionalBlock>,
     /// hashes indexed by height
     /// Hashes in this map are part of the best chain.
     pub heights_to_hashes: HashMap<Height, BlockHash>,
@@ -214,6 +214,36 @@ impl ProvisionalBlock {
     /// Commitment tree data after this block.
     pub(crate) fn commitment_tree_data(&self) -> &CommitmentTreeData {
         &self.commitment_tree_data
+    }
+
+    /// The compact-block representation. Compact blocks carry no cumulative
+    /// chainwork, so this is identical to an indexed block's; both delegate to
+    /// [`compact_block_from_parts`].
+    pub(crate) fn to_compact_block(&self) -> zaino_proto::proto::compact_formats::CompactBlock {
+        compact_block_from_parts(
+            self.height(),
+            self.hash(),
+            self.parent_hash(),
+            self.data().time(),
+            self.transactions(),
+            self.commitment_tree_data(),
+        )
+    }
+
+    /// Build the seam anchor from a finalized [`IndexedBlock`]. The anchor's
+    /// relative work is zero by definition ([`ProvisionalCumulativeWork::seam`]);
+    /// the block's absolute chainwork is intentionally dropped — the NFS tracks
+    /// work relative to this seam, and the absolute base is reattached only at
+    /// resolution.
+    pub(crate) fn from_indexed_seam(indexed: IndexedBlock) -> Self {
+        Self {
+            index: indexed.context.index,
+            parent_hash: indexed.context.parent_hash,
+            provisional_cumulative_work: ProvisionalCumulativeWork::seam(),
+            data: indexed.data,
+            transactions: indexed.transactions,
+            commitment_tree_data: indexed.commitment_tree_data,
+        }
     }
 
     /// Promote to an [`IndexedBlock`] once the seam's absolute cumulative work
@@ -348,7 +378,7 @@ impl NonfinalizedBlockCacheSnapshot {
         let mut blocks = HashMap::new();
         let mut heights_to_hashes = HashMap::new();
 
-        blocks.insert(hash, block);
+        blocks.insert(hash, ProvisionalBlock::from_indexed_seam(block));
         heights_to_hashes.insert(height, hash);
 
         Self {
@@ -358,7 +388,7 @@ impl NonfinalizedBlockCacheSnapshot {
         }
     }
 
-    fn add_block_new_chaintip(&mut self, block: IndexedBlock) {
+    fn add_block_new_chaintip(&mut self, block: ProvisionalBlock) {
         self.best_tip = BlockIndex {
             height: block.height(),
             hash: *block.hash(),
@@ -366,7 +396,10 @@ impl NonfinalizedBlockCacheSnapshot {
         self.add_block(block)
     }
 
-    fn get_block_by_hash_bytes_in_serialized_order(&self, hash: [u8; 32]) -> Option<&IndexedBlock> {
+    fn get_block_by_hash_bytes_in_serialized_order(
+        &self,
+        hash: [u8; 32],
+    ) -> Option<&ProvisionalBlock> {
         self.blocks
             .values()
             .find(|block| block.hash_bytes_serialized_order() == hash)
@@ -381,7 +414,7 @@ impl NonfinalizedBlockCacheSnapshot {
             .retain(|height, _hash| height >= &finalized_height);
     }
 
-    fn add_block(&mut self, block: IndexedBlock) {
+    fn add_block(&mut self, block: ProvisionalBlock) {
         self.heights_to_hashes.insert(block.height(), *block.hash());
         self.blocks.insert(*block.hash(), block);
     }
@@ -558,24 +591,29 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
             let parent_hash = BlockHash::from(block.header.previous_block_hash);
             if parent_hash == working_snapshot.best_tip.hash {
                 // Normal chain progression
-                let prev_block = working_snapshot
-                    .blocks
-                    .get(&working_snapshot.best_tip.hash)
-                    .ok_or_else(|| {
-                        SyncError::ReorgFailure(format!(
-                            "found blocks {:?}, expected block {:?}",
-                            working_snapshot
-                                .blocks
-                                .values()
-                                .map(|block| (block.context.index.hash, block.context.index.height))
-                                .collect::<Vec<_>>(),
-                            working_snapshot.best_tip
-                        ))
-                    })?;
-                let chainblock = self.block_to_chainblock(prev_block, &block).await?;
+                let parent_work = {
+                    let prev_block = working_snapshot
+                        .blocks
+                        .get(&working_snapshot.best_tip.hash)
+                        .ok_or_else(|| {
+                            SyncError::ReorgFailure(format!(
+                                "found blocks {:?}, expected block {:?}",
+                                working_snapshot
+                                    .blocks
+                                    .values()
+                                    .map(|block| (*block.hash(), block.height()))
+                                    .collect::<Vec<_>>(),
+                                working_snapshot.best_tip
+                            ))
+                        })?;
+                    *prev_block.provisional_cumulative_work()
+                };
+                let chainblock = self
+                    .block_to_provisional_block(&parent_work, &block)
+                    .await?;
                 info!(
                     height = (working_snapshot.best_tip.height + 1).0,
-                    hash = %chainblock.context.index.hash,
+                    hash = %chainblock.hash(),
                     "Syncing block"
                 );
                 working_snapshot.add_block_new_chaintip(chainblock);
@@ -610,7 +648,7 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
         &self,
         working_snapshot: &mut NonfinalizedBlockCacheSnapshot,
         block: &impl Block,
-    ) -> Result<IndexedBlock, SyncError> {
+    ) -> Result<ProvisionalBlock, SyncError> {
         let prev_block = match working_snapshot
             .get_block_by_hash_bytes_in_serialized_order(block.prev_hash_bytes_serialized_order())
             .cloned()
@@ -648,9 +686,10 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
                 Box::pin(self.handle_reorg(working_snapshot, &*prev_block)).await?
             }
         };
-        let indexed_block = block.to_indexed_block(&prev_block, self).await?;
-        working_snapshot.add_block_new_chaintip(indexed_block.clone());
-        Ok(indexed_block)
+        let parent_work = *prev_block.provisional_cumulative_work();
+        let provisional_block = block.to_provisional_block(&parent_work, self).await?;
+        working_snapshot.add_block_new_chaintip(provisional_block.clone());
+        Ok(provisional_block)
     }
 
     /// Handle non-finalized change listener events
@@ -708,7 +747,7 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
         let best_block = &new_snapshot
             .blocks
             .values()
-            .max_by_key(|block| block.chainwork())
+            .max_by_key(|block| block.provisional_cumulative_work())
             .cloned()
             .expect("empty snapshot impossible");
         self.handle_reorg(&mut new_snapshot, best_block)
@@ -913,7 +952,7 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
         &self,
         working_snapshot: &mut NonfinalizedBlockCacheSnapshot,
         block: &impl Block,
-    ) -> Result<IndexedBlock, SyncError> {
+    ) -> Result<ProvisionalBlock, SyncError> {
         let prev_block = match working_snapshot
             .get_block_by_hash_bytes_in_serialized_order(block.prev_hash_bytes_serialized_order())
             .cloned()
@@ -941,9 +980,10 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
                 Box::pin(self.add_nonbest_block(working_snapshot, &*prev_block)).await?
             }
         };
-        let indexed_block = block.to_indexed_block(&prev_block, self).await?;
-        working_snapshot.add_block(indexed_block.clone());
-        Ok(indexed_block)
+        let parent_work = *prev_block.provisional_cumulative_work();
+        let provisional_block = block.to_provisional_block(&parent_work, self).await?;
+        working_snapshot.add_block(provisional_block.clone());
+        Ok(provisional_block)
     }
 }
 
@@ -969,27 +1009,32 @@ pub enum UpdateError {
 trait Block {
     fn hash_bytes_serialized_order(&self) -> [u8; 32];
     fn prev_hash_bytes_serialized_order(&self) -> [u8; 32];
-    async fn to_indexed_block<Source: BlockchainSource>(
+    /// Produce the [`ProvisionalBlock`] for this block, accumulating its work
+    /// onto `parent_work` (relative to the seam). Replaces the former
+    /// `to_indexed_block`: the NFS holds provisional, not indexed, blocks.
+    async fn to_provisional_block<Source: BlockchainSource>(
         &self,
-        prev_block: &IndexedBlock,
+        parent_work: &ProvisionalCumulativeWork,
         nfs: &NonFinalizedState<Source>,
-    ) -> Result<IndexedBlock, SyncError>;
+    ) -> Result<ProvisionalBlock, SyncError>;
 }
 
-impl Block for IndexedBlock {
+impl Block for ProvisionalBlock {
     fn hash_bytes_serialized_order(&self) -> [u8; 32] {
         self.hash().0
     }
 
     fn prev_hash_bytes_serialized_order(&self) -> [u8; 32] {
-        self.context.parent_hash.0
+        self.parent_hash().0
     }
 
-    async fn to_indexed_block<Source: BlockchainSource>(
+    async fn to_provisional_block<Source: BlockchainSource>(
         &self,
-        _prev_block: &IndexedBlock,
+        _parent_work: &ProvisionalCumulativeWork,
         _nfs: &NonFinalizedState<Source>,
-    ) -> Result<IndexedBlock, SyncError> {
+    ) -> Result<ProvisionalBlock, SyncError> {
+        // Identity: a block already in the snapshot keeps the relative work it
+        // was assigned when first added; `parent_work` is irrelevant here.
         Ok(self.clone())
     }
 }
@@ -1002,11 +1047,11 @@ impl Block for zebra_chain::block::Block {
         self.header.previous_block_hash.bytes_in_serialized_order()
     }
 
-    async fn to_indexed_block<Source: BlockchainSource>(
+    async fn to_provisional_block<Source: BlockchainSource>(
         &self,
-        prev_block: &IndexedBlock,
+        parent_work: &ProvisionalCumulativeWork,
         nfs: &NonFinalizedState<Source>,
-    ) -> Result<IndexedBlock, SyncError> {
-        nfs.block_to_chainblock(prev_block, self).await
+    ) -> Result<ProvisionalBlock, SyncError> {
+        nfs.block_to_provisional_block(parent_work, self).await
     }
 }

--- a/packages/zaino-state/src/chain_index/tests/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/tests/non_finalised_state.rs
@@ -19,8 +19,17 @@
 //! Tests of the cold-start "still-syncing" variant are deliberately
 //! omitted: that variant is being eliminated, and pinning its shape
 //! would create immediate test churn at the refactor PR.
+//!
+//! The one exception is the trailing **red driver** for #1096
+//! (`best_chaintip_derives_tip_from_nfs_snapshot_not_validator_passthrough`).
+//! Unlike the characterization tests above — which pin behavior that must
+//! survive the refactor unchanged — that test is *failing on purpose* and is
+//! expected to be rewritten when the still-syncing variant is removed. It
+//! pins cold-start shape precisely because it is driving that variant's
+//! elimination, so the churn it incurs is the point, not an accident.
 
 use super::{load_test_vectors_and_sync_chain_index, poll::poll_until, MockchainMode};
+use crate::chain_index::non_finalised_state::ChainIndexSnapshot;
 use crate::chain_index::{finalized_height_floor, ChainIndex};
 use std::time::Duration;
 use tokio::time::sleep;
@@ -284,5 +293,61 @@ async fn race_pre_mine_finalized_height_block_is_evicted_when_source_advances_mi
          source advances mid-iter; published NFS overshoots its iter-committed \
          seam (#1126)",
         pre_mine_finalized_height.0,
+    );
+}
+
+/// **Red driver for #1096** (NOT a surviving characterization test — see the
+/// module-level doc; this one is *failing on purpose* and is expected to be
+/// rewritten when the still-syncing variant is removed).
+///
+/// Target invariant: `best_chaintip` must derive the chain tip from the
+/// non-finalized snapshot in *every* availability state — it must never fall
+/// back to a validator passthrough.
+///
+/// Today the lazy design hands out
+/// [`ChainIndexSnapshot::StillSyncingFinalizedState`] during the cold-start
+/// window, before the NFS slot is populated. In that variant `best_chaintip`
+/// (`chain_index.rs`, the `StillSyncingFinalizedState` arm) has no snapshot
+/// tip to read, so it round-trips to the validator and reports the *finalized
+/// floor* (`validator_finalized_height`) as the tip — a stale height, and a
+/// fallible call that surfaces `database_hole` if the validator can't serve
+/// the floor block.
+///
+/// After #1096 there is no still-syncing variant: the snapshot always carries
+/// an NFS `best_tip`, so `best_chaintip` reads it directly and reports the
+/// real tip with no validator call. The test will then be rewritten to assert
+/// the invariant over a snapshot returned by `snapshot_nonfinalized_state()`.
+///
+/// multi_thread: depends on the harness's background sync loop advancing the
+/// NFS concurrently with the setup's poll-until-ready loop.
+#[tokio::test(flavor = "multi_thread")]
+async fn best_chaintip_derives_tip_from_nfs_snapshot_not_validator_passthrough() {
+    let (_blocks, _indexer, index_reader, mockchain) =
+        load_test_vectors_and_sync_chain_index(MockchainMode::Active).await;
+
+    // The chain tip the always-present NFS snapshot reports: the harness syncs
+    // the NFS to exactly the source's active height before returning.
+    let chain_tip = mockchain.active_height();
+
+    // The cold-start variant the lazy design can hand out instead. Its
+    // `validator_finalized_height` is the true floor — exactly what
+    // `snapshot_nonfinalized_state()` computes while the NFS slot is `None`.
+    let cold_start_snapshot = ChainIndexSnapshot::StillSyncingFinalizedState {
+        validator_finalized_height: finalized_height_floor(chain_tip),
+    };
+
+    let tip = index_reader
+        .best_chaintip(&cold_start_snapshot)
+        .await
+        .expect("best_chaintip resolves against a still-syncing snapshot");
+
+    assert_eq!(
+        tip.height.0,
+        chain_tip,
+        "best_chaintip must derive the tip from the NFS snapshot and report the \
+         chain tip ({chain_tip}) in every availability state; today the cold-start \
+         variant passes through to the validator and reports the finalized floor \
+         ({}) instead (#1096)",
+        finalized_height_floor(chain_tip).0,
     );
 }

--- a/packages/zaino-state/src/chain_index/tests/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/tests/non_finalised_state.rs
@@ -20,13 +20,14 @@
 //! omitted: that variant is being eliminated, and pinning its shape
 //! would create immediate test churn at the refactor PR.
 //!
-//! The one exception is the trailing **red driver** for #1096
-//! (`best_chaintip_derives_tip_from_nfs_snapshot_not_validator_passthrough`).
+//! The one exception is the trailing **bug-characterization tripwire** for
+//! #1096 (`best_chaintip_derives_tip_from_nfs_snapshot_not_validator_passthrough`).
 //! Unlike the characterization tests above — which pin behavior that must
-//! survive the refactor unchanged — that test is *failing on purpose* and is
-//! expected to be rewritten when the still-syncing variant is removed. It
-//! pins cold-start shape precisely because it is driving that variant's
-//! elimination, so the churn it incurs is the point, not an accident.
+//! survive the refactor unchanged — that test is `#[should_panic]`: it asserts
+//! the *target* invariant and documents that the assertion does not hold today,
+//! because the cold-start variant passes through to the validator. It passes
+//! now and goes red the moment #1096 removes the still-syncing variant, which
+//! is the signal to rewrite it against `snapshot_nonfinalized_state()`.
 
 use super::{load_test_vectors_and_sync_chain_index, poll::poll_until, MockchainMode};
 use crate::chain_index::non_finalised_state::ChainIndexSnapshot;
@@ -296,13 +297,21 @@ async fn race_pre_mine_finalized_height_block_is_evicted_when_source_advances_mi
     );
 }
 
-/// **Red driver for #1096** (NOT a surviving characterization test — see the
-/// module-level doc; this one is *failing on purpose* and is expected to be
-/// rewritten when the still-syncing variant is removed).
+/// **Bug-characterization tripwire for #1096** (NOT a surviving
+/// characterization test — see the module-level doc; this one is
+/// `#[should_panic]` and is expected to be rewritten when the still-syncing
+/// variant is removed).
 ///
 /// Target invariant: `best_chaintip` must derive the chain tip from the
 /// non-finalized snapshot in *every* availability state — it must never fall
 /// back to a validator passthrough.
+///
+/// The body asserts that invariant directly. It does not hold today, so the
+/// assertion panics — hence `#[should_panic]`: the test is green now precisely
+/// *because* the cold-start variant is still broken. When #1096 removes the
+/// still-syncing variant, `best_chaintip` reports the real tip, the assertion
+/// passes, the expected panic never fires, and this test goes red — the signal
+/// to rewrite it against a `snapshot_nonfinalized_state()` result.
 ///
 /// Today the lazy design hands out
 /// [`ChainIndexSnapshot::StillSyncingFinalizedState`] during the cold-start
@@ -321,11 +330,7 @@ async fn race_pre_mine_finalized_height_block_is_evicted_when_source_advances_mi
 /// multi_thread: depends on the harness's background sync loop advancing the
 /// NFS concurrently with the setup's poll-until-ready loop.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "red driver for #1096: fails on purpose against today's still-syncing \
-            variant, which passes through to the validator and reports the \
-            finalized floor instead of the tip. Pins the target invariant to \
-            drive that variant's elimination; rewritten against \
-            snapshot_nonfinalized_state() once #1096 lands."]
+#[should_panic(expected = "passes through to the validator and reports the finalized floor")]
 async fn best_chaintip_derives_tip_from_nfs_snapshot_not_validator_passthrough() {
     let (_blocks, _indexer, index_reader, mockchain) =
         load_test_vectors_and_sync_chain_index(MockchainMode::Active).await;

--- a/packages/zaino-state/src/chain_index/tests/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/tests/non_finalised_state.rs
@@ -321,6 +321,11 @@ async fn race_pre_mine_finalized_height_block_is_evicted_when_source_advances_mi
 /// multi_thread: depends on the harness's background sync loop advancing the
 /// NFS concurrently with the setup's poll-until-ready loop.
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "red driver for #1096: fails on purpose against today's still-syncing \
+            variant, which passes through to the validator and reports the \
+            finalized floor instead of the tip. Pins the target invariant to \
+            drive that variant's elimination; rewritten against \
+            snapshot_nonfinalized_state() once #1096 lands."]
 async fn best_chaintip_derives_tip_from_nfs_snapshot_not_validator_passthrough() {
     let (_blocks, _indexer, index_reader, mockchain) =
         load_test_vectors_and_sync_chain_index(MockchainMode::Active).await;

--- a/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
+++ b/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
@@ -420,7 +420,10 @@ fn make_chain() {
                 .unwrap();
             for (hash, block) in &non_finalized_snapshot.blocks {
                 if hash != &best_tip_hash {
-                    assert!(block.chainwork().to_u256() <= best_tip_block.chainwork().to_u256());
+                    assert!(
+                        block.provisional_cumulative_work()
+                            <= best_tip_block.provisional_cumulative_work()
+                    );
                     if non_finalized_snapshot.heights_to_hashes.get(&block.height()) == Some(block.hash()) {
                         assert_eq!(index_reader.find_fork_point(&snapshot, hash).await.unwrap().unwrap().0, *hash);
                     } else {

--- a/packages/zaino-state/src/chain_index/types/db/legacy.rs
+++ b/packages/zaino-state/src/chain_index/types/db/legacy.rs
@@ -1179,33 +1179,53 @@ impl IndexedBlock {
     ///       with tx data being added selectively here.
     pub fn to_compact_block(&self) -> zaino_proto::proto::compact_formats::CompactBlock {
         // NOTE: Returns u64::MAX if the block is not in the best chain.
-        let height: u64 = self.height().0.into();
+        compact_block_from_parts(
+            self.height(),
+            self.hash(),
+            &self.context.parent_hash,
+            self.data().time(),
+            self.transactions(),
+            self.commitment_tree_data(),
+        )
+    }
+}
 
-        let hash = self.hash().0.to_vec();
-        let prev_hash = self.context.parent_hash.0.to_vec();
+/// Build a proto-v4 `CompactBlock` from the parts shared by [`IndexedBlock`]
+/// and the non-finalized `ProvisionalBlock`. Compact-block construction needs
+/// no cumulative chainwork, so both block types produce identical output via
+/// this one assembly — no duplication.
+pub(crate) fn compact_block_from_parts(
+    height: Height,
+    hash: &BlockHash,
+    parent_hash: &BlockHash,
+    time: i64,
+    transactions: &[CompactTxData],
+    commitment_tree_data: &CommitmentTreeData,
+) -> zaino_proto::proto::compact_formats::CompactBlock {
+    let height: u64 = height.0.into();
+    let hash = hash.0.to_vec();
+    let prev_hash = parent_hash.0.to_vec();
 
-        let vtx: Vec<zaino_proto::proto::compact_formats::CompactTx> = self
-            .transactions()
-            .iter()
-            .map(|tx| tx.to_compact_tx(None))
-            .collect();
+    let vtx: Vec<zaino_proto::proto::compact_formats::CompactTx> = transactions
+        .iter()
+        .map(|tx| tx.to_compact_tx(None))
+        .collect();
 
-        let sapling_commitment_tree_size = self.commitment_tree_data().sizes().sapling();
-        let orchard_commitment_tree_size = self.commitment_tree_data().sizes().orchard();
+    let sapling_commitment_tree_size = commitment_tree_data.sizes().sapling();
+    let orchard_commitment_tree_size = commitment_tree_data.sizes().orchard();
 
-        zaino_proto::proto::compact_formats::CompactBlock {
-            proto_version: 4,
-            height,
-            hash,
-            prev_hash,
-            time: self.data().time() as u32,
-            header: vec![],
-            vtx,
-            chain_metadata: Some(zaino_proto::proto::compact_formats::ChainMetadata {
-                sapling_commitment_tree_size,
-                orchard_commitment_tree_size,
-            }),
-        }
+    zaino_proto::proto::compact_formats::CompactBlock {
+        proto_version: 4,
+        height,
+        hash,
+        prev_hash,
+        time: time as u32,
+        header: vec![],
+        vtx,
+        chain_metadata: Some(zaino_proto::proto::compact_formats::ChainMetadata {
+            sapling_commitment_tree_size,
+            orchard_commitment_tree_size,
+        }),
     }
 }
 

--- a/packages/zaino-state/src/chain_index/types/helpers.rs
+++ b/packages/zaino-state/src/chain_index/types/helpers.rs
@@ -129,8 +129,23 @@ impl<'a> BlockWithMetadata<'a> {
         Self { block, metadata }
     }
 
+    /// This block's own work, derived from its header difficulty target.
+    /// Header-only, so it is shared by both absolute chainwork accumulation
+    /// (`create_block_context`) and relative/provisional accumulation.
+    pub(crate) fn block_work(&self) -> Result<ChainWork, String> {
+        let work = self
+            .block
+            .header
+            .difficulty_threshold
+            .to_work()
+            .ok_or_else(|| {
+                "Failed to calculate block work from difficulty threshold".to_string()
+            })?;
+        Ok(ChainWork::from(U256::from(work.as_u128())))
+    }
+
     /// Extract block header data
-    fn extract_block_data(&self) -> Result<BlockData, String> {
+    pub(crate) fn extract_block_data(&self) -> Result<BlockData, String> {
         let block = self.block;
         let network = &self.metadata.network;
 
@@ -150,7 +165,7 @@ impl<'a> BlockWithMetadata<'a> {
     }
 
     /// Extract and process all transactions in the block
-    fn extract_transactions(&self) -> Result<Vec<CompactTxData>, String> {
+    pub(crate) fn extract_transactions(&self) -> Result<Vec<CompactTxData>, String> {
         let mut transactions = Vec::new();
 
         for (i, txn) in self.block.transactions.iter().enumerate() {
@@ -278,19 +293,13 @@ impl<'a> BlockWithMetadata<'a> {
             .map(|height| Height(height.0))
             .ok_or_else(|| String::from("Any valid block has a coinbase height"))?;
 
-        let block_work = block.header.difficulty_threshold.to_work().ok_or_else(|| {
-            "Failed to calculate block work from difficulty threshold".to_string()
-        })?;
-        let chainwork = self
-            .metadata
-            .parent_chainwork
-            .add(&ChainWork::from(U256::from(block_work.as_u128())));
+        let chainwork = self.metadata.parent_chainwork.add(&self.block_work()?);
 
         Ok(BlockContext::new(hash, parent_hash, chainwork, height))
     }
 
     /// Create commitment tree data from metadata
-    fn create_commitment_tree_data(&self) -> super::db::CommitmentTreeData {
+    pub(crate) fn create_commitment_tree_data(&self) -> super::db::CommitmentTreeData {
         let commitment_tree_roots = super::db::CommitmentTreeRoots::new(
             <[u8; 32]>::from(self.metadata.sapling_root),
             <[u8; 32]>::from(self.metadata.orchard_root),


### PR DESCRIPTION
Addresses #1096

This PR depends on #1151 so it should only be reviewed if that PR has passed review.

It wires the conservative ProvisionalBlocks that are defined in the PR into the NFS snapshot.

This provides type level safety against mistaking accumulated work for provisional work.