### PR TITLE
Tooling/CI: setup shellcheck and extract bash from Makefile.toml

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,0 +1,24 @@
+name: Shellcheck
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    branches:
+      - dev
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Lint shell scripts
+        run: ./tools/scripts/lint-shell.sh

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,11 @@
+# ShellCheck configuration for the zaino repo.
+#
+# external-sources lets ShellCheck follow `source`d files referenced by
+# `# shellcheck source=...` directives (equivalent to passing -x), so checks
+# see helper definitions in tools/scripts/helpers.sh and functions.sh.
+external-sources=true
+
+# Resolve `source=...` directive paths relative to the repo root (where the
+# lint runs from) as well as the script's own directory.
+source-path=.
+source-path=SCRIPTDIR

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -21,110 +21,16 @@ RUST_VERSION = { script = ["./tools/scripts/get-rust-version.sh"] }
 description = "List available commands and usage notes"
 script_runner = "bash"
 extend = "base-script"
-script.main = '''
-set -euo pipefail
-
-echo ""
-echo "Zaino CI Image Tasks"
-echo "---------------------"
-echo ""
-echo "Common usage:"
-echo "  makers container-test"
-echo ""
-echo "If you modify '.env.testing-artifacts', the test command will automatically:"
-echo "  - Recompute the image tag"
-echo "  - Build a new local container image if needed"
-echo ""
-echo "Available commands:"
-echo ""
-echo "  container-test             Run integration tests using the local image"
-echo "  integration-test           Run integration-tests sub-workspace (forwards flags to nextest)"
-echo "  container-test-save-failures    Run tests, save failures to .failed-tests"
-echo "  container-test-retry-failures   Rerun only the previously failed tests"
-echo "  build-image                Build the container image with current artifact versions"
-echo "  push-image                 Push the image (used in CI, can be used manually)"
-echo "  compute-image-tag          Compute the tag for the container image based on versions"
-echo "  get-podman-hash            Get CONTAINER_DIR_HASH value (hash for the image defining files)"
-echo "  ensure-image-exists        Check if the required image exists locally, build if not"
-echo "  pull-ci-image              Pull the CI image from the registry"
-echo "  check-matching-zebras      Verify Zebra versions match between Cargo.toml and .env"
-echo "  validate-test-targets      Check if nextest targets match CI workflow matrix"
-echo "  update-test-targets        Update CI workflow matrix to match nextest targets"
-echo "  validate-makefile-tasks    Run minimal validation of all maker tasks"
-echo "  verify-all                 Exercise every task for correctness (idempotent)"
-echo "  hello-rust                 Test rust-script functionality"
-echo ""
-echo "Lint commands:"
-echo "  lint                       Run all lints (fmt, clippy, doc). Use as a pre-commit hook."
-echo "  fmt                        Check formatting (cargo fmt --all -- --check)"
-echo "  clippy                     Run Clippy with -D warnings (--all-targets --all-features)"
-echo "  doc                        Build docs (no deps, all features, document private items) with RUSTDOCFLAGS='-D warnings'"
-echo "  toggle-hooks               Toggle the git config for core.hooksPath to use .githooks/"
-echo ""
-echo "Build speed:"
-echo "  use-system-rocksdb         Link against system RocksDB (skips slow C++ build)"
-echo "  use-bundled-rocksdb        Revert to building RocksDB from source"
-echo "  check-system-rocksdb       Check system RocksDB compatibility"
-echo "  audit-system-rocksdb       Re-audit if Cargo.lock or system version changed"
-echo "  set-worktree-parent-tools  Copy .cargo/config.toml to common worktree parent"
-echo ""
-echo "Environment:"
-echo "  ZCASH_VERSION, ZEBRA_VERSION  Defined by: .env.testing-artifacts"
-echo "  RUST_VERSION                  Derived from rust-toolchain.toml"
-echo "                                via tools/scripts/get-rust-version.sh"
-echo ""
-echo "Build Context:"
-echo "  integration-tests/test_environment/   Directory containing the container build environment"
-echo "    ├── Containerfile                 Containerfile for CI/test container"
-echo "    └── entrypoint.sh                Entrypoint script that sets up test binaries"
-echo ""
-echo "Helpers:"
-echo "  - tools/scripts/get-ci-image-tag.sh: computes the version-based image tag"
-echo "  - tools/scripts/helpers.sh: logging and helper functions"
-echo ""
-'''
+script.main = 'source "./tools/scripts/help.sh"'
 
 [tasks.base-script]
-script.pre = '''
-source "./tools/scripts/helpers.sh"
-TAG=$(./tools/scripts/get-ci-image-tag.sh)
-
-# Generic cleanup function for containers
-podman_cleanup() {
-    # Prevent running cleanup twice
-    if [ "${CLEANUP_RAN:-0}" -eq 1 ]; then
-        return
-    fi
-    CLEANUP_RAN=1
-
-    # Check if we're cleaning up due to interruption
-    if [ "$?" -eq 130 ] || [ "$?" -eq 143 ]; then
-        echo ""
-        warn "Task '${CARGO_MAKE_CURRENT_TASK_NAME}' interrupted! Cleaning up..."
-    fi
-
-    # Kill all child processes
-    local pids=$(jobs -pr)
-    if [ -n "$pids" ]; then
-        kill $pids 2>/dev/null || true
-    fi
-
-    # Stop any containers started by this script
-    if [ -n "${CONTAINER_ID:-}" ]; then
-        info "Stopping container..."
-        podman stop "$CONTAINER_ID" >/dev/null 2>&1 || true
-    fi
-
-    # Also stop by name if CONTAINER_NAME is set
-    if [ -n "${CONTAINER_NAME:-}" ] && [ -z "${CONTAINER_ID:-}" ]; then
-        info "Stopping container ${CONTAINER_NAME}..."
-        podman stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
-    fi
-}
-
-# Set up cleanup trap
-trap podman_cleanup EXIT INT TERM
-'''
+# The pre-script lives in tools/scripts/base-script-pre.sh and is *sourced*
+# (not executed) so the TAG var, podman_cleanup function, and cleanup trap it
+# defines stay in scope for each consuming task's script.main. cargo-make
+# concatenates pre/main/post into one shell program, so sourcing keeps them in
+# the same shell.
+script_runner = "bash"
+script.pre = 'source "./tools/scripts/base-script-pre.sh"'
 script.main = "err 'default main script. define a proper script to skip this one'"
 script.post = ""
 
@@ -133,77 +39,35 @@ script.post = ""
 [tasks.init-podman-volumes]
 description = "Initialize named podman volumes for container builds"
 script_runner = "bash"
-script = '''
-for vol in zaino-container-target zaino-cargo-git zaino-cargo-registry; do
-    if ! podman volume inspect "$vol" >/dev/null 2>&1; then
-        podman volume create "$vol"
-        echo "Created podman volume: $vol"
-    fi
-done
-
-# Pre-create host-side target/ owned by the current user. The container-test
-# podman invocation bind-mounts $PWD into the container and then overlays the
-# zaino-container-target volume on /.../zaino/target. If host-side target/
-# does not exist when that mount layer is applied, some podman/runc/buildah
-# combinations create it under a uidmap-escaped UID (e.g. UID 100000), which
-# then breaks host-side `cargo` with EACCES. Pre-creating it as the current
-# user avoids that. If target/ already exists but is unwritable (a previous
-# leak), recreate it: rm -rf works because the parent directory is owned by
-# the current user even if target/ itself is not.
-if [[ -e target && ! -w target ]]; then
-    echo "target/ exists but is not writable; recreating to recover from uidmap leak..."
-    rm -rf target
-fi
-mkdir -p target
-'''
+script = 'source "./tools/scripts/init-podman-volumes.sh"'
 
 # -------------------------------------------------------------------
 
 [tasks.compute-image-tag]
 description = "Compute image tag from version vars"
-script = '''
-TAG=$(./tools/scripts/get-ci-image-tag.sh)
-echo "CARGO_MAKE_IMAGE_TAG=$TAG"
-export CARGO_MAKE_IMAGE_TAG=$TAG
-'''
+script_runner = "bash"
+script = 'source "./tools/scripts/compute-image-tag.sh"'
+
 # -------------------------------------------------------------------
 
 [tasks.get-podman-hash]
 description = "Get the current CONTAINER_DIR_HASH"
 script_runner = "bash"
-script = '''
-HASH=$(./tools/scripts/get-container-hash.sh)
-echo "CONTAINER_DIR_HASH=$HASH"
-'''
+script = 'source "./tools/scripts/get-podman-hash.sh"'
 
 [tasks.ensure-image-exists]
 description = "Ensure the image exists locally, building if needed"
 dependencies = ["init-podman-volumes"]
 script_runner = "bash"
 extend = "base-script"
-script.main = '''
-if ! podman image inspect ${IMAGE_NAME}:${TAG} > /dev/null 2>&1; then
-  info "Image not found locally. Building..."
-  makers build-image
-else
-  info "Image ${IMAGE_NAME}:${TAG} already exists locally."
-fi
-'''
+script.main = 'source "./tools/scripts/ensure-image-exists.sh"'
 
 # -------------------------------------------------------------------
 
 [tasks.pull-ci-image]
 description = "Pull the CI image from the registry"
 extend = "base-script"
-script.main = '''
-info "Pulling ${IMAGE_NAME}:${TAG} from registry..."
-if podman pull ${IMAGE_NAME}:${TAG}; then
-  info "Image ${IMAGE_NAME}:${TAG} pulled successfully."
-else
-  err "Image ${IMAGE_NAME}:${TAG} not found on registry."
-  exit 1
-fi
-'''
+script.main = 'source "./tools/scripts/pull-ci-image.sh"'
 
 # -------------------------------------------------------------------
 
@@ -213,35 +77,7 @@ description = "Build the container image for testing artifacts"
 # directory, which contains the Containerfile and entrypoint.sh for the CI/test environment.
 script_runner = "bash"
 extend = "base-script"
-script.main = '''
-set -euo pipefail
-
-# Create target directory with correct ownership before podman creates it as root
-mkdir -p target
-
-TARGET=$(resolve_build_target "$ZCASH_VERSION" "$ZEBRA_VERSION")
-
-# For local builds, use the current user's UID/GID to avoid permission issues
-# CI builds will use the default UID=1001 from the Containerfile
-
-info "Building image"
-info "Tag: ${TAG}"
-info "Target: $TARGET"
-info "Current directory: $(pwd)"
-info "Files in tools/scripts/: $(ls -la tools/scripts/ | head -5)"
-
-cd integration-tests/test_environment && \
-podman build -f Containerfile \
-  --target "$TARGET" \
-  --build-arg ZCASH_VERSION=$ZCASH_VERSION \
-  --build-arg ZEBRA_VERSION=$ZEBRA_VERSION \
-  --build-arg RUST_VERSION=$RUST_VERSION \
-  --build-arg UID=$(id -u) \
-  --build-arg GID=$(id -g) \
-  -t ${IMAGE_NAME}:$TAG \
-  ${@} \
-  .
-'''
+script.main = 'source "./tools/scripts/build-image.sh"'
 
 # -------------------------------------------------------------------
 
@@ -251,13 +87,7 @@ description = "Push image if running in CI"
 dependencies = ["ensure-image-exists"]
 script_runner = "bash"
 extend = "base-script"
-script.main = '''
-set -euo pipefail
-
-info "Pushing image: ${IMAGE_NAME}:$TAG"
-
-podman push ${IMAGE_NAME}:$TAG
-'''
+script.main = 'source "./tools/scripts/push-image.sh"'
 
 # -------------------------------------------------------------------
 
@@ -270,52 +100,7 @@ description = "Run integration tests using the local image"
 dependencies = ["init-podman-volumes", "ensure-image-exists"]
 script_runner = "bash"
 extend = "base-script"
-script.main = '''
-set -euo pipefail
-
-info "Running tests using:"
-info "-- IMAGE             = ${IMAGE_NAME}"
-info "-- TAG               = $TAG"
-# info "-- TEST_BINARIES_DIR = ${TEST_BINARIES_DIR}"
-
-# Set container name for cleanup. Suffix with $$ (script PID) so concurrent
-# `makers container-test` invocations on the same host don't collide on the
-# `zaino-testing` name. The base-script cleanup trap reads CONTAINER_NAME
-# from script scope and stops the right container on EXIT/INT/TERM.
-CONTAINER_NAME="zaino-testing-$$"
-
-# Run podman in foreground with proper signal handling.
-#
-# `--pids-limit=-1` removes the default 2048-process cgroup cap. With
-# `--profile stable` (test-threads = num-cpus) each integration test
-# spawns a full zebrad whose rayon pool itself sizes to num-cpus, so
-# peak task count scales ~num_cpus^2. On developer hosts with many
-# cores the default cap is breached and `clone()` returns EAGAIN,
-# surfacing as "OS can't spawn worker thread" / rayon ThreadPoolBuildError
-# panics scattered across unrelated tests.
-podman run --rm \
-  --init \
-  --pids-limit=-1 \
-  --name "$CONTAINER_NAME" \
-  -v "$PWD":/home/container_user/zaino \
-  -v zaino-container-target:/home/container_user/zaino/target:U \
-  -v zaino-cargo-git:/usr/local/cargo/git:U \
-  -v zaino-cargo-registry:/usr/local/cargo/registry:U \
-  -e "TEST_BINARIES_DIR=${TEST_BINARIES_DIR}" \
-  -e "NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1" \
-  -e "ZAINOLOG_FORMAT=${ZAINOLOG_FORMAT:-stream}" \
-  -e "RUST_LOG=${RUST_LOG:-}" \
-  -w /home/container_user/zaino \
-  -u container_user \
-  "${IMAGE_NAME}:$TAG" \
-  cargo nextest run "${@}" &
-
-# Capture the background job PID
-PODMAN_PID=$!
-
-# Wait for the podman process
-wait $PODMAN_PID
-'''
+script.main = 'source "./tools/scripts/container-test.sh"'
 script.post = "makers notify"
 
 # -------------------------------------------------------------------
@@ -324,14 +109,7 @@ script.post = "makers notify"
 description = "Run the integration-tests sub-workspace inside the CI container (forwards extra args to `cargo nextest run`)"
 script_runner = "bash"
 extend = "base-script"
-script.main = '''
-set -euo pipefail
-
-info "Running integration-tests sub-workspace via container-test"
-info "-- manifest: integration-tests/Cargo.toml"
-
-exec makers container-test --manifest-path integration-tests/Cargo.toml "${@}"
-'''
+script.main = 'source "./tools/scripts/integration-test.sh"'
 
 # -------------------------------------------------------------------
 
@@ -339,40 +117,7 @@ exec makers container-test --manifest-path integration-tests/Cargo.toml "${@}"
 description = "Check that zebra versions in .env.testing-artifacts match what's in Cargo.toml"
 extend = "base-script"
 script_runner = "bash"
-script.main = '''
-set -euo pipefail
-
-# Verify ZEBRA_VERSION from .env.testing-artifacts is consistent with Cargo.toml.
-# Zebra deps may be crates.io versions ("6.0.1") or git revs (rev="abc123").
-# The .env ZEBRA_VERSION is the Docker image tag (e.g. "4.3.0").
-
-# Check for git rev-based deps first
-cargo_toml=$(sed 's/#.*//' Cargo.toml | tr -d '[:space:]')
-zebra_revs=$(echo "$cargo_toml" | grep -o 'zebra-[a-z]*={[^}]*rev="[^"]*"' | grep -o 'rev="[^"]*"' | cut -d'"' -f2 | sort -u || true)
-
-if [[ -n "$zebra_revs" ]]; then
-  rev_count=$(echo "$zebra_revs" | wc -l)
-  if [[ "$rev_count" -ne 1 ]]; then
-    err "❌ Multiple Zebra revs detected in Cargo.toml:"
-    echo "$zebra_revs"
-    exit 1
-  fi
-  # Accept short SHA match
-  if [[ "$zebra_revs" != "$ZEBRA_VERSION" && "${zebra_revs:0:${#ZEBRA_VERSION}}" != "$ZEBRA_VERSION" ]]; then
-    err "❌ Mismatch: Cargo.toml has rev $zebra_revs, but .env has $ZEBRA_VERSION"
-    exit 1
-  fi
-else
-  # Crates.io version deps — just verify the Docker image tag is set
-  if [[ -z "$ZEBRA_VERSION" ]]; then
-    err "❌ ZEBRA_VERSION is not set in .env.testing-artifacts"
-    exit 1
-  fi
-  info "Zebra deps are crates.io versions; Docker image tag is ${ZEBRA_VERSION}"
-fi
-
-info "✅ Zebra version check passed (.env ZEBRA_VERSION=${ZEBRA_VERSION})"
-'''
+script.main = 'source "./tools/scripts/check-matching-zebras.sh"'
 
 # -------------------------------------------------------------------
 
@@ -380,104 +125,7 @@ info "✅ Zebra version check passed (.env ZEBRA_VERSION=${ZEBRA_VERSION})"
 description = "Validate all tasks work correctly with minimal execution"
 dependencies = ["init-podman-volumes"]
 script_runner = "@rust"
-script = '''
-use std::process::{Command, Stdio};
-use std::env;
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("🔍 Starting validation of all Makefile tasks...");
-
-    // 1. Check version matching
-    println!("\nStep 1: Checking version consistency...");
-    run_makers_task("check-matching-zebras")?;
-
-    // 2. Compute the image tag
-    println!("\nStep 2: Computing image tag...");
-    run_makers_task("compute-image-tag")?;
-
-    // 3. Ensure image exists (will build if necessary)
-    println!("\nStep 3: Ensuring container image exists...");
-    run_makers_task("ensure-image-exists")?;
-
-    // 4. Get the computed tag
-    let tag = get_image_tag()?;
-    let image_name = env::var("IMAGE_NAME").unwrap_or_else(|_| "zingodevops/zaino-ci".to_string());
-    let working_dir = env::current_dir()?.to_string_lossy().to_string();
-
-    // 5. Run a single fast test to validate the full pipeline
-    println!("\nStep 4: Running minimal test to validate setup...");
-    println!("Using image: {}:{}", image_name, tag);
-
-    let status = Command::new("podman")
-        .args(&[
-            "run", "--rm",
-            "--init",
-            "--name", "zaino-validation-test",
-            "-v", &format!("{}:/home/container_user/zaino", working_dir),
-            "-v", "zaino-container-target:/home/container_user/zaino/target:U",
-            "-v", "zaino-cargo-git:/usr/local/cargo/git:U",
-            "-v", "zaino-cargo-registry:/usr/local/cargo/registry:U",
-            "-e", "TEST_BINARIES_DIR=/home/container_user/zaino/integration-tests/test_binaries/bins",
-            "-w", "/home/container_user/zaino",
-            "-u", "container_user",
-            &format!("{}:{}", image_name, tag),
-            "cargo", "test",
-            "--package", "zaino-testutils",
-            "--lib", "launch_testmanager::zcashd::basic",
-            "--", "--nocapture"
-        ])
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()?;
-
-    if !status.success() {
-        eprintln!("❌ Validation failed!");
-        std::process::exit(1);
-    }
-
-    println!("\n✅ All tasks validated successfully!");
-    Ok(())
-}
-
-fn run_makers_task(task: &str) -> Result<(), Box<dyn std::error::Error>> {
-    println!("DEBUG: About to run makers {}", task);
-    let status = Command::new("makers")
-        .arg(task)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()?;
-
-    println!("DEBUG: makers {} completed with status: {:?}", task, status);
-    if !status.success() {
-        return Err(format!("Task '{}' failed", task).into());
-    }
-    Ok(())
-}
-
-fn get_image_tag() -> Result<String, Box<dyn std::error::Error>> {
-    println!("DEBUG: Getting image tag...");
-    // First try to get from environment
-    if let Ok(tag) = env::var("CARGO_MAKE_IMAGE_TAG") {
-        if !tag.is_empty() {
-            println!("DEBUG: Found tag in env: {}", tag);
-            return Ok(tag);
-        }
-    }
-
-    println!("DEBUG: Computing tag with script...");
-    // Otherwise compute it
-    let output = Command::new("./tools/scripts/get-ci-image-tag.sh")
-        .output()?;
-
-    if !output.status.success() {
-        return Err("Failed to compute image tag".into());
-    }
-
-    let tag = String::from_utf8(output.stdout)?.trim().to_string();
-    println!("DEBUG: Computed tag: {}", tag);
-    Ok(tag)
-}
-'''
+script = { file = "tools/scripts/validate-makefile-tasks.rs" }
 
 # -------------------------------------------------------------------
 
@@ -485,62 +133,7 @@ fn get_image_tag() -> Result<String, Box<dyn std::error::Error>> {
 description = "Validate that nextest targets match CI workflow matrix"
 script_runner = "bash"
 extend = "base-script"
-script.main = '''
-set -euo pipefail
-
-info "🔍 Validating test targets between nextest and CI workflow..."
-
-# Extract nextest targets with non-empty testcases.
-# The `ci` profile lives in integration-tests/.config/nextest.toml, so use --manifest-path.
-info "Extracting targets from nextest..."
-NEXTEST_TARGETS=$(mktemp)
-cargo nextest list --manifest-path integration-tests/Cargo.toml --profile ci -T json-pretty | jq -r '.["rust-suites"] | to_entries[] | select(.value.testcases | length > 0) | .key' | sort > "$NEXTEST_TARGETS"
-
-# Extract CI matrix partition values
-info "Extracting targets from CI workflow..."
-CI_TARGETS=$(mktemp)
-lq -r '.jobs.test.strategy.matrix.partition[]' < .github/workflows/ci.yml | sort > "$CI_TARGETS"
-
-# Compare the lists
-info "Comparing target lists..."
-
-MISSING_IN_CI=$(mktemp)
-EXTRA_IN_CI=$(mktemp)
-
-# Find targets in nextest but not in CI
-comm -23 "$NEXTEST_TARGETS" "$CI_TARGETS" > "$MISSING_IN_CI"
-
-# Find targets in CI but not in nextest (or with empty testcases)
-comm -13 "$NEXTEST_TARGETS" "$CI_TARGETS" > "$EXTRA_IN_CI"
-
-# Display results
-if [[ ! -s "$MISSING_IN_CI" && ! -s "$EXTRA_IN_CI" ]]; then
-    info "✅ All test targets are synchronized!"
-    echo "Nextest targets ($(wc -l < "$NEXTEST_TARGETS")):"
-    cat "$NEXTEST_TARGETS" | sed 's/^/  - /'
-else
-    warn "❌ Test target synchronization issues found:"
-
-    if [[ -s "$MISSING_IN_CI" ]]; then
-        echo ""
-        warn "📋 Targets with tests missing from CI matrix ($(wc -l < "$MISSING_IN_CI")):"
-        cat "$MISSING_IN_CI" | sed 's/^/  - /'
-    fi
-
-    if [[ -s "$EXTRA_IN_CI" ]]; then
-        echo ""
-        warn "🗑️  Targets in CI matrix with no tests ($(wc -l < "$EXTRA_IN_CI")):"
-        cat "$EXTRA_IN_CI" | sed 's/^/  - /'
-    fi
-
-    echo ""
-    info "💡 To automatically update the CI workflow, run:"
-    info "   makers update-test-targets"
-fi
-
-# Cleanup temp files
-rm "$NEXTEST_TARGETS" "$CI_TARGETS" "$MISSING_IN_CI" "$EXTRA_IN_CI"
-'''
+script.main = 'source "./tools/scripts/validate-test-targets.sh"'
 
 # -------------------------------------------------------------------
 
@@ -548,50 +141,7 @@ rm "$NEXTEST_TARGETS" "$CI_TARGETS" "$MISSING_IN_CI" "$EXTRA_IN_CI"
 description = "Update CI workflow matrix to match nextest targets"
 script_runner = "bash"
 extend = "base-script"
-script.main = '''
-set -euo pipefail
-
-info "🔧 Updating CI workflow matrix to match nextest targets..."
-
-# Extract nextest targets with non-empty testcases.
-# The `ci` profile lives in integration-tests/.config/nextest.toml, so use --manifest-path.
-info "Extracting current nextest targets..."
-NEXTEST_TARGETS=$(mktemp)
-cargo nextest list --manifest-path integration-tests/Cargo.toml --profile ci -T json-pretty | jq -r '.["rust-suites"] | to_entries[] | select(.value.testcases | length > 0) | .key' | sort > "$NEXTEST_TARGETS"
-
-echo "Found $(wc -l < "$NEXTEST_TARGETS") targets with tests:"
-cat "$NEXTEST_TARGETS" | sed 's/^/  - /'
-
-# Update only the partition array using sed to preserve formatting
-# First, create the new partition list in the exact format we need
-NEW_PARTITION_LINES=$(mktemp)
-while IFS= read -r target; do
-    echo "          - \"${target}\""
-done < "$NEXTEST_TARGETS" > "$NEW_PARTITION_LINES"
-
-# Use sed to replace just the partition array section
-# Find the partition: line and replace everything until the next non-indented item
-sed -i '/^[[:space:]]*partition:/,/^[[:space:]]*[^[:space:]-]/{
-    /^[[:space:]]*partition:/!{
-        /^[[:space:]]*[^[:space:]-]/!d
-    }
-}' .github/workflows/ci.yml
-
-# Now insert the new partition lines after the "partition:" line
-sed -i "/^[[:space:]]*partition:$/r $NEW_PARTITION_LINES" .github/workflows/ci.yml
-
-rm "$NEW_PARTITION_LINES"
-
-info "✅ CI workflow updated successfully!"
-
-# Show what was changed using git diff
-echo ""
-info "Changes made:"
-git diff --no-index /dev/null .github/workflows/ci.yml 2>/dev/null | grep "^[+-].*partition\|^[+-].*integration-tests\|^[+-].*zaino\|^[+-].*zainod" || git diff .github/workflows/ci.yml || echo "No changes detected"
-
-# Cleanup temp files
-rm "$NEXTEST_TARGETS"
-'''
+script.main = 'source "./tools/scripts/update-test-targets.sh"'
 
 # -------------------------------------------------------------------
 
@@ -599,32 +149,7 @@ rm "$NEXTEST_TARGETS"
 description = "Run container-test and save failed test names for later retry"
 script_runner = "bash"
 extend = "base-script"
-script.main = '''
-set -uo pipefail
-
-FAILURES_FILE=".failed-tests"
-
-info "Running container-test with failure tracking..."
-
-# Run container-test with libtest-json, tee output for parsing
-makers container-test --no-fail-fast --message-format libtest-json "${@}" 2>&1 | tee /tmp/nextest-output.json || true
-
-# Extract failed test names
-grep '"event":"failed"' /tmp/nextest-output.json 2>/dev/null | \
-    jq -r '.name // empty' | sort -u > "$FAILURES_FILE"
-
-FAIL_COUNT=$(wc -l < "$FAILURES_FILE" | tr -d ' ')
-
-if [[ "$FAIL_COUNT" -gt 0 ]]; then
-    warn "💾 Saved $FAIL_COUNT failed test(s) to $FAILURES_FILE"
-    cat "$FAILURES_FILE"
-    echo ""
-    info "Run 'makers container-test-retry-failures' to rerun them"
-else
-    info "✅ All tests passed!"
-    rm -f "$FAILURES_FILE"
-fi
-'''
+script.main = 'source "./tools/scripts/container-test-save-failures.sh"'
 script.post = "makers notify"
 
 # -------------------------------------------------------------------
@@ -633,37 +158,7 @@ script.post = "makers notify"
 description = "Rerun only failed tests from previous container-test-save-failures"
 script_runner = "bash"
 extend = "base-script"
-script.main = '''
-set -euo pipefail
-
-FAILURES_FILE=".failed-tests"
-
-if [[ ! -f "$FAILURES_FILE" ]]; then
-    err "No $FAILURES_FILE found. Run 'makers container-test-save-failures' first."
-    exit 1
-fi
-
-FAIL_COUNT=$(wc -l < "$FAILURES_FILE" | tr -d ' ')
-if [[ "$FAIL_COUNT" -eq 0 ]]; then
-    info "No failed tests to retry!"
-    exit 0
-fi
-
-info "Retrying $FAIL_COUNT failed test(s)..."
-
-# Build filter from libtest-json format: "package::binary$testname"
-# Output format: (package(P) & binary(B) & test(=T)) | ...
-FILTER=$(while IFS= read -r line; do
-    pkg="${line%%::*}"
-    rest="${line#*::}"
-    bin="${rest%%\$*}"
-    test="${rest#*\$}"
-    echo "(package($pkg) & binary($bin) & test(=$test))"
-done < "$FAILURES_FILE" | tr '\n' '|' | sed 's/|$//; s/|/ | /g')
-
-info "Filter: $FILTER"
-makers container-test -E "$FILTER" "${@}"
-'''
+script.main = 'source "./tools/scripts/container-test-retry-failures.sh"'
 script.post = "makers notify"
 
 # -------------------------------------------------------------------
@@ -671,153 +166,4 @@ script.post = "makers notify"
 [tasks.verify-all]
 description = "Exercise every Makefile.toml task for correctness (idempotent)"
 script_runner = "bash"
-script = '''
-set -uo pipefail
-
-source "./tools/scripts/helpers.sh"
-
-VERIFY_TMPDIR=$(mktemp -d)
-PASS=0
-FAIL=0
-SKIPPED=0
-
-cleanup() {
-    info "Cleaning up verification artifacts..."
-
-    # Restore .cargo/config.toml if we saved one
-    if [[ -f "$VERIFY_TMPDIR/cargo-config.toml.bak" ]]; then
-        mkdir -p .cargo
-        cp "$VERIFY_TMPDIR/cargo-config.toml.bak" .cargo/config.toml
-    elif [[ -f "$VERIFY_TMPDIR/cargo-config-absent" ]]; then
-        rm -f .cargo/config.toml
-    fi
-
-    # Restore .cargo/.rocksdb-audit if we saved one
-    if [[ -f "$VERIFY_TMPDIR/rocksdb-audit.bak" ]]; then
-        cp "$VERIFY_TMPDIR/rocksdb-audit.bak" .cargo/.rocksdb-audit
-    elif [[ -f "$VERIFY_TMPDIR/rocksdb-audit-absent" ]]; then
-        rm -f .cargo/.rocksdb-audit
-    fi
-
-    # Remove test image if we built one
-    if [[ -f "$VERIFY_TMPDIR/image-tag" ]]; then
-        local tag
-        tag=$(cat "$VERIFY_TMPDIR/image-tag")
-        info "Removing verification image ${IMAGE_NAME}:verify-${tag}..."
-        podman rmi "${IMAGE_NAME}:verify-${tag}" 2>/dev/null || true
-    fi
-
-    # Remove temp dir
-    rm -rf "$VERIFY_TMPDIR"
-
-    echo ""
-    echo "========================================="
-    echo "verify-all: ${PASS} passed, ${FAIL} failed, ${SKIPPED} skipped"
-    echo "========================================="
-    if [[ $FAIL -gt 0 ]]; then
-        exit 1
-    fi
-}
-trap cleanup EXIT
-
-run_task() {
-    local name="$1"
-    shift
-    echo ""
-    info "--- ${name} ---"
-    if "$@" 2>&1; then
-        PASS=$((PASS + 1))
-        info "PASS: ${name}"
-    else
-        FAIL=$((FAIL + 1))
-        err "FAIL: ${name}"
-    fi
-}
-
-skip_task() {
-    local name="$1"
-    local reason="$2"
-    echo ""
-    warn "--- SKIP: ${name} (${reason}) ---"
-    SKIPPED=$((SKIPPED + 1))
-}
-
-# === Save state for idempotency ===
-if [[ -f .cargo/config.toml ]]; then
-    cp .cargo/config.toml "$VERIFY_TMPDIR/cargo-config.toml.bak"
-else
-    touch "$VERIFY_TMPDIR/cargo-config-absent"
-fi
-if [[ -f .cargo/.rocksdb-audit ]]; then
-    cp .cargo/.rocksdb-audit "$VERIFY_TMPDIR/rocksdb-audit.bak"
-else
-    touch "$VERIFY_TMPDIR/rocksdb-audit-absent"
-fi
-
-# === Tier 1: No container needed ===
-
-run_task "help" makers help
-run_task "compute-image-tag" makers compute-image-tag
-run_task "get-podman-hash" makers get-podman-hash
-run_task "init-podman-volumes" makers init-podman-volumes
-run_task "check-matching-zebras" makers check-matching-zebras
-run_task "fmt" makers fmt
-run_task "clippy" makers clippy
-run_task "doc" makers doc
-
-# Rocksdb tasks (save/restore state around them)
-if pkg-config --exists rocksdb 2>/dev/null; then
-    run_task "check-system-rocksdb" makers check-system-rocksdb
-    run_task "use-system-rocksdb" makers use-system-rocksdb
-    run_task "audit-system-rocksdb" makers audit-system-rocksdb
-    run_task "use-bundled-rocksdb" makers use-bundled-rocksdb
-else
-    skip_task "rocksdb tasks" "system rocksdb not installed"
-fi
-
-# toggle-hooks: run twice to restore original state
-run_task "toggle-hooks (on)" makers toggle-hooks
-run_task "toggle-hooks (off)" makers toggle-hooks
-
-# === Tier 2: Container build ===
-
-TAG=$(./tools/scripts/get-ci-image-tag.sh)
-echo "$TAG" > "$VERIFY_TMPDIR/image-tag"
-
-run_task "build-image" makers build-image
-run_task "ensure-image-exists" makers ensure-image-exists
-
-# Tag a verification copy so we can clean up without affecting cached images
-podman tag "${IMAGE_NAME}:${TAG}" "${IMAGE_NAME}:verify-${TAG}" 2>/dev/null || true
-
-# === Tier 3: Container execution ===
-# One test per component: zcashd, zebrad, lightwallet gRPC, wallet-to-validator
-# Tests live in the integration-tests sub-workspace.
-ITESTS="--manifest-path integration-tests/Cargo.toml"
-
-run_task "container-test (zcashd)" makers container-test \
-    $ITESTS -E "binary(wallet_to_validator) & test(=zcashd::connect_to_node_get_info)"
-
-run_task "container-test (zebrad)" makers container-test \
-    $ITESTS -E "binary(wallet_to_validator) & test(=zebrad::state_service::connect_to_node_get_info)"
-
-run_task "container-test (lightwallet)" makers container-test \
-    $ITESTS -E "binary(state_service) & test(=zebra::lightwallet_indexer::get_block)"
-
-run_task "container-test (wallet-to-validator)" makers container-test \
-    $ITESTS -E "binary(wallet_to_validator) & test(=zcashd::sent_to::transparent)"
-
-if command -v jq &>/dev/null && command -v yq &>/dev/null; then
-    run_task "validate-test-targets" makers validate-test-targets
-else
-    skip_task "validate-test-targets" "jq or yq not installed"
-fi
-
-# === Tier 4: Destructive/CI-only (skip) ===
-
-skip_task "push-image" "pushes to registry"
-skip_task "update-test-targets" "modifies CI workflow files"
-skip_task "validate-makefile-tasks" "redundant with this task"
-skip_task "container-test-save-failures" "requires full test run"
-skip_task "container-test-retry-failures" "requires prior save-failures"
-'''
+script = 'source "./tools/scripts/verify-all.sh"'

--- a/tools/makefiles/lints.toml
+++ b/tools/makefiles/lints.toml
@@ -61,9 +61,20 @@ script = [
     '''
 ]
 
+[tasks.lint-shell]
+description = "Lint all shell scripts with shellcheck"
+script_runner = "bash"
+script = 'source "./tools/scripts/lint-shell.sh"'
+
 [tasks.lint]
 description = "Run all lints. Use as a pre-commit hook."
-dependencies = ["fmt", "clippy", "doc", "lint-boundary-conversions"]
+dependencies = [
+    "fmt",
+    "clippy",
+    "doc",
+    "lint-boundary-conversions",
+    "lint-shell",
+]
 
 [tasks.toggle-hooks]
 description = "Toggles the git config for core.hooksPath"

--- a/tools/scripts/base-script-pre.sh
+++ b/tools/scripts/base-script-pre.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Pre-script for the `base-script` cargo-make task (Makefile.toml).
+#
+# This file is *sourced* (not executed) as the `script.pre` of `base-script`.
+# cargo-make concatenates a task's pre/main/post into a single shell program,
+# so everything defined here -- the `TAG` variable, the `podman_cleanup`
+# function, and the EXIT/INT/TERM trap -- stays in scope for the task's
+# `script.main`. Do not add `set -euo pipefail` here: the original inline
+# pre-script did not set it, and each consuming `script.main` sets its own
+# shell options.
+
+# shellcheck source=tools/scripts/helpers.sh
+source "./tools/scripts/helpers.sh"
+# TAG is consumed by each task's script.main after this file is sourced into
+# the same shell, so it is not unused here (SC2034 cannot see across sourcing).
+# shellcheck disable=SC2034
+TAG=$(./tools/scripts/get-ci-image-tag.sh)
+
+# Generic cleanup function for containers
+podman_cleanup() {
+    # Capture the triggering exit code before anything else clobbers $?.
+    local exit_code=$?
+
+    # Prevent running cleanup twice
+    if [ "${CLEANUP_RAN:-0}" -eq 1 ]; then
+        return
+    fi
+    CLEANUP_RAN=1
+
+    # Check if we're cleaning up due to interruption
+    if [ "$exit_code" -eq 130 ] || [ "$exit_code" -eq 143 ]; then
+        echo ""
+        warn "Task '${CARGO_MAKE_CURRENT_TASK_NAME}' interrupted! \
+Cleaning up..."
+    fi
+
+    # Kill all child processes
+    local pids
+    mapfile -t pids < <(jobs -pr)
+    if [ "${#pids[@]}" -gt 0 ]; then
+        kill "${pids[@]}" 2>/dev/null || true
+    fi
+
+    # Stop any containers started by this script
+    if [ -n "${CONTAINER_ID:-}" ]; then
+        info "Stopping container..."
+        podman stop "$CONTAINER_ID" >/dev/null 2>&1 || true
+    fi
+
+    # Also stop by name if CONTAINER_NAME is set
+    if [ -n "${CONTAINER_NAME:-}" ] && [ -z "${CONTAINER_ID:-}" ]; then
+        info "Stopping container ${CONTAINER_NAME}..."
+        podman stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    fi
+}
+
+# Set up cleanup trap
+trap podman_cleanup EXIT INT TERM

--- a/tools/scripts/build-image.sh
+++ b/tools/scripts/build-image.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build the container image for testing artifacts.
+#
+# Builds from integration-tests/test_environment, which contains the
+# Containerfile and entrypoint.sh for the CI/test environment.
+#
+# Sourced as the script.main of the `build-image` task (extends
+# `base-script`); TAG, IMAGE_NAME, the version vars, info, and
+# resolve_build_target come from the base-script pre-script
+# (tools/scripts/base-script-pre.sh) and Makefile.toml [env].
+
+set -euo pipefail
+
+# Create target directory with correct ownership before podman creates it as
+# root.
+mkdir -p target
+
+TARGET=$(resolve_build_target "$ZCASH_VERSION" "$ZEBRA_VERSION")
+
+# For local builds, use the current user's UID/GID to avoid permission
+# issues. CI builds will use the default UID=1001 from the Containerfile.
+
+info "Building image"
+info "Tag: ${TAG}"
+info "Target: $TARGET"
+info "Current directory: $(pwd)"
+# ls is intentional here: a short human-readable listing for debug output, not
+# machine-parsed, so SC2012 (use find) does not apply.
+# shellcheck disable=SC2012
+info "Files in tools/scripts/: $(ls -la tools/scripts/ | head -5)"
+
+cd integration-tests/test_environment && \
+podman build -f Containerfile \
+  --target "$TARGET" \
+  --build-arg "ZCASH_VERSION=$ZCASH_VERSION" \
+  --build-arg "ZEBRA_VERSION=$ZEBRA_VERSION" \
+  --build-arg "RUST_VERSION=$RUST_VERSION" \
+  --build-arg "UID=$(id -u)" \
+  --build-arg "GID=$(id -g)" \
+  -t "${IMAGE_NAME}:$TAG" \
+  "$@" \
+  .

--- a/tools/scripts/cargo-update-unfrozen.sh
+++ b/tools/scripts/cargo-update-unfrozen.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Re-resolve every package in Cargo.lock *except* the LRZ / zebra / sapling-crypto
-# subgraph pinned to yanked `core2 0.3.x`.
+# Re-resolve every package in Cargo.lock *except* the LRZ / zebra /
+# sapling-crypto subgraph pinned to yanked `core2 0.3.x`.
 #
 # Why: `core2` 0.3.0–0.3.3 was yanked from crates.io on 2026-04-17. Upstream
 # migrated to `corez` (zcash/librustzcash merge d8491512, zcash/sapling-crypto
@@ -15,7 +15,10 @@
 set -euo pipefail
 
 # Frozen subgraph — transitive closure of `core2 0.3.x` consumers.
-FROZEN_RE='^(core2|equihash|orchard|sapling-crypto|zcash_(address|client_backend|encoding|keys|note_encryption|primitives|proofs|protocol|transparent)|zebra-.*)$'
+FROZEN_RE='^(core2|equihash|orchard|sapling-crypto'
+FROZEN_RE+='|zcash_(address|client_backend|encoding|keys|note_encryption'
+FROZEN_RE+='|primitives|proofs|protocol|transparent)'
+FROZEN_RE+='|zebra-.*)$'
 
 cd "$(git rev-parse --show-toplevel)"
 

--- a/tools/scripts/check-matching-zebras.sh
+++ b/tools/scripts/check-matching-zebras.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Check that zebra versions in .env.testing-artifacts match Cargo.toml.
+#
+# Sourced as the script.main of the `check-matching-zebras` task (extends
+# `base-script`); ZEBRA_VERSION, info, and err come from the base-script
+# pre-script (tools/scripts/base-script-pre.sh) and Makefile.toml [env].
+
+set -euo pipefail
+
+# Verify ZEBRA_VERSION from .env.testing-artifacts is consistent with
+# Cargo.toml. Zebra deps may be crates.io versions ("6.0.1") or git revs
+# (rev="abc123"). The .env ZEBRA_VERSION is the Docker image tag (e.g.
+# "4.3.0").
+
+# Check for git rev-based deps first
+cargo_toml=$(sed 's/#.*//' Cargo.toml | tr -d '[:space:]')
+zebra_revs=$(
+  echo "$cargo_toml" \
+    | grep -o 'zebra-[a-z]*={[^}]*rev="[^"]*"' \
+    | grep -o 'rev="[^"]*"' \
+    | cut -d'"' -f2 \
+    | sort -u || true
+)
+
+if [[ -n "$zebra_revs" ]]; then
+  rev_count=$(echo "$zebra_revs" | wc -l)
+  if [[ "$rev_count" -ne 1 ]]; then
+    err "❌ Multiple Zebra revs detected in Cargo.toml:"
+    echo "$zebra_revs"
+    exit 1
+  fi
+  # Accept short SHA match
+  if [[ "$zebra_revs" != "$ZEBRA_VERSION" \
+        && "${zebra_revs:0:${#ZEBRA_VERSION}}" != "$ZEBRA_VERSION" ]]; then
+    err "❌ Mismatch: Cargo.toml has rev $zebra_revs, but .env has \
+$ZEBRA_VERSION"
+    exit 1
+  fi
+else
+  # Crates.io version deps -- just verify the Docker image tag is set
+  if [[ -z "$ZEBRA_VERSION" ]]; then
+    err "❌ ZEBRA_VERSION is not set in .env.testing-artifacts"
+    exit 1
+  fi
+  info "Zebra deps are crates.io versions; Docker image tag is \
+${ZEBRA_VERSION}"
+fi
+
+info "✅ Zebra version check passed (.env ZEBRA_VERSION=${ZEBRA_VERSION})"

--- a/tools/scripts/compute-image-tag.sh
+++ b/tools/scripts/compute-image-tag.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Compute the container image tag from the version vars.
+
+TAG=$(./tools/scripts/get-ci-image-tag.sh)
+echo "CARGO_MAKE_IMAGE_TAG=$TAG"
+export CARGO_MAKE_IMAGE_TAG=$TAG

--- a/tools/scripts/container-test-retry-failures.sh
+++ b/tools/scripts/container-test-retry-failures.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Rerun only failed tests from a previous container-test-save-failures run.
+#
+# Sourced as the script.main of the `container-test-retry-failures` task
+# (extends `base-script`); info and err come from the base-script pre-script
+# (tools/scripts/base-script-pre.sh).
+
+set -euo pipefail
+
+FAILURES_FILE=".failed-tests"
+
+if [[ ! -f "$FAILURES_FILE" ]]; then
+    err "No $FAILURES_FILE found. Run \
+'makers container-test-save-failures' first."
+    exit 1
+fi
+
+FAIL_COUNT=$(wc -l < "$FAILURES_FILE" | tr -d ' ')
+if [[ "$FAIL_COUNT" -eq 0 ]]; then
+    info "No failed tests to retry!"
+    exit 0
+fi
+
+info "Retrying $FAIL_COUNT failed test(s)..."
+
+# Build filter from libtest-json format: "package::binary$testname"
+# Output format: (package(P) & binary(B) & test(=T)) | ...
+FILTER=$(while IFS= read -r line; do
+    pkg="${line%%::*}"
+    rest="${line#*::}"
+    bin="${rest%%\$*}"
+    test="${rest#*\$}"
+    echo "(package($pkg) & binary($bin) & test(=$test))"
+done < "$FAILURES_FILE" | tr '\n' '|' | sed 's/|$//; s/|/ | /g')
+
+info "Filter: $FILTER"
+makers container-test -E "$FILTER" "$@"

--- a/tools/scripts/container-test-save-failures.sh
+++ b/tools/scripts/container-test-save-failures.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Run container-test and save failed test names for later retry.
+#
+# Sourced as the script.main of the `container-test-save-failures` task
+# (extends `base-script`); info and warn come from the base-script pre-script
+# (tools/scripts/base-script-pre.sh).
+
+set -uo pipefail
+
+FAILURES_FILE=".failed-tests"
+
+info "Running container-test with failure tracking..."
+
+# Run container-test with libtest-json, tee output for parsing
+makers container-test \
+    --no-fail-fast --message-format libtest-json "$@" 2>&1 \
+    | tee /tmp/nextest-output.json || true
+
+# Extract failed test names
+grep '"event":"failed"' /tmp/nextest-output.json 2>/dev/null \
+    | jq -r '.name // empty' | sort -u > "$FAILURES_FILE"
+
+FAIL_COUNT=$(wc -l < "$FAILURES_FILE" | tr -d ' ')
+
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+    warn "💾 Saved $FAIL_COUNT failed test(s) to $FAILURES_FILE"
+    cat "$FAILURES_FILE"
+    echo ""
+    info "Run 'makers container-test-retry-failures' to rerun them"
+else
+    info "✅ All tests passed!"
+    rm -f "$FAILURES_FILE"
+fi

--- a/tools/scripts/container-test.sh
+++ b/tools/scripts/container-test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Run integration tests using the local image.
+#
+# Runs tests inside the container built from
+# integration-tests/test_environment. The container's entrypoint.sh sets up
+# test binaries (zcashd, zebrad, zcash-cli) by symlinking
+# /home/container_user/artifacts to the expected
+# integration-tests/test_binaries/bins location.
+#
+# Sourced as the script.main of the `container-test` task (extends
+# `base-script`); TAG, IMAGE_NAME, TEST_BINARIES_DIR, info, and the cleanup
+# trap come from the base-script pre-script
+# (tools/scripts/base-script-pre.sh).
+
+set -euo pipefail
+
+info "Running tests using:"
+info "-- IMAGE             = ${IMAGE_NAME}"
+info "-- TAG               = $TAG"
+# info "-- TEST_BINARIES_DIR = ${TEST_BINARIES_DIR}"
+
+# Set container name for cleanup. Suffix with $$ (script PID) so concurrent
+# `makers container-test` invocations on the same host don't collide on the
+# `zaino-testing` name. The base-script cleanup trap reads CONTAINER_NAME
+# from script scope and stops the right container on EXIT/INT/TERM.
+CONTAINER_NAME="zaino-testing-$$"
+
+# Run podman in foreground with proper signal handling.
+#
+# `--pids-limit=-1` removes the default 2048-process cgroup cap. With
+# `--profile stable` (test-threads = num-cpus) each integration test
+# spawns a full zebrad whose rayon pool itself sizes to num-cpus, so
+# peak task count scales ~num_cpus^2. On developer hosts with many
+# cores the default cap is breached and `clone()` returns EAGAIN,
+# surfacing as "OS can't spawn worker thread" / rayon
+# ThreadPoolBuildError panics scattered across unrelated tests.
+podman run --rm \
+  --init \
+  --pids-limit=-1 \
+  --name "$CONTAINER_NAME" \
+  -v "$PWD":/home/container_user/zaino \
+  -v zaino-container-target:/home/container_user/zaino/target:U \
+  -v zaino-cargo-git:/usr/local/cargo/git:U \
+  -v zaino-cargo-registry:/usr/local/cargo/registry:U \
+  -e "TEST_BINARIES_DIR=${TEST_BINARIES_DIR}" \
+  -e "NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1" \
+  -e "ZAINOLOG_FORMAT=${ZAINOLOG_FORMAT:-stream}" \
+  -e "RUST_LOG=${RUST_LOG:-}" \
+  -w /home/container_user/zaino \
+  -u container_user \
+  "${IMAGE_NAME}:$TAG" \
+  cargo nextest run "$@" &
+
+# Capture the background job PID
+PODMAN_PID=$!
+
+# Wait for the podman process
+wait "$PODMAN_PID"

--- a/tools/scripts/ensure-image-exists.sh
+++ b/tools/scripts/ensure-image-exists.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Ensure the image exists locally, building it if needed.
+#
+# Sourced as the script.main of the `ensure-image-exists` task, which extends
+# `base-script`; TAG, IMAGE_NAME, and the info/warn/err helpers come from the
+# base-script pre-script (tools/scripts/base-script-pre.sh).
+
+if ! podman image inspect "${IMAGE_NAME}:${TAG}" > /dev/null 2>&1; then
+  info "Image not found locally. Building..."
+  makers build-image
+else
+  info "Image ${IMAGE_NAME}:${TAG} already exists locally."
+fi

--- a/tools/scripts/functions.sh
+++ b/tools/scripts/functions.sh
@@ -4,6 +4,8 @@
 get_container_hash() {
   local git_root
   git_root=$(git rev-parse --show-toplevel)
-  cd "$git_root"
-  git ls-tree HEAD integration-tests/test_environment | git hash-object --stdin | cut -c1-14
+  cd "$git_root" || return 1
+  git ls-tree HEAD integration-tests/test_environment \
+    | git hash-object --stdin \
+    | cut -c1-14
 }

--- a/tools/scripts/get-ci-image-tag.sh
+++ b/tools/scripts/get-ci-image-tag.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 # Source shared utility functions
+# shellcheck source=tools/scripts/functions.sh
 source "$(dirname "${BASH_SOURCE[0]}")/functions.sh"
 
 # Accepts env vars already loaded in the calling context
@@ -9,11 +10,9 @@ main() {
   local container_hash
   container_hash=$(get_container_hash)
 
-  local tag_vars="RUST_$RUST_VERSION-ZCASH_$ZCASH_VERSION-ZEBRA_$ZEBRA_VERSION-CONTAINER_$container_hash"
-  local tag
-  tag=$(echo "$tag_vars" | tr ' ' '\n' | sort | sha256sum | cut -c1-12)
-  # echo "VERSIONS: $tag_vars"
-  # echo "TAG: $tag"
+  local tag_vars
+  tag_vars="RUST_$RUST_VERSION-ZCASH_$ZCASH_VERSION"
+  tag_vars+="-ZEBRA_$ZEBRA_VERSION-CONTAINER_$container_hash"
   echo "$tag_vars"
 }
 

--- a/tools/scripts/get-container-hash.sh
+++ b/tools/scripts/get-container-hash.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 # Source shared utility functions
+# shellcheck source=tools/scripts/functions.sh
 source "$(dirname "${BASH_SOURCE[0]}")/functions.sh"
 
 # Execute the function and output result

--- a/tools/scripts/get-podman-hash.sh
+++ b/tools/scripts/get-podman-hash.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Print the current CONTAINER_DIR_HASH.
+
+HASH=$(./tools/scripts/get-container-hash.sh)
+echo "CONTAINER_DIR_HASH=$HASH"

--- a/tools/scripts/get-rust-version.sh
+++ b/tools/scripts/get-rust-version.sh
@@ -28,8 +28,10 @@ if [[ -z "$channel" ]]; then
 fi
 
 if [[ ! "$channel" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-  echo "get-rust-version.sh: channel '$channel' is not a concrete numeric version (e.g. 1.95 or 1.95.0)" >&2
-  echo "get-rust-version.sh: the CI image requires a pinned rustc; set channel = \"<x.y[.z]>\" in $toolchain_file" >&2
+  echo "get-rust-version.sh: channel '$channel' is not a concrete numeric \
+version (e.g. 1.95 or 1.95.0)" >&2
+  echo "get-rust-version.sh: the CI image requires a pinned rustc; set \
+channel = \"<x.y[.z]>\" in $toolchain_file" >&2
   exit 1
 fi
 

--- a/tools/scripts/help.sh
+++ b/tools/scripts/help.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Print available commands and usage notes.
+#
+# Sourced as the script.main of the `help` task (extends `base-script`).
+
+set -euo pipefail
+
+echo ""
+echo "Zaino CI Image Tasks"
+echo "---------------------"
+echo ""
+echo "Common usage:"
+echo "  makers container-test"
+echo ""
+echo "If you modify '.env.testing-artifacts', the test command will \
+automatically:"
+echo "  - Recompute the image tag"
+echo "  - Build a new local container image if needed"
+echo ""
+echo "Available commands:"
+echo ""
+echo "  container-test             Run integration tests using the local \
+image"
+echo "  integration-test           Run integration-tests sub-workspace \
+(forwards flags to nextest)"
+echo "  container-test-save-failures    Run tests, save failures to \
+.failed-tests"
+echo "  container-test-retry-failures   Rerun only the previously failed \
+tests"
+echo "  build-image                Build the container image with current \
+artifact versions"
+echo "  push-image                 Push the image (used in CI, can be used \
+manually)"
+echo "  compute-image-tag          Compute the tag for the container image \
+based on versions"
+echo "  get-podman-hash            Get CONTAINER_DIR_HASH value (hash for \
+the image defining files)"
+echo "  ensure-image-exists        Check if the required image exists \
+locally, build if not"
+echo "  pull-ci-image              Pull the CI image from the registry"
+echo "  check-matching-zebras      Verify Zebra versions match between \
+Cargo.toml and .env"
+echo "  validate-test-targets      Check if nextest targets match CI \
+workflow matrix"
+echo "  update-test-targets        Update CI workflow matrix to match \
+nextest targets"
+echo "  validate-makefile-tasks    Run minimal validation of all maker tasks"
+echo "  verify-all                 Exercise every task for correctness \
+(idempotent)"
+echo "  hello-rust                 Test rust-script functionality"
+echo ""
+echo "Lint commands:"
+echo "  lint                       Run all lints (fmt, clippy, doc). Use as \
+a pre-commit hook."
+echo "  fmt                        Check formatting (cargo fmt --all -- \
+--check)"
+echo "  clippy                     Run Clippy with -D warnings (--all-targets \
+--all-features)"
+echo "  doc                        Build docs (no deps, all features, \
+document private items) with RUSTDOCFLAGS='-D warnings'"
+echo "  toggle-hooks               Toggle the git config for core.hooksPath \
+to use .githooks/"
+echo ""
+echo "Build speed:"
+echo "  use-system-rocksdb         Link against system RocksDB (skips slow \
+C++ build)"
+echo "  use-bundled-rocksdb        Revert to building RocksDB from source"
+echo "  check-system-rocksdb       Check system RocksDB compatibility"
+echo "  audit-system-rocksdb       Re-audit if Cargo.lock or system version \
+changed"
+echo "  set-worktree-parent-tools  Copy .cargo/config.toml to common \
+worktree parent"
+echo ""
+echo "Environment:"
+echo "  ZCASH_VERSION, ZEBRA_VERSION  Defined by: .env.testing-artifacts"
+echo "  RUST_VERSION                  Derived from rust-toolchain.toml"
+echo "                                via tools/scripts/get-rust-version.sh"
+echo ""
+echo "Build Context:"
+echo "  integration-tests/test_environment/   Directory containing the \
+container build environment"
+echo "    ├── Containerfile                 Containerfile for CI/test \
+container"
+echo "    └── entrypoint.sh                Entrypoint script that sets up \
+test binaries"
+echo ""
+echo "Helpers:"
+echo "  - tools/scripts/get-ci-image-tag.sh: computes the version-based \
+image tag"
+echo "  - tools/scripts/helpers.sh: logging and helper functions"
+echo ""

--- a/tools/scripts/init-podman-volumes.sh
+++ b/tools/scripts/init-podman-volumes.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Initialize named podman volumes for container builds.
+
+for vol in zaino-container-target zaino-cargo-git zaino-cargo-registry; do
+    if ! podman volume inspect "$vol" >/dev/null 2>&1; then
+        podman volume create "$vol"
+        echo "Created podman volume: $vol"
+    fi
+done
+
+# Pre-create host-side target/ owned by the current user. The
+# container-test podman invocation bind-mounts $PWD into the container and
+# then overlays the zaino-container-target volume on /.../zaino/target. If
+# host-side target/ does not exist when that mount layer is applied, some
+# podman/runc/buildah combinations create it under a uidmap-escaped UID
+# (e.g. UID 100000), which then breaks host-side `cargo` with EACCES.
+# Pre-creating it as the current user avoids that. If target/ already exists
+# but is unwritable (a previous leak), recreate it: rm -rf works because the
+# parent directory is owned by the current user even if target/ itself is
+# not.
+if [[ -e target && ! -w target ]]; then
+    echo "target/ exists but is not writable; recreating to recover from \
+uidmap leak..."
+    rm -rf target
+fi
+mkdir -p target

--- a/tools/scripts/integration-test.sh
+++ b/tools/scripts/integration-test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Run the integration-tests sub-workspace inside the CI container, forwarding
+# extra args to `cargo nextest run`.
+#
+# Sourced as the script.main of the `integration-test` task (extends
+# `base-script`); info comes from the base-script pre-script
+# (tools/scripts/base-script-pre.sh).
+
+set -euo pipefail
+
+info "Running integration-tests sub-workspace via container-test"
+info "-- manifest: integration-tests/Cargo.toml"
+
+exec makers container-test \
+  --manifest-path integration-tests/Cargo.toml "$@"

--- a/tools/scripts/lint-shell.sh
+++ b/tools/scripts/lint-shell.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Lint every shell script tracked in the repo with shellcheck.
+#
+# Run directly (./tools/scripts/lint-shell.sh) or via `makers lint-shell`.
+# Configuration (external sources, source paths) lives in .shellcheckrc at the
+# repo root.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+mapfile -t scripts < <(git ls-files '*.sh')
+
+if [ "${#scripts[@]}" -eq 0 ]; then
+    echo "lint-shell: no shell scripts found."
+    exit 0
+fi
+
+shellcheck "${scripts[@]}"
+
+echo "lint-shell: ${#scripts[@]} shell script(s) passed shellcheck."

--- a/tools/scripts/precommit-check.sh
+++ b/tools/scripts/precommit-check.sh
@@ -1,1 +1,8 @@
-cargo check --all-features && cargo check --tests --all-features && cargo fmt && cargo clippy && ./tools/scripts/trailing-whitespace.sh reject
+#!/usr/bin/env bash
+set -euo pipefail
+
+cargo check --all-features \
+  && cargo check --tests --all-features \
+  && cargo fmt \
+  && cargo clippy \
+  && ./tools/scripts/trailing-whitespace.sh reject

--- a/tools/scripts/pull-ci-image.sh
+++ b/tools/scripts/pull-ci-image.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Pull the CI image from the registry.
+#
+# Sourced as the script.main of the `pull-ci-image` task (extends
+# `base-script`); TAG, IMAGE_NAME, and info/err come from the base-script
+# pre-script (tools/scripts/base-script-pre.sh).
+
+info "Pulling ${IMAGE_NAME}:${TAG} from registry..."
+if podman pull "${IMAGE_NAME}:${TAG}"; then
+  info "Image ${IMAGE_NAME}:${TAG} pulled successfully."
+else
+  err "Image ${IMAGE_NAME}:${TAG} not found on registry."
+  exit 1
+fi

--- a/tools/scripts/push-image.sh
+++ b/tools/scripts/push-image.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Push the image to the registry.
+#
+# Sourced as the script.main of the `push-image` task (extends `base-script`);
+# TAG, IMAGE_NAME, and info come from the base-script pre-script
+# (tools/scripts/base-script-pre.sh).
+
+set -euo pipefail
+
+info "Pushing image: ${IMAGE_NAME}:${TAG}"
+
+podman push "${IMAGE_NAME}:${TAG}"

--- a/tools/scripts/thousand_runs.sh
+++ b/tools/scripts/thousand_runs.sh
@@ -1,53 +1,64 @@
-  #!/usr/bin/env bash
-  set -u
+#!/usr/bin/env bash
+set -u
 
-  # How many runs, where to put failure logs, and what to run.
-  # Override with env vars: N_RUNS=10 CARGO_NEXTEST_ARGS="-p zaino-state" ./thousand_tests.sh
-  N_RUNS=${N_RUNS:-1000}
-  OUTDIR=${OUTDIR:-thousand_tests}
-  CARGO_NEXTEST_ARGS=${CARGO_NEXTEST_ARGS:-"--no-fail-fast"}
+# How many runs, where to put failure logs, and what to run.
+# Override with env vars:
+#   N_RUNS=10 CARGO_NEXTEST_ARGS="-p zaino-state" ./thousand_runs.sh
+N_RUNS=${N_RUNS:-1000}
+OUTDIR=${OUTDIR:-thousand_tests}
+CARGO_NEXTEST_ARGS=${CARGO_NEXTEST_ARGS:-"--no-fail-fast"}
 
-  mkdir -p "$OUTDIR"
+# Split the configured args into an array so word-splitting is explicit
+# rather than relying on an unquoted expansion of CARGO_NEXTEST_ARGS.
+read -ra nextest_args <<< "$CARGO_NEXTEST_ARGS"
 
-  pass=0
-  fail=0
-  trap 'printf "\nInterrupted at run %d. Summary: %d passed, %d failed.\n" "$run" "$pass" "$fail"; exit 130' INT TERM
+mkdir -p "$OUTDIR"
 
-  for run in $(seq 1 "$N_RUNS"); do
-      ts=$(date +%Y%m%d-%H%M%S-%N)
-      log=$(mktemp --tmpdir nextest.XXXXXX.log)
+pass=0
+fail=0
+trap 'printf "\nInterrupted at run %d. Summary: %d passed, %d failed.\n" \
+  "$run" "$pass" "$fail"; exit 130' INT TERM
 
-      if cargo nextest run $CARGO_NEXTEST_ARGS >"$log" 2>&1; then
-          pass=$((pass + 1))
-          printf '[run %4d/%d] PASS  (pass=%d fail=%d)\n' "$run" "$N_RUNS" "$pass" "$fail"
-      else
-          fail=$((fail + 1))
-          printf '[run %4d/%d] FAIL  (pass=%d fail=%d) -> extracting\n' "$run" "$N_RUNS" "$pass" "$fail"
+for run in $(seq 1 "$N_RUNS"); do
+    ts=$(date +%Y%m%d-%H%M%S-%N)
+    log=$(mktemp --tmpdir nextest.XXXXXX.log)
 
-          # Split the run log into per-test-failure files.
-          # Each FAIL section is delimited by the next PASS/FAIL line or the
-          # summary "────" divider.
-          awk -v ts="$ts" -v dir="$OUTDIR" '
-              function close_current() {
-                  if (current_file != "") { close(current_file); current_file = "" }
-              }
-              /^[[:space:]]+FAIL \[/ {
-                  close_current()
-                  name = $NF
-                  gsub(/::/, "__", name)
-                  gsub(/[^A-Za-z0-9_-]/, "_", name)
-                  current_file = dir "/" name "-" ts ".log"
-                  print > current_file
-                  next
-              }
-              /^[[:space:]]+PASS \[/ { close_current(); next }
-              /^────+$/            { close_current(); next }
-              current_file != ""   { print >> current_file }
-              END { close_current() }
-          ' "$log"
-      fi
+    if cargo nextest run "${nextest_args[@]}" >"$log" 2>&1; then
+        pass=$((pass + 1))
+        printf '[run %4d/%d] PASS  (pass=%d fail=%d)\n' \
+            "$run" "$N_RUNS" "$pass" "$fail"
+    else
+        fail=$((fail + 1))
+        printf '[run %4d/%d] FAIL  (pass=%d fail=%d) -> extracting\n' \
+            "$run" "$N_RUNS" "$pass" "$fail"
 
-      rm -f "$log"
-  done
+        # Split the run log into per-test-failure files.
+        # Each FAIL section is delimited by the next PASS/FAIL line or the
+        # summary "────" divider.
+        awk -v ts="$ts" -v dir="$OUTDIR" '
+            function close_current() {
+                if (current_file != "") {
+                    close(current_file); current_file = ""
+                }
+            }
+            /^[[:space:]]+FAIL \[/ {
+                close_current()
+                name = $NF
+                gsub(/::/, "__", name)
+                gsub(/[^A-Za-z0-9_-]/, "_", name)
+                current_file = dir "/" name "-" ts ".log"
+                print > current_file
+                next
+            }
+            /^[[:space:]]+PASS \[/ { close_current(); next }
+            /^────+$/            { close_current(); next }
+            current_file != ""   { print >> current_file }
+            END { close_current() }
+        ' "$log"
+    fi
 
-  printf '\nSummary: %d passed, %d failed out of %d runs\n' "$pass" "$fail" "$N_RUNS"
+    rm -f "$log"
+done
+
+printf '\nSummary: %d passed, %d failed out of %d runs\n' \
+    "$pass" "$fail" "$N_RUNS"

--- a/tools/scripts/trailing-whitespace.sh
+++ b/tools/scripts/trailing-whitespace.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -efuo pipefail 
+set -efuo pipefail
 
 function main
 {
@@ -22,13 +22,15 @@ function fix
 
 function reject
 {
-  local F="$(mktemp --tmpdir zingolib-trailing-whitespace.XXX)"
+  local F
+  F="$(mktemp --tmpdir zingolib-trailing-whitespace.XXX)"
 
   process-well-known-text-files grep -E --with-filename ' +$' \
     | sed 's/$/\\n/' \
     | tee "$F"
 
-  local NOISE="$(cat "$F" | wc -l)"
+  local NOISE
+  NOISE="$(wc -l < "$F")"
   rm "$F"
 
   if [ "$NOISE" -eq 0 ]

--- a/tools/scripts/update-test-targets.sh
+++ b/tools/scripts/update-test-targets.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Update the CI workflow matrix to match nextest targets.
+#
+# Sourced as the script.main of the `update-test-targets` task (extends
+# `base-script`); info comes from the base-script pre-script
+# (tools/scripts/base-script-pre.sh).
+
+set -euo pipefail
+
+info "🔧 Updating CI workflow matrix to match nextest targets..."
+
+# Extract nextest targets with non-empty testcases.
+# The `ci` profile lives in integration-tests/.config/nextest.toml, so use
+# --manifest-path.
+info "Extracting current nextest targets..."
+NEXTEST_TARGETS=$(mktemp)
+cargo nextest list \
+  --manifest-path integration-tests/Cargo.toml \
+  --profile ci -T json-pretty \
+  | jq -r '
+      .["rust-suites"]
+      | to_entries[]
+      | select(.value.testcases | length > 0)
+      | .key
+    ' \
+  | sort > "$NEXTEST_TARGETS"
+
+echo "Found $(wc -l < "$NEXTEST_TARGETS") targets with tests:"
+sed 's/^/  - /' "$NEXTEST_TARGETS"
+
+# Update only the partition array using sed to preserve formatting.
+# First, create the new partition list in the exact format we need.
+NEW_PARTITION_LINES=$(mktemp)
+while IFS= read -r target; do
+    echo "          - \"${target}\""
+done < "$NEXTEST_TARGETS" > "$NEW_PARTITION_LINES"
+
+# Use sed to replace just the partition array section.
+# Find the partition: line and replace everything until the next
+# non-indented item.
+sed -i '/^[[:space:]]*partition:/,/^[[:space:]]*[^[:space:]-]/{
+    /^[[:space:]]*partition:/!{
+        /^[[:space:]]*[^[:space:]-]/!d
+    }
+}' .github/workflows/ci.yml
+
+# Now insert the new partition lines after the "partition:" line
+sed -i "/^[[:space:]]*partition:$/r $NEW_PARTITION_LINES" \
+  .github/workflows/ci.yml
+
+rm "$NEW_PARTITION_LINES"
+
+info "✅ CI workflow updated successfully!"
+
+# Show what was changed using git diff
+echo ""
+info "Changes made:"
+git diff --no-index /dev/null .github/workflows/ci.yml 2>/dev/null \
+  | grep -e "^[+-].*partition" \
+         -e "^[+-].*integration-tests" \
+         -e "^[+-].*zaino" \
+         -e "^[+-].*zainod" \
+  || git diff .github/workflows/ci.yml \
+  || echo "No changes detected"
+
+# Cleanup temp files
+rm "$NEXTEST_TARGETS"

--- a/tools/scripts/validate-makefile-tasks.rs
+++ b/tools/scripts/validate-makefile-tasks.rs
@@ -1,0 +1,105 @@
+// Validate all Makefile.toml tasks work correctly with minimal execution.
+//
+// Run by the `validate-makefile-tasks` task via cargo-make's `@rust` script
+// runner (script = { file = "tools/scripts/validate-makefile-tasks.rs" } in
+// Makefile.toml). IMAGE_NAME and the version vars come from Makefile.toml
+// [env].
+
+use std::process::{Command, Stdio};
+use std::env;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("🔍 Starting validation of all Makefile tasks...");
+
+    // 1. Check version matching
+    println!("\nStep 1: Checking version consistency...");
+    run_makers_task("check-matching-zebras")?;
+
+    // 2. Compute the image tag
+    println!("\nStep 2: Computing image tag...");
+    run_makers_task("compute-image-tag")?;
+
+    // 3. Ensure image exists (will build if necessary)
+    println!("\nStep 3: Ensuring container image exists...");
+    run_makers_task("ensure-image-exists")?;
+
+    // 4. Get the computed tag
+    let tag = get_image_tag()?;
+    let image_name = env::var("IMAGE_NAME")
+        .unwrap_or_else(|_| "zingodevops/zaino-ci".to_string());
+    let working_dir = env::current_dir()?.to_string_lossy().to_string();
+
+    // 5. Run a single fast test to validate the full pipeline
+    println!("\nStep 4: Running minimal test to validate setup...");
+    println!("Using image: {}:{}", image_name, tag);
+
+    let status = Command::new("podman")
+        .args(&[
+            "run", "--rm",
+            "--init",
+            "--name", "zaino-validation-test",
+            "-v", &format!("{}:/home/container_user/zaino", working_dir),
+            "-v", "zaino-container-target:/home/container_user/zaino/target:U",
+            "-v", "zaino-cargo-git:/usr/local/cargo/git:U",
+            "-v", "zaino-cargo-registry:/usr/local/cargo/registry:U",
+            "-e", "TEST_BINARIES_DIR=/home/container_user/zaino/\
+                   integration-tests/test_binaries/bins",
+            "-w", "/home/container_user/zaino",
+            "-u", "container_user",
+            &format!("{}:{}", image_name, tag),
+            "cargo", "test",
+            "--package", "zaino-testutils",
+            "--lib", "launch_testmanager::zcashd::basic",
+            "--", "--nocapture"
+        ])
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()?;
+
+    if !status.success() {
+        eprintln!("❌ Validation failed!");
+        std::process::exit(1);
+    }
+
+    println!("\n✅ All tasks validated successfully!");
+    Ok(())
+}
+
+fn run_makers_task(task: &str) -> Result<(), Box<dyn std::error::Error>> {
+    println!("DEBUG: About to run makers {}", task);
+    let status = Command::new("makers")
+        .arg(task)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()?;
+
+    println!("DEBUG: makers {} completed with status: {:?}", task, status);
+    if !status.success() {
+        return Err(format!("Task '{}' failed", task).into());
+    }
+    Ok(())
+}
+
+fn get_image_tag() -> Result<String, Box<dyn std::error::Error>> {
+    println!("DEBUG: Getting image tag...");
+    // First try to get from environment
+    if let Ok(tag) = env::var("CARGO_MAKE_IMAGE_TAG") {
+        if !tag.is_empty() {
+            println!("DEBUG: Found tag in env: {}", tag);
+            return Ok(tag);
+        }
+    }
+
+    println!("DEBUG: Computing tag with script...");
+    // Otherwise compute it
+    let output = Command::new("./tools/scripts/get-ci-image-tag.sh")
+        .output()?;
+
+    if !output.status.success() {
+        return Err("Failed to compute image tag".into());
+    }
+
+    let tag = String::from_utf8(output.stdout)?.trim().to_string();
+    println!("DEBUG: Computed tag: {}", tag);
+    Ok(tag)
+}

--- a/tools/scripts/validate-test-targets.sh
+++ b/tools/scripts/validate-test-targets.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Validate that nextest targets match the CI workflow matrix.
+#
+# Sourced as the script.main of the `validate-test-targets` task (extends
+# `base-script`); info and warn come from the base-script pre-script
+# (tools/scripts/base-script-pre.sh).
+
+set -euo pipefail
+
+info "🔍 Validating test targets between nextest and CI workflow..."
+
+# Extract nextest targets with non-empty testcases.
+# The `ci` profile lives in integration-tests/.config/nextest.toml, so use
+# --manifest-path.
+info "Extracting targets from nextest..."
+NEXTEST_TARGETS=$(mktemp)
+cargo nextest list \
+  --manifest-path integration-tests/Cargo.toml \
+  --profile ci -T json-pretty \
+  | jq -r '
+      .["rust-suites"]
+      | to_entries[]
+      | select(.value.testcases | length > 0)
+      | .key
+    ' \
+  | sort > "$NEXTEST_TARGETS"
+
+# Extract CI matrix partition values
+info "Extracting targets from CI workflow..."
+CI_TARGETS=$(mktemp)
+lq -r '.jobs.test.strategy.matrix.partition[]' \
+  < .github/workflows/ci.yml | sort > "$CI_TARGETS"
+
+# Compare the lists
+info "Comparing target lists..."
+
+MISSING_IN_CI=$(mktemp)
+EXTRA_IN_CI=$(mktemp)
+
+# Find targets in nextest but not in CI
+comm -23 "$NEXTEST_TARGETS" "$CI_TARGETS" > "$MISSING_IN_CI"
+
+# Find targets in CI but not in nextest (or with empty testcases)
+comm -13 "$NEXTEST_TARGETS" "$CI_TARGETS" > "$EXTRA_IN_CI"
+
+# Display results
+if [[ ! -s "$MISSING_IN_CI" && ! -s "$EXTRA_IN_CI" ]]; then
+    info "✅ All test targets are synchronized!"
+    echo "Nextest targets ($(wc -l < "$NEXTEST_TARGETS")):"
+    sed 's/^/  - /' "$NEXTEST_TARGETS"
+else
+    warn "❌ Test target synchronization issues found:"
+
+    if [[ -s "$MISSING_IN_CI" ]]; then
+        echo ""
+        warn "📋 Targets with tests missing from CI matrix \
+($(wc -l < "$MISSING_IN_CI")):"
+        sed 's/^/  - /' "$MISSING_IN_CI"
+    fi
+
+    if [[ -s "$EXTRA_IN_CI" ]]; then
+        echo ""
+        warn "🗑️  Targets in CI matrix with no tests \
+($(wc -l < "$EXTRA_IN_CI")):"
+        sed 's/^/  - /' "$EXTRA_IN_CI"
+    fi
+
+    echo ""
+    info "💡 To automatically update the CI workflow, run:"
+    info "   makers update-test-targets"
+fi
+
+# Cleanup temp files
+rm "$NEXTEST_TARGETS" "$CI_TARGETS" "$MISSING_IN_CI" "$EXTRA_IN_CI"

--- a/tools/scripts/verify-all.sh
+++ b/tools/scripts/verify-all.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Exercise every Makefile.toml task for correctness (idempotent).
+#
+# Run directly as the `verify-all` task script (does not extend base-script);
+# it sources helpers.sh itself for info/warn/err and IMAGE_NAME comes from
+# Makefile.toml [env].
+
+set -uo pipefail
+
+# shellcheck source=tools/scripts/helpers.sh
+source "./tools/scripts/helpers.sh"
+
+VERIFY_TMPDIR=$(mktemp -d)
+PASS=0
+FAIL=0
+SKIPPED=0
+
+cleanup() {
+    info "Cleaning up verification artifacts..."
+
+    # Restore .cargo/config.toml if we saved one
+    if [[ -f "$VERIFY_TMPDIR/cargo-config.toml.bak" ]]; then
+        mkdir -p .cargo
+        cp "$VERIFY_TMPDIR/cargo-config.toml.bak" .cargo/config.toml
+    elif [[ -f "$VERIFY_TMPDIR/cargo-config-absent" ]]; then
+        rm -f .cargo/config.toml
+    fi
+
+    # Restore .cargo/.rocksdb-audit if we saved one
+    if [[ -f "$VERIFY_TMPDIR/rocksdb-audit.bak" ]]; then
+        cp "$VERIFY_TMPDIR/rocksdb-audit.bak" .cargo/.rocksdb-audit
+    elif [[ -f "$VERIFY_TMPDIR/rocksdb-audit-absent" ]]; then
+        rm -f .cargo/.rocksdb-audit
+    fi
+
+    # Remove test image if we built one
+    if [[ -f "$VERIFY_TMPDIR/image-tag" ]]; then
+        local tag
+        tag=$(cat "$VERIFY_TMPDIR/image-tag")
+        info "Removing verification image ${IMAGE_NAME}:verify-${tag}..."
+        podman rmi "${IMAGE_NAME}:verify-${tag}" 2>/dev/null || true
+    fi
+
+    # Remove temp dir
+    rm -rf "$VERIFY_TMPDIR"
+
+    echo ""
+    echo "========================================="
+    echo "verify-all: ${PASS} passed, ${FAIL} failed, ${SKIPPED} skipped"
+    echo "========================================="
+    if [[ $FAIL -gt 0 ]]; then
+        exit 1
+    fi
+}
+trap cleanup EXIT
+
+run_task() {
+    local name="$1"
+    shift
+    echo ""
+    info "--- ${name} ---"
+    if "$@" 2>&1; then
+        PASS=$((PASS + 1))
+        info "PASS: ${name}"
+    else
+        FAIL=$((FAIL + 1))
+        err "FAIL: ${name}"
+    fi
+}
+
+skip_task() {
+    local name="$1"
+    local reason="$2"
+    echo ""
+    warn "--- SKIP: ${name} (${reason}) ---"
+    SKIPPED=$((SKIPPED + 1))
+}
+
+# === Save state for idempotency ===
+if [[ -f .cargo/config.toml ]]; then
+    cp .cargo/config.toml "$VERIFY_TMPDIR/cargo-config.toml.bak"
+else
+    touch "$VERIFY_TMPDIR/cargo-config-absent"
+fi
+if [[ -f .cargo/.rocksdb-audit ]]; then
+    cp .cargo/.rocksdb-audit "$VERIFY_TMPDIR/rocksdb-audit.bak"
+else
+    touch "$VERIFY_TMPDIR/rocksdb-audit-absent"
+fi
+
+# === Tier 1: No container needed ===
+
+run_task "help" makers help
+run_task "compute-image-tag" makers compute-image-tag
+run_task "get-podman-hash" makers get-podman-hash
+run_task "init-podman-volumes" makers init-podman-volumes
+run_task "check-matching-zebras" makers check-matching-zebras
+run_task "fmt" makers fmt
+run_task "clippy" makers clippy
+run_task "doc" makers doc
+
+# Rocksdb tasks (save/restore state around them)
+if pkg-config --exists rocksdb 2>/dev/null; then
+    run_task "check-system-rocksdb" makers check-system-rocksdb
+    run_task "use-system-rocksdb" makers use-system-rocksdb
+    run_task "audit-system-rocksdb" makers audit-system-rocksdb
+    run_task "use-bundled-rocksdb" makers use-bundled-rocksdb
+else
+    skip_task "rocksdb tasks" "system rocksdb not installed"
+fi
+
+# toggle-hooks: run twice to restore original state
+run_task "toggle-hooks (on)" makers toggle-hooks
+run_task "toggle-hooks (off)" makers toggle-hooks
+
+# === Tier 2: Container build ===
+
+TAG=$(./tools/scripts/get-ci-image-tag.sh)
+echo "$TAG" > "$VERIFY_TMPDIR/image-tag"
+
+run_task "build-image" makers build-image
+run_task "ensure-image-exists" makers ensure-image-exists
+
+# Tag a verification copy so we can clean up without affecting cached images
+podman tag "${IMAGE_NAME}:${TAG}" "${IMAGE_NAME}:verify-${TAG}" \
+    2>/dev/null || true
+
+# === Tier 3: Container execution ===
+# One test per component: zcashd, zebrad, lightwallet gRPC,
+# wallet-to-validator. Tests live in the integration-tests sub-workspace.
+ITESTS=(--manifest-path integration-tests/Cargo.toml)
+
+run_task "container-test (zcashd)" makers container-test \
+    "${ITESTS[@]}" \
+    -E "binary(wallet_to_validator) & test(=zcashd::connect_to_node_get_info)"
+
+run_task "container-test (zebrad)" makers container-test \
+    "${ITESTS[@]}" \
+    -E "binary(wallet_to_validator) & \
+test(=zebrad::state_service::connect_to_node_get_info)"
+
+run_task "container-test (lightwallet)" makers container-test \
+    "${ITESTS[@]}" \
+    -E "binary(state_service) & test(=zebra::lightwallet_indexer::get_block)"
+
+run_task "container-test (wallet-to-validator)" makers container-test \
+    "${ITESTS[@]}" \
+    -E "binary(wallet_to_validator) & test(=zcashd::sent_to::transparent)"
+
+if command -v jq &>/dev/null && command -v yq &>/dev/null; then
+    run_task "validate-test-targets" makers validate-test-targets
+else
+    skip_task "validate-test-targets" "jq or yq not installed"
+fi
+
+# === Tier 4: Destructive/CI-only (skip) ===
+
+skip_task "push-image" "pushes to registry"
+skip_task "update-test-targets" "modifies CI workflow files"
+skip_task "validate-makefile-tasks" "redundant with this task"
+skip_task "container-test-save-failures" "requires full test run"
+skip_task "container-test-retry-failures" "requires prior save-failures"


### PR DESCRIPTION
It is cleaner and more maintainable to have all the bash code into files. We also can run `shellcheck` independently. In addition to that, developers aren't forced to use `cargo-make` is they don't want to.

Helped by Claude Code.