### PR TITLE
Merge dev into rc/0.4.0 for rc.2

### DIFF
--- a/packages/zaino-fetch/CHANGELOG.md
+++ b/packages/zaino-fetch/CHANGELOG.md
@@ -8,11 +8,20 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
-- `JsonRpSeeConnector::get_tx_out_set_info` — JSON-RPC client method for the
-  upstream `gettxoutsetinfo` call.
-- `jsonrpsee::response::GetTxOutSetInfoResponse` (`Info` | `Empty` untagged
+- `JsonRpSeeConnector`: — JSON-RPC client method for the upstream calls.
+  - `get_tx_out_set_info` - RPC gettxoutsetinfo 
+  - `get_chain_tips` - RPC getchaintips
+  - `get_tx_out` - RPC gettxout
+  - `get_spent_info` - RPC getspentinfo
+- `jsonrpsee::response`
+  - `GetTxOutSetInfoResponse` (`Info` | `Empty` untagged
   enum), `GetTxOutSetInfo` and `EmptyTxOutSetInfo` types covering both the
   populated and stats-collection-failed shapes returned by zcashd.
+  - `chain_tip` mod containing `ChainTip`, `ChainTipStatus`, `GetChainTipsResponse`
+  - `GetTxOutResponse`
+  - `GetSpentInfoRequest`
+  - `GetSpentInfoResponse`, `GetSpentInfoError`
+  
 ### Changed
 ### Deprecated
 ### Removed

--- a/packages/zaino-serve/CHANGELOG.md
+++ b/packages/zaino-serve/CHANGELOG.md
@@ -8,6 +8,13 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+- `rpc::grpc_routes` helper function to expose routes
+  without callers needing direct `zaino-proto` dependency
+- `rpc::jsonrpc::service::ZcashIndexerRpc` new trait methods:
+  - `get_tx_out_set_info`
+  - `get_chain_tips`
+  - `get_tx_out`
+  - `get_spent_info`
 ### Changed
 ### Deprecated
 ### Removed


### PR DESCRIPTION
## Summary
Brings latest dev into the RC branch for 0.4.0-rc.2.

- #1153 — tx_out_set accumulator bug fix
- #1067 — lightwalletd compact block parity
- #1143 — minimal zainod README

Tag `0.4.0-rc.2` already pushed and release workflow running.