### PR TITLE
bound get_address_utxos address fan-out (#974)

### DIFF
--- a/packages/zaino-state/src/backends.rs
+++ b/packages/zaino-state/src/backends.rs
@@ -15,6 +15,32 @@ fn latest_network_upgrade(
     })
 }
 
+/// Maximum number of addresses a single `get_address_utxos` / `get_address_utxos_stream`
+/// request may carry.
+///
+/// Both backends resolve the full backend UTXO set before applying `max_entries` /
+/// `start_height` (issue #974). A complete pushdown fix needs upstream interface changes
+/// the caller-supplied entry cap cannot reach today, so until then this bounds the one
+/// input the service controls locally: the address fan-out. It stops an unauthenticated
+/// caller forcing an unbounded number of backend address lookups in a single request, and
+/// is set well above realistic wallet usage.
+///
+/// TODO: make this deployment-configurable rather than a fixed constant.
+const UTXO_MAX_ADDRESSES: usize = 1000;
+
+/// Reject a `get_address_utxos` request whose address list exceeds [`UTXO_MAX_ADDRESSES`].
+///
+/// `max_entries` bounds the response size, not the backend work; this guard bounds the
+/// address fan-out, the part the service can cap without upstream changes.
+fn validate_utxo_address_count(count: usize) -> Result<(), tonic::Status> {
+    if count > UTXO_MAX_ADDRESSES {
+        return Err(tonic::Status::invalid_argument(format!(
+            "Error: too many addresses in request: {count} exceeds the maximum of {UTXO_MAX_ADDRESSES}."
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -27,5 +53,19 @@ mod tests {
             err.message(),
             "validator returned no network upgrade metadata"
         );
+    }
+
+    #[test]
+    fn utxo_address_count_within_limit_is_accepted() {
+        assert!(super::validate_utxo_address_count(0).is_ok());
+        assert!(super::validate_utxo_address_count(super::UTXO_MAX_ADDRESSES).is_ok());
+    }
+
+    #[test]
+    fn utxo_address_count_over_limit_is_rejected() {
+        let err = super::validate_utxo_address_count(super::UTXO_MAX_ADDRESSES + 1)
+            .expect_err("over-limit address count must fail");
+
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
     }
 }

--- a/packages/zaino-state/src/backends/fetch.rs
+++ b/packages/zaino-state/src/backends/fetch.rs
@@ -1865,6 +1865,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
         &self,
         request: GetAddressUtxosArg,
     ) -> Result<GetAddressUtxosReplyList, Self::Error> {
+        super::validate_utxo_address_count(request.addresses.len())?;
         let taddrs = GetAddressBalanceRequest::new(request.addresses);
         let utxos = self.z_get_address_utxos(taddrs).await?;
         let mut address_utxos: Vec<GetAddressUtxosReply> = Vec::new();
@@ -1918,6 +1919,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
         &self,
         request: GetAddressUtxosArg,
     ) -> Result<UtxoReplyStream, Self::Error> {
+        super::validate_utxo_address_count(request.addresses.len())?;
         let taddrs = GetAddressBalanceRequest::new(request.addresses);
         let utxos = self.z_get_address_utxos(taddrs).await?;
         let service_timeout = self.config.common.service.timeout;

--- a/packages/zaino-state/src/backends/state.rs
+++ b/packages/zaino-state/src/backends/state.rs
@@ -2511,6 +2511,7 @@ impl LightWalletIndexer for StateServiceSubscriber {
         &self,
         request: GetAddressUtxosArg,
     ) -> Result<GetAddressUtxosReplyList, Self::Error> {
+        super::validate_utxo_address_count(request.addresses.len())?;
         let taddrs = GetAddressBalanceRequest::new(request.addresses);
         let utxos = self.z_get_address_utxos(taddrs).await?;
         let mut address_utxos: Vec<GetAddressUtxosReply> = Vec::new();
@@ -2563,6 +2564,7 @@ impl LightWalletIndexer for StateServiceSubscriber {
         &self,
         request: GetAddressUtxosArg,
     ) -> Result<UtxoReplyStream, Self::Error> {
+        super::validate_utxo_address_count(request.addresses.len())?;
         let taddrs = GetAddressBalanceRequest::new(request.addresses);
         let utxos = self.z_get_address_utxos(taddrs).await?;
         let service_timeout = self.config.common.service.timeout;

--- a/packages/zaino-state/src/indexer.rs
+++ b/packages/zaino-state/src/indexer.rs
@@ -896,6 +896,8 @@ pub trait LightWalletIndexer: Send + Sync + Clone + ZcashIndexer + 'static {
     ///
     /// Ignores all utxos below block height [GetAddressUtxosArg.start_height].
     /// Returns max [GetAddressUtxosArg.max_entries] utxos, or unrestricted if [GetAddressUtxosArg.max_entries] = 0.
+    /// max_entries bounds the response size, not the backend work; the address list is
+    /// capped server-side to bound backend fan-out (see UTXO_MAX_ADDRESSES in backends).
     /// Utxos are collected and returned as a single Vec.
     async fn get_address_utxos(
         &self,
@@ -906,6 +908,8 @@ pub trait LightWalletIndexer: Send + Sync + Clone + ZcashIndexer + 'static {
     ///
     /// Ignores all utxos below block height [GetAddressUtxosArg.start_height].
     /// Returns max [GetAddressUtxosArg.max_entries] utxos, or unrestricted if [GetAddressUtxosArg.max_entries] = 0.
+    /// max_entries bounds the response size, not the backend work; the address list is
+    /// capped server-side to bound backend fan-out (see UTXO_MAX_ADDRESSES in backends).
     /// Utxos are returned in a stream.
     async fn get_address_utxos_stream(
         &self,


### PR DESCRIPTION
partial fix for #974.

#974 has two parts: the post-fetch cap (already in dev) and the fact that both backends materialize the full backend utxo set before applying max_entries/start_height. a complete pushdown fix needs upstream interface changes (zebra UtxosByAddresses and zcashd getaddressutxos take no entry cap), so this does the zaino-local part only.

what this does:
- caps the address list size at all four utxo entry points (state + fetch, unary + stream) before the backend call, via a shared validate_utxo_address_count with tests. bounds the one input the service controls locally, the address fan-out, so a caller cannot force an unbounded number of backend address lookups in a single request.
- documents that max_entries bounds response size, not backend work.

UTXO_MAX_ADDRESSES is 1000, set well above realistic wallet usage. left as a const with a TODO; happy to make it config-driven if you prefer.

deliberately not here:
- backend pushdown of max_entries/start_height: needs upstream coordination, tracked by the rest of #974.
- rejecting unrestricted max_entries: that changes the documented 0 = unrestricted contract, so i left it out. tell me if you want it gated in public service mode.
- try_collect removal: already gone from dev.

questions: prefer a config field over the const for the address cap? and do you want unrestricted max_entries rejected in public mode, or is the existing clamp-after-fetch enough?