### PR TITLE
Bound GetAddressUtxos result materialization

### DIFF
--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -33,7 +33,7 @@ use arc_swap::ArcSwapOption;
 use futures::{FutureExt, Stream};
 use hex::FromHex as _;
 use non_finalised_state::NonfinalizedBlockCacheSnapshot;
-use source::{BlockchainSource, ValidatorConnector};
+use source::{AddressUtxosRequest, BlockchainSource, ValidatorConnector};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, instrument};
@@ -512,6 +512,17 @@ pub trait ChainIndex {
     fn get_address_utxos(
         &self,
         address_strings: GetAddressBalanceRequest,
+    ) -> impl std::future::Future<Output = Result<Vec<GetAddressUtxos>, Self::Error>>;
+
+    /// Returns a bounded subset of unspent transparent outputs for the given addresses.
+    ///
+    /// `start_height` is inclusive. `max_entries = None` leaves the result unrestricted.
+    /// These bounds apply to Zaino's converted result, not the backing validator's query work.
+    fn get_address_utxos_bounded(
+        &self,
+        address_strings: GetAddressBalanceRequest,
+        start_height: u64,
+        max_entries: Option<u32>,
     ) -> impl std::future::Future<Output = Result<Vec<GetAddressUtxos>, Self::Error>>;
 
     /// For each outpoint, returns the txid of the transaction that spent it on the best
@@ -2340,8 +2351,23 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
         &self,
         address_strings: GetAddressBalanceRequest,
     ) -> Result<Vec<GetAddressUtxos>, Self::Error> {
+        self.get_address_utxos_bounded(address_strings, 0, None)
+            .await
+    }
+
+    /// Returns a bounded subset of unspent transparent outputs for the given addresses.
+    async fn get_address_utxos_bounded(
+        &self,
+        address_strings: GetAddressBalanceRequest,
+        start_height: u64,
+        max_entries: Option<u32>,
+    ) -> Result<Vec<GetAddressUtxos>, Self::Error> {
         self.source()
-            .get_address_utxos(address_strings)
+            .get_address_utxos(AddressUtxosRequest::new(
+                address_strings,
+                start_height,
+                max_entries,
+            ))
             .await
             .map_err(ChainIndexError::backing_validator)
     }

--- a/packages/zaino-state/src/chain_index/source.rs
+++ b/packages/zaino-state/src/chain_index/source.rs
@@ -40,6 +40,45 @@ pub(crate) mod mockchain_source;
 pub mod validator_connector;
 pub use validator_connector::*;
 
+/// A transparent-UTXO query with response-conversion bounds.
+///
+/// The backing validator interfaces currently accept only the address set, so
+/// `start_height` and `max_entries` bound the rows converted and returned by
+/// Zaino, not the validator's query work or its initial response.
+#[derive(Clone, Debug)]
+pub struct AddressUtxosRequest {
+    addresses: GetAddressBalanceRequest,
+    start_height: u64,
+    max_entries: Option<u32>,
+}
+
+impl AddressUtxosRequest {
+    /// Creates a transparent-UTXO query with an inclusive minimum height and
+    /// an optional global result cap.
+    pub fn new(
+        addresses: GetAddressBalanceRequest,
+        start_height: u64,
+        max_entries: Option<u32>,
+    ) -> Self {
+        Self {
+            addresses,
+            start_height,
+            max_entries,
+        }
+    }
+
+    /// Creates the unbounded query used by the zcash-compatible RPC surface.
+    pub fn unbounded(addresses: GetAddressBalanceRequest) -> Self {
+        Self::new(addresses, 0, None)
+    }
+
+    /// Returns the address set, inclusive minimum height, and optional global
+    /// result cap.
+    pub fn into_parts(self) -> (GetAddressBalanceRequest, u64, Option<u32>) {
+        (self.addresses, self.start_height, self.max_entries)
+    }
+}
+
 /// One pool's treestate for a block, as reported by the backing validator.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PoolTreestate {
@@ -327,7 +366,7 @@ pub trait BlockchainSource: Clone + Send + Sync + 'static {
     /// <https://github.com/zcash/lightwalletd/blob/master/frontend/service.go#L402>
     fn get_address_utxos(
         &self,
-        address_strings: GetAddressBalanceRequest,
+        request: AddressUtxosRequest,
     ) -> impl SendFut<BlockchainSourceResult<Vec<GetAddressUtxos>>>;
 
     // ********** Utility methods **********

--- a/packages/zaino-state/src/chain_index/source/mockchain_source.rs
+++ b/packages/zaino-state/src/chain_index/source/mockchain_source.rs
@@ -9,7 +9,7 @@ use super::*;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr as _;
 use std::sync::{
-    atomic::{AtomicU32, Ordering},
+    atomic::{AtomicU32, AtomicUsize, Ordering},
     Arc, Mutex,
 };
 use zaino_common::network::ActivationHeights;
@@ -158,6 +158,10 @@ pub(crate) struct MockchainSource {
     >,
     active_chain_height: Arc<AtomicU32>,
     force_requests_against_source_to_fail: Arc<std::sync::atomic::AtomicBool>,
+    /// Number of transparent-UTXO source calls, shared across clones for tests.
+    address_utxo_request_count: Arc<AtomicUsize>,
+    /// Number of transparent-UTXO rows converted after bounds are applied.
+    address_utxo_conversion_count: Arc<AtomicUsize>,
     /// One-shot test hook: fires on the first `get_block(HashOrHeight::Height(_))`
     /// call after [`Self::arm_one_shot_get_block_hook`], regardless of which
     /// height is requested. Used by race regression tests (#1126) to inject
@@ -247,6 +251,8 @@ impl MockchainSource {
             force_requests_against_source_to_fail: Arc::new(std::sync::atomic::AtomicBool::new(
                 false,
             )),
+            address_utxo_request_count: Arc::new(AtomicUsize::new(0)),
+            address_utxo_conversion_count: Arc::new(AtomicUsize::new(0)),
             get_block_hook: Arc::new(Mutex::new(None)),
             blocks_received_broadcaster: tokio::sync::watch::channel(()).0,
             shutdown_called: Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -264,6 +270,23 @@ impl MockchainSource {
     pub(crate) fn set_failing(&self, fail: bool) {
         self.force_requests_against_source_to_fail
             .store(fail, Ordering::SeqCst);
+    }
+
+    /// Resets transparent-UTXO source-call and conversion counters.
+    pub(crate) fn reset_address_utxo_counters(&self) {
+        self.address_utxo_request_count.store(0, Ordering::SeqCst);
+        self.address_utxo_conversion_count
+            .store(0, Ordering::SeqCst);
+    }
+
+    /// Returns the number of transparent-UTXO source calls since the last reset.
+    pub(crate) fn address_utxo_request_count(&self) -> usize {
+        self.address_utxo_request_count.load(Ordering::SeqCst)
+    }
+
+    /// Returns the number of transparent-UTXO rows converted since the last reset.
+    pub(crate) fn address_utxo_conversion_count(&self) -> usize {
+        self.address_utxo_conversion_count.load(Ordering::SeqCst)
     }
 
     /// Advances `active_chain_height` by up to `blocks`, capped at
@@ -1240,8 +1263,11 @@ impl BlockchainSource for MockchainSource {
 
     async fn get_address_utxos(
         &self,
-        address_strings: GetAddressBalanceRequest,
+        request: AddressUtxosRequest,
     ) -> BlockchainSourceResult<Vec<GetAddressUtxos>> {
+        self.address_utxo_request_count
+            .fetch_add(1, Ordering::SeqCst);
+        let (address_strings, start_height, max_entries) = request.into_parts();
         let valid_addresses = address_strings.valid_addresses().map_err(|error| {
             BlockchainSourceError::Unrecoverable(format!("invalid address: {error}"))
         })?;
@@ -1265,7 +1291,13 @@ impl BlockchainSource for MockchainSource {
 
         let utxos = unspent_outputs
             .into_iter()
+            .filter(|(_outpoint, matching_output)| {
+                (matching_output.height.0 as u64) >= start_height
+            })
+            .take(max_entries.map_or(usize::MAX, |limit| limit as usize))
             .map(|(_outpoint, matching_output)| {
+                self.address_utxo_conversion_count
+                    .fetch_add(1, Ordering::SeqCst);
                 GetAddressUtxos::new(
                     matching_output.address,
                     matching_output.transaction_hash,

--- a/packages/zaino-state/src/chain_index/source/validator_connector.rs
+++ b/packages/zaino-state/src/chain_index/source/validator_connector.rs
@@ -1630,8 +1630,10 @@ impl BlockchainSource for ValidatorConnector {
 
     async fn get_address_utxos(
         &self,
-        addresses: GetAddressBalanceRequest,
+        request: AddressUtxosRequest,
     ) -> BlockchainSourceResult<Vec<GetAddressUtxos>> {
+        let (addresses, start_height, max_entries) = request.into_parts();
+
         match self {
             ValidatorConnector::State(state) => {
                 let mut state = state.read_state_service.clone();
@@ -1651,47 +1653,66 @@ impl BlockchainSource for ValidatorConnector {
                 let mut last_output_location =
                     zebra_state::OutputLocation::from_usize(zebra_chain::block::Height(0), 0, 0);
 
-                Ok(utxos
-                    .utxos()
-                    .map(
-                        |(
-                            utxo_address,
-                            utxo_hash,
-                            utxo_output_location,
-                            utxo_transparent_output,
-                        )| {
-                            assert!(utxo_output_location > &last_output_location);
-                            last_output_location = *utxo_output_location;
-                            GetAddressUtxos::new(
-                                utxo_address,
-                                *utxo_hash,
-                                utxo_output_location.output_index(),
-                                utxo_transparent_output.lock_script.clone(),
-                                u64::from(utxo_transparent_output.value()),
-                                utxo_output_location.height(),
-                            )
-                        },
-                    )
-                    .collect())
+                let mut address_utxos = Vec::new();
+                for (utxo_address, utxo_hash, utxo_output_location, utxo_transparent_output) in
+                    utxos.utxos()
+                {
+                    assert!(utxo_output_location > &last_output_location);
+                    last_output_location = *utxo_output_location;
+
+                    if (utxo_output_location.height().0 as u64) < start_height {
+                        continue;
+                    }
+                    if let Some(limit) = max_entries {
+                        if address_utxos.len() >= limit as usize {
+                            break;
+                        }
+                    }
+
+                    address_utxos.push(GetAddressUtxos::new(
+                        utxo_address,
+                        *utxo_hash,
+                        utxo_output_location.output_index(),
+                        utxo_transparent_output.lock_script.clone(),
+                        u64::from(utxo_transparent_output.value()),
+                        utxo_output_location.height(),
+                    ));
+                }
+
+                Ok(address_utxos)
             }
-            ValidatorConnector::Fetch(fetch) => Ok(fetch
-                .get_address_utxos(
-                    addresses
-                        .valid_addresses()
-                        .map_err(|_error| {
-                            BlockchainSourceError::Unrecoverable(
-                                "Invalid address provided".to_string(),
-                            )
-                        })?
-                        .into_iter()
-                        .map(|address| address.to_string())
-                        .collect(),
-                )
-                .await
-                .map_err(BlockchainSourceError::unrecoverable)?
-                .into_iter()
-                .map(|utxos| utxos.into())
-                .collect()),
+            ValidatorConnector::Fetch(fetch) => {
+                let rpc_utxos = fetch
+                    .get_address_utxos(
+                        addresses
+                            .valid_addresses()
+                            .map_err(|_error| {
+                                BlockchainSourceError::Unrecoverable(
+                                    "Invalid address provided".to_string(),
+                                )
+                            })?
+                            .into_iter()
+                            .map(|address| address.to_string())
+                            .collect(),
+                    )
+                    .await
+                    .map_err(BlockchainSourceError::unrecoverable)?;
+
+                let mut address_utxos = Vec::new();
+                for utxo in rpc_utxos {
+                    if (utxo.height.0 as u64) < start_height {
+                        continue;
+                    }
+                    if let Some(limit) = max_entries {
+                        if address_utxos.len() >= limit as usize {
+                            break;
+                        }
+                    }
+                    address_utxos.push(utxo.into());
+                }
+
+                Ok(address_utxos)
+            }
         }
     }
 

--- a/packages/zaino-state/src/chain_index/tests.rs
+++ b/packages/zaino-state/src/chain_index/tests.rs
@@ -26,7 +26,7 @@ use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 use tokio::sync::OnceCell;
 use tokio::time::Duration;
-use zaino_common::{network::ActivationHeights, DatabaseConfig, StorageConfig};
+use zaino_common::{network::ActivationHeights, DatabaseConfig, DatabaseSize, StorageConfig};
 
 use crate::{
     chain_index::{
@@ -128,6 +128,7 @@ async fn load_with_settings(
         storage: StorageConfig {
             database: DatabaseConfig {
                 path: db_path,
+                size: DatabaseSize(1),
                 ..Default::default()
             },
             ..Default::default()
@@ -216,6 +217,7 @@ async fn v1_finalised_seed_dir(mode: MockchainMode) -> &'static Path {
             storage: StorageConfig {
                 database: DatabaseConfig {
                     path: temp_dir.path().to_path_buf(),
+                    size: DatabaseSize(1),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/packages/zaino-state/src/chain_index/tests/mockchain_tests.rs
+++ b/packages/zaino-state/src/chain_index/tests/mockchain_tests.rs
@@ -1,7 +1,7 @@
 use super::{load_test_vectors_and_sync_chain_index, MockchainMode};
 use crate::{
     chain_index::{
-        source::mockchain_source::MockchainSource,
+        source::{mockchain_source::MockchainSource, AddressUtxosRequest},
         tests::{
             poll::poll_until,
             vectors::{indexed_block_chain, load_test_vectors, TestVectorBlockData},
@@ -777,19 +777,78 @@ async fn get_address_utxos() {
     let transparent_address = faucet_transparent_address();
 
     let expected_utxos = mockchain
+        .get_address_utxos(AddressUtxosRequest::unbounded(
+            GetAddressBalanceRequest::new(vec![transparent_address.clone()]),
+        ))
+        .await
+        .unwrap();
+
+    let indexer_utxos = index_reader
         .get_address_utxos(GetAddressBalanceRequest::new(vec![
             transparent_address.clone()
         ]))
         .await
         .unwrap();
 
-    let indexer_utxos = index_reader
-        .get_address_utxos(GetAddressBalanceRequest::new(vec![transparent_address]))
+    assert!(!indexer_utxos.is_empty());
+    assert_eq!(indexer_utxos, expected_utxos);
+    assert!(expected_utxos.len() > 1);
+
+    mockchain.reset_address_utxo_counters();
+    let capped_utxos = index_reader
+        .get_address_utxos_bounded(
+            GetAddressBalanceRequest::new(vec![transparent_address.clone()]),
+            0,
+            Some(1),
+        )
         .await
         .unwrap();
 
-    assert!(!indexer_utxos.is_empty());
-    assert_eq!(indexer_utxos, expected_utxos);
+    assert_eq!(capped_utxos, vec![expected_utxos[0].clone()]);
+    assert_eq!(mockchain.address_utxo_request_count(), 1);
+    assert_eq!(mockchain.address_utxo_conversion_count(), 1);
+
+    let (_, _, _, _, _, start_height) = expected_utxos[1].clone().into_parts();
+    let start_height = start_height.0 as u64;
+    let expected_from_start = expected_utxos
+        .iter()
+        .filter(|utxo| {
+            let (_, _, _, _, _, height) = (*utxo).clone().into_parts();
+            (height.0 as u64) >= start_height
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+
+    mockchain.reset_address_utxo_counters();
+    let from_start = index_reader
+        .get_address_utxos_bounded(
+            GetAddressBalanceRequest::new(vec![transparent_address.clone()]),
+            start_height,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(from_start, expected_from_start);
+    assert_eq!(mockchain.address_utxo_request_count(), 1);
+    assert_eq!(
+        mockchain.address_utxo_conversion_count(),
+        expected_from_start.len()
+    );
+
+    mockchain.reset_address_utxo_counters();
+    let from_start_capped = index_reader
+        .get_address_utxos_bounded(
+            GetAddressBalanceRequest::new(vec![transparent_address.clone()]),
+            start_height,
+            Some(1),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(from_start_capped, vec![expected_from_start[0].clone()]);
+    assert_eq!(mockchain.address_utxo_request_count(), 1);
+    assert_eq!(mockchain.address_utxo_conversion_count(), 1);
 
     let invalid_address_result = index_reader
         .get_address_utxos(GetAddressBalanceRequest::new(vec![
@@ -798,6 +857,105 @@ async fn get_address_utxos() {
         .await;
 
     assert!(invalid_address_result.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn address_utxo_handlers_apply_identical_bounds_before_source_conversion() {
+    use crate::indexer::node_backed_indexer::NodeBackedIndexerServiceSubscriber;
+    use crate::LightWalletIndexer as _;
+    use zaino_common::network::ActivationHeights;
+    use zaino_proto::proto::service::GetAddressUtxosArg;
+
+    let (_blocks, _indexer, index_reader, mockchain) =
+        load_test_vectors_and_sync_chain_index(MockchainMode::Static).await;
+    let transparent_address = faucet_transparent_address();
+    let source_utxos = mockchain
+        .get_address_utxos(AddressUtxosRequest::unbounded(
+            GetAddressBalanceRequest::new(vec![transparent_address.clone()]),
+        ))
+        .await
+        .unwrap();
+    let (_, _, _, _, _, start_height) = source_utxos[1].clone().into_parts();
+    let service = NodeBackedIndexerServiceSubscriber::new_for_test(
+        index_reader,
+        ActivationHeights::default().to_regtest_network(),
+    );
+
+    let bounded_request = GetAddressUtxosArg {
+        addresses: vec![transparent_address.clone()],
+        start_height: start_height.0 as u64,
+        max_entries: 1,
+    };
+
+    mockchain.reset_address_utxo_counters();
+    let unary = service
+        .get_address_utxos(bounded_request.clone())
+        .await
+        .unwrap()
+        .address_utxos;
+
+    assert_eq!(unary.len(), 1);
+    assert_eq!(mockchain.address_utxo_request_count(), 1);
+    assert_eq!(mockchain.address_utxo_conversion_count(), 1);
+
+    mockchain.reset_address_utxo_counters();
+    let streamed = service
+        .get_address_utxos_stream(bounded_request)
+        .await
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .await
+        .unwrap();
+
+    assert_eq!(streamed, unary);
+    assert_eq!(mockchain.address_utxo_request_count(), 1);
+    assert_eq!(mockchain.address_utxo_conversion_count(), 1);
+
+    mockchain.reset_address_utxo_counters();
+    let unrestricted = service
+        .get_address_utxos(GetAddressUtxosArg {
+            addresses: vec![transparent_address.clone()],
+            start_height: 0,
+            max_entries: 0,
+        })
+        .await
+        .unwrap()
+        .address_utxos;
+
+    assert!(unrestricted.len() > 1);
+    assert_eq!(mockchain.address_utxo_request_count(), 1);
+    assert_eq!(
+        mockchain.address_utxo_conversion_count(),
+        unrestricted.len()
+    );
+
+    let over_limit_request = GetAddressUtxosArg {
+        addresses: vec![transparent_address; 1001],
+        start_height: 0,
+        max_entries: 1,
+    };
+
+    mockchain.reset_address_utxo_counters();
+    let unary_error = match service.get_address_utxos(over_limit_request.clone()).await {
+        Ok(_) => panic!(),
+        Err(error) => error,
+    };
+    let unary_status: tonic::Status = unary_error.into();
+
+    assert_eq!(unary_status.code(), tonic::Code::InvalidArgument);
+    assert_eq!(mockchain.address_utxo_request_count(), 0);
+    assert_eq!(mockchain.address_utxo_conversion_count(), 0);
+
+    mockchain.reset_address_utxo_counters();
+    let stream_error = match service.get_address_utxos_stream(over_limit_request).await {
+        Ok(_) => panic!(),
+        Err(error) => error,
+    };
+    let stream_status: tonic::Status = stream_error.into();
+
+    assert_eq!(stream_status.code(), tonic::Code::InvalidArgument);
+    assert_eq!(mockchain.address_utxo_request_count(), 0);
+    assert_eq!(mockchain.address_utxo_conversion_count(), 0);
 }
 
 /// Walks zaino's own indexed view of the test-vector chain and derives, for every

--- a/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
+++ b/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
@@ -28,7 +28,7 @@ use crate::{
     chain_index::{
         finalized_height_floor,
         non_finalised_state::ChainIndexSnapshot,
-        source::{BlockchainSourceResult, GetTransactionLocation},
+        source::{AddressUtxosRequest, BlockchainSourceResult, GetTransactionLocation},
         tests::{init_tracing, poll::poll_until, proptest_blockgen::proptest_helpers::add_segment},
         types::BestChainLocation,
         NonFinalizedSnapshot, OPERATIONAL_NFS_DEPTH,
@@ -1350,7 +1350,7 @@ impl BlockchainSource for ProptestMockchain {
 
     async fn get_address_utxos(
         &self,
-        _address_strings: GetAddressBalanceRequest,
+        _request: AddressUtxosRequest,
     ) -> BlockchainSourceResult<Vec<GetAddressUtxos>> {
         //
         todo!()

--- a/packages/zaino-state/src/indexer.rs
+++ b/packages/zaino-state/src/indexer.rs
@@ -922,7 +922,7 @@ pub trait LightWalletIndexer: Send + Sync + Clone + ZcashIndexer + 'static {
     /// Ignores all utxos below block height [GetAddressUtxosArg.start_height].
     /// Returns max [GetAddressUtxosArg.max_entries] utxos, or unrestricted if [GetAddressUtxosArg.max_entries] = 0.
     /// max_entries bounds the response size, not the backend work; the address list is
-    /// capped server-side to bound backend fan-out (see UTXO_MAX_ADDRESSES in backends).
+    /// capped server-side by [`UTXO_MAX_ADDRESSES`] to bound backend fan-out.
     /// Utxos are collected and returned as a single Vec.
     fn get_address_utxos(
         &self,
@@ -934,7 +934,7 @@ pub trait LightWalletIndexer: Send + Sync + Clone + ZcashIndexer + 'static {
     /// Ignores all utxos below block height [GetAddressUtxosArg.start_height].
     /// Returns max [GetAddressUtxosArg.max_entries] utxos, or unrestricted if [GetAddressUtxosArg.max_entries] = 0.
     /// max_entries bounds the response size, not the backend work; the address list is
-    /// capped server-side to bound backend fan-out (see UTXO_MAX_ADDRESSES in backends).
+    /// capped server-side by [`UTXO_MAX_ADDRESSES`] to bound backend fan-out.
     /// Utxos are returned in a stream.
     fn get_address_utxos_stream(
         &self,

--- a/packages/zaino-state/src/indexer/node_backed_indexer.rs
+++ b/packages/zaino-state/src/indexer/node_backed_indexer.rs
@@ -1878,7 +1878,14 @@ impl<Source: BlockchainSource> LightWalletIndexer for NodeBackedIndexerServiceSu
     ) -> Result<GetAddressUtxosReplyList, Self::Error> {
         super::validate_utxo_address_count(request.addresses.len())?;
         let taddrs = GetAddressBalanceRequest::new(request.addresses);
-        let utxos = self.z_get_address_utxos(taddrs).await?;
+        let utxos = self
+            .indexer
+            .get_address_utxos_bounded(
+                taddrs,
+                request.start_height,
+                (request.max_entries > 0).then_some(request.max_entries),
+            )
+            .await?;
         let mut address_utxos: Vec<GetAddressUtxosReply> = Vec::new();
         let mut entries: u32 = 0;
         for utxo in utxos {
@@ -1936,7 +1943,14 @@ impl<Source: BlockchainSource> LightWalletIndexer for NodeBackedIndexerServiceSu
     ) -> Result<UtxoReplyStream, Self::Error> {
         super::validate_utxo_address_count(request.addresses.len())?;
         let taddrs = GetAddressBalanceRequest::new(request.addresses);
-        let utxos = self.z_get_address_utxos(taddrs).await?;
+        let utxos = self
+            .indexer
+            .get_address_utxos_bounded(
+                taddrs,
+                request.start_height,
+                (request.max_entries > 0).then_some(request.max_entries),
+            )
+            .await?;
         let service_timeout = self.config.service.timeout;
         let (channel_tx, channel_rx) = mpsc::channel(self.config.service.channel_size as usize);
         tokio::spawn(async move {


### PR DESCRIPTION
## Summary

Fixes #974 by applying `start_height` and `max_entries` inside the current `chain_index` path before Zaino converts the full result.

This replaces the obsolete `backends` implementation removed by #1361.

## Changes

- Added `AddressUtxosRequest` with addresses, inclusive `start_height`, and optional global `max_entries`.
- Added `ChainIndex::get_address_utxos_bounded(...)` while preserving the existing unbounded method.
- Routed unary and streaming handlers through the same bounded path.
- Applied bounds before `GetAddressUtxos` conversion in State, Fetch, and mockchain sources.
- Preserved the 1,000-address guard before any source call.
- Added tests for inclusive height filtering, global caps, `max_entries = 0`, unary and stream parity, conversion counts, and early address-limit rejection.
- Set the shared temporary test LMDB map to 1 GiB instead of inheriting the 384 GiB production default.

The backing State query and Fetch RPC response are still materialized upstream. The Fetch RPC has no height or limit parameters. This patch bounds Zaino-side conversion and returned materialization.

## Validation

Base: `zingolabs:dev` at `d98984d10ce802bc7cb553dae091f6581272eec0`

- `cargo fmt --all -- --check`
- `git diff HEAD^ HEAD --check`
- `cargo +stable-x86_64-pc-windows-msvc test -p zaino-state --lib --no-default-features --no-run`
- `chain_index::tests::mockchain_tests::get_address_utxos`: passed
- `chain_index::tests::mockchain_tests::address_utxo_handlers_apply_identical_bounds_before_source_conversion`: passed

Current public CI:

- Seven distinct generic checks pass: Hadolint, cargo publish dry-run, Shellcheck, Rustfmt, repo guards, cargo-deny, and Docker-tag computation.
- `Trigger integration tests` fails before product tests because fork PR context has no GitHub App `client-id`.
- `Build test artifacts`, `No-zcashd build`, and `Tests` are skipped behind that dispatch gate.

The patch is ready for maintainer review. Production/canonical jobs still need maintainer-context execution; the trigger failure is not treated as a code-test failure.
