### PR TITLE
Add NU6.2 activation height support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5480,7 +5480,6 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "time",
- "toml 0.5.11",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6224,8 +6224,10 @@ dependencies = [
 [[package]]
 name = "zingo_common_components"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ed7ebc771980a59ec5f208d5dcf40c010dce2b5d493164c9d2f7baa73e9284"
+source = "git+https://github.com/valargroup/zingo-common.git?rev=3d58a4399c00ca10779fcef5ecf8ed46f913cb84#3d58a4399c00ca10779fcef5ecf8ed46f913cb84"
+dependencies = [
+ "hex",
+]
 
 [[package]]
 name = "zip32"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6222,8 +6222,9 @@ dependencies = [
 
 [[package]]
 name = "zingo_common_components"
-version = "0.3.0"
-source = "git+https://github.com/valargroup/zingo-common.git?rev=3d58a4399c00ca10779fcef5ecf8ed46f913cb84#3d58a4399c00ca10779fcef5ecf8ed46f913cb84"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3378e81bdef45a9659736a09deaef2b5e5cb3d1556031468debfca3a21d4fa76"
 dependencies = [
  "hex",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "halo2_gadgets"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45824ce0dd12e91ec0c68ebae2a7ed8ae19b70946624c849add59f1d1a62a143"
+checksum = "fb2a697cad929f706b7987fe804ad57d43622cd37463ba7e4d662a926fdcfea3"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2580,9 +2580,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497e74492624a1d1cc8c9675a7afb17b430d32fd9efc171513d0840140b5f0c7"
+checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
 dependencies = [
  "aes",
  "bitvec",
@@ -5480,6 +5480,7 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "time",
+ "toml 0.5.11",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
@@ -5627,9 +5628,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f3db1087875052b5ad0f9e7179a7e7794f0ae9cb1d6ab2b7db29f7b9a9b0b"
+checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
 dependencies = [
  "bech32",
  "bs58",
@@ -5663,9 +5664,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b340e2bc20698c4d784d920dcda1f270d076bef2b0726b732ca9ca7574d61241"
+checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -5704,9 +5705,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a59f418f8b1274a526d57dfa3b1a7b3724f04926c84712a27c1602e4b44bfacd"
+checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -5735,9 +5736,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c6749aeaf49a56874d915482bc03e4afb9f6e561ed476b7c906e6d9de3ef74"
+checksum = "3de6b0ca82e08a9d38b1121f87c5b180b5feac19fecba074cb582882210d2371"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5758,9 +5759,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ef3de16a4464a574591aa3e4ea875116372638307d7ae04415279ec187ba88"
+checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
 dependencies = [
  "corez",
  "document-features",
@@ -5771,9 +5772,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774d808ab619b0f1887d7b90cd815c356101698d16aa681f3d2d9dea063de475"
+checksum = "2f872800287d118be71bdf6fe8c869c6a6ff6fb0a5762f68fb2af54c97edf0f2"
 dependencies = [
  "bip32",
  "bitflags 2.11.1",
@@ -5797,9 +5798,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9ad72051b49432acd56d44ab301bb6467bd70eb23faab3f35539e4ecf2733d"
+checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
 dependencies = [
  "bip32",
  "bs58",
@@ -5822,9 +5823,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "7.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99160b5cb49188c44bcba2ae56d0a85d2ba592243247451458bdf50ac3fd596d"
+checksum = "30ed3a4e00e8f0b2197f3d8fd6cad02351a25ddbffcf0a6dc1fe463d7ea4ccfa"
 dependencies = [
  "bech32",
  "bitflags 2.11.1",
@@ -5891,9 +5892,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "6.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e7835e49a2056b262cd4adc4b9b1f85f11821dad6b9353742d4bf088cef3fb"
+checksum = "15475adf8c271d03de99d18d622a8ae4c512c401e3e29da1f27a0ba62b22057c"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5905,6 +5906,7 @@ dependencies = [
  "halo2_proofs",
  "jubjub",
  "lazy_static",
+ "libzcash_script",
  "metrics",
  "mset",
  "once_cell",
@@ -5920,8 +5922,11 @@ dependencies = [
  "tower-fallback",
  "tracing",
  "tracing-futures",
+ "zcash_primitives",
  "zcash_proofs",
  "zcash_protocol",
+ "zcash_script",
+ "zcash_transparent",
  "zebra-chain",
  "zebra-node-services",
  "zebra-script",
@@ -5930,9 +5935,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "6.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c072b418e2858eb1963116356c5093033ca3c6f62426ea7acf2a22e0d031bcaf"
+checksum = "b8ba4f7dcd795eb84a5a33f5c4f29df60dd4971be363d2cd98d5fba5ce0477f2"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -5968,9 +5973,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "5.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa5570277295b66b33fb6aa4a1d8ceed5e33925d3928be7afc18e8af157ec7b"
+checksum = "abeece0fb4503a1df00c5ab736754b55c702613968f622f6aa3c2f9842aed2b2"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -5984,9 +5989,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "7.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e44dc2ca75c5ab16a2ce489f9919da2f6b2141ea5bff1f84addf96e871b5b5"
+checksum = "b460869e352c9f1b49a00ed9beaae04ca3e6498381c7189d4b90a79e51c260bd"
 dependencies = [
  "base64",
  "chrono",
@@ -6001,9 +6006,11 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-proc-macros",
  "jsonrpsee-types",
+ "lazy_static",
  "metrics",
  "nix",
  "openrpsee",
+ "orchard",
  "phf",
  "prost",
  "rand 0.8.6",
@@ -6013,6 +6020,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -6025,6 +6035,7 @@ dependencies = [
  "zcash_address",
  "zcash_keys",
  "zcash_primitives",
+ "zcash_proofs",
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
@@ -6038,9 +6049,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "6.0.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44d0d0e79ff9ed4db6b86dd60bec76c2d6fc3046658f82456063cad43b8dfe4"
+checksum = "c4fc38c19388671df8a77c767e279b135ffaecd5e7df6ed7cd096390c080b4a3"
 dependencies = [
  "libzcash_script",
  "rand 0.8.6",
@@ -6052,9 +6063,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "6.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fecd536ba6131e3560995b42590dbe08bd767003dfac102995140a00ad2ab3"
+checksum = "57b351fde5047dce0d505c9dc26863ee818b7579e9cf8d8e44489deb9decfbb7"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ license = "Apache-2.0"
 
 # Zingo
 
-zingo_common_components =  "0.3.0"
+zingo_common_components = { git = "https://github.com/valargroup/zingo-common.git", rev = "3d58a4399c00ca10779fcef5ecf8ed46f913cb84" }
 
 # Librustzcash
 incrementalmerkletree = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,17 +32,17 @@ zingo_common_components =  "0.3.0"
 
 # Librustzcash
 incrementalmerkletree = "0.8"
-zcash_address = "0.11"
-zcash_keys = "0.13"
-zcash_protocol = "0.8"
-zcash_primitives = "0.27"
-zcash_transparent = "0.7"
-zcash_client_backend = "0.22"
+zcash_address = "0.12"
+zcash_keys = "0.14"
+zcash_protocol = "0.9"
+zcash_primitives = "0.28"
+zcash_transparent = "0.8"
+zcash_client_backend = "0.23"
 
 # Zebra
-zebra-chain = "7.0.0"
-zebra-state = "6.0.0"
-zebra-rpc = "7.0.0"
+zebra-chain = "9.0.0"
+zebra-state = "8.0.0"
+zebra-rpc = "9.0.0"
 
 # Runtime
 tokio = { version = "1.38", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ license = "Apache-2.0"
 
 # Zingo
 
-zingo_common_components = { git = "https://github.com/valargroup/zingo-common.git", rev = "3d58a4399c00ca10779fcef5ecf8ed46f913cb84" }
+zingo_common_components = "0.3.1"
 
 # Librustzcash
 incrementalmerkletree = "0.8"

--- a/integration-tests/tests/chain_cache.rs
+++ b/integration-tests/tests/chain_cache.rs
@@ -122,6 +122,7 @@ mod chain_query_interface {
                                 nu5: local_net_activation_heights.nu5(),
                                 nu6: local_net_activation_heights.nu6(),
                                 nu6_1: local_net_activation_heights.nu6_1(),
+                                nu6_2: local_net_activation_heights.nu6_2(),
                                 nu7: local_net_activation_heights.nu7(),
                             },
                         ))

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -72,6 +72,7 @@ async fn create_test_manager_and_services<V: ValidatorExt>(
                 nu5: activation_heights.nu5(),
                 nu6: activation_heights.nu6(),
                 nu6_1: activation_heights.nu6_1(),
+                nu6_2: activation_heights.nu6_2(),
                 nu7: activation_heights.nu7(),
             }
         }),

--- a/integration-tests/zaino-testutils/src/lib.rs
+++ b/integration-tests/zaino-testutils/src/lib.rs
@@ -214,6 +214,9 @@ pub fn local_network_from_activation_heights(
         nu6_1: activation_heights
             .nu6_1
             .map(zcash_protocol::consensus::BlockHeight::from),
+        nu6_2: activation_heights
+            .nu6_2
+            .map(zcash_protocol::consensus::BlockHeight::from),
     }
 }
 

--- a/packages/zaino-common/Cargo.toml
+++ b/packages/zaino-common/Cargo.toml
@@ -28,3 +28,6 @@ time = { workspace = true }
 
 # Zingo
 zingo_common_components = { workspace = true }
+
+[dev-dependencies]
+toml = { workspace = true }

--- a/packages/zaino-common/Cargo.toml
+++ b/packages/zaino-common/Cargo.toml
@@ -28,6 +28,3 @@ time = { workspace = true }
 
 # Zingo
 zingo_common_components = { workspace = true }
-
-[dev-dependencies]
-toml = { workspace = true }

--- a/packages/zaino-common/src/config/network.rs
+++ b/packages/zaino-common/src/config/network.rs
@@ -364,25 +364,20 @@ mod tests {
     use super::ActivationHeights;
 
     #[test]
-    fn activation_heights_parse_nu6_2() {
-        let heights: ActivationHeights = toml::from_str(
-            r#"
-BeforeOverwinter = 1
-Overwinter = 1
-Sapling = 1
-Blossom = 1
-Heartwood = 1
-Canopy = 1
-NU5 = 1
-NU6 = 1
-"NU6.1" = 1
-"NU6.2" = 2
-NU7 = 1000
-"#,
-        )
-        .expect("activation heights should parse");
-
-        assert_eq!(heights.nu6_2, Some(2));
+    fn activation_heights_round_trip_nu6_2() {
+        let heights = ActivationHeights {
+            before_overwinter: Some(1),
+            overwinter: Some(1),
+            sapling: Some(1),
+            blossom: Some(1),
+            heartwood: Some(1),
+            canopy: Some(1),
+            nu5: Some(1),
+            nu6: Some(1),
+            nu6_1: Some(1),
+            nu6_2: Some(2),
+            nu7: Some(1000),
+        };
 
         let zebra_heights: zebra_chain::parameters::testnet::ConfiguredActivationHeights =
             heights.into();

--- a/packages/zaino-common/src/config/network.rs
+++ b/packages/zaino-common/src/config/network.rs
@@ -142,6 +142,7 @@ impl From<ActivationHeights> for zingo_common_components::protocol::ActivationHe
             .set_nu5(val.nu5)
             .set_nu6(val.nu6)
             .set_nu6_1(val.nu6_1)
+            .set_nu6_2(val.nu6_2)
             .set_nu7(val.nu7)
             .build()
     }
@@ -222,7 +223,7 @@ impl From<zingo_common_components::protocol::ActivationHeights> for ActivationHe
             nu5: activation_heights.nu5(),
             nu6: activation_heights.nu6(),
             nu6_1: activation_heights.nu6_1(),
-            nu6_2: None,
+            nu6_2: activation_heights.nu6_2(),
             nu7: activation_heights.nu7(),
         }
     }
@@ -386,5 +387,9 @@ NU7 = 1000
         let zebra_heights: zebra_chain::parameters::testnet::ConfiguredActivationHeights =
             heights.into();
         assert_eq!(zebra_heights.nu6_2, Some(2));
+
+        let zingo_heights: zingo_common_components::protocol::ActivationHeights = heights.into();
+        let heights = ActivationHeights::from(zingo_heights);
+        assert_eq!(heights.nu6_2, Some(2));
     }
 }

--- a/packages/zaino-common/src/config/network.rs
+++ b/packages/zaino-common/src/config/network.rs
@@ -15,6 +15,7 @@ pub const ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS: ActivationHeights = ActivationHeigh
     nu5: Some(2),
     nu6: Some(2),
     nu6_1: Some(1000),
+    nu6_2: None,
     nu7: None,
 };
 
@@ -104,6 +105,9 @@ pub struct ActivationHeights {
     /// see <https://zips.z.cash/#nu6-1-candidate-zips> for info on NU6.1
     #[serde(rename = "NU6.1")]
     pub nu6_1: Option<u32>,
+    /// Activation height for `NU6.2` network upgrade.
+    #[serde(rename = "NU6.2")]
+    pub nu6_2: Option<u32>,
     /// Activation height for `NU7` network upgrade.
     #[serde(rename = "NU7")]
     pub nu7: Option<u32>,
@@ -121,6 +125,7 @@ impl Default for ActivationHeights {
             nu5: Some(2),
             nu6: Some(2),
             nu6_1: Some(2),
+            nu6_2: None,
             nu7: None,
         }
     }
@@ -154,6 +159,7 @@ impl From<ConfiguredActivationHeights> for ActivationHeights {
             nu5,
             nu6,
             nu6_1,
+            nu6_2,
             nu7,
         }: ConfiguredActivationHeights,
     ) -> Self {
@@ -167,6 +173,7 @@ impl From<ConfiguredActivationHeights> for ActivationHeights {
             nu5,
             nu6,
             nu6_1,
+            nu6_2,
             nu7,
         }
     }
@@ -183,6 +190,7 @@ impl From<ActivationHeights> for ConfiguredActivationHeights {
             nu5,
             nu6,
             nu6_1,
+            nu6_2,
             nu7,
         }: ActivationHeights,
     ) -> Self {
@@ -196,6 +204,7 @@ impl From<ActivationHeights> for ConfiguredActivationHeights {
             nu5,
             nu6,
             nu6_1,
+            nu6_2,
             nu7,
         }
     }
@@ -213,6 +222,7 @@ impl From<zingo_common_components::protocol::ActivationHeights> for ActivationHe
             nu5: activation_heights.nu5(),
             nu6: activation_heights.nu6(),
             nu6_1: activation_heights.nu6_1(),
+            nu6_2: None,
             nu7: activation_heights.nu7(),
         }
     }
@@ -236,6 +246,7 @@ impl Network {
             nu5: Some(1),
             nu6: Some(1),
             nu6_1: None,
+            nu6_2: None,
             nu7: None,
         }
     }
@@ -279,6 +290,7 @@ impl From<zebra_chain::parameters::Network> for Network {
                         nu5: None,
                         nu6: None,
                         nu6_1: None,
+                        nu6_2: None,
                         nu7: None,
                     };
                     for (height, upgrade) in parameters.activation_heights().iter() {
@@ -311,6 +323,9 @@ impl From<zebra_chain::parameters::Network> for Network {
                             zebra_chain::parameters::NetworkUpgrade::Nu6_1 => {
                                 activation_heights.nu6_1 = Some(height.0)
                             }
+                            zebra_chain::parameters::NetworkUpgrade::Nu6_2 => {
+                                activation_heights.nu6_2 = Some(height.0)
+                            }
                             zebra_chain::parameters::NetworkUpgrade::Nu7 => {
                                 activation_heights.nu7 = Some(height.0)
                             }
@@ -340,5 +355,36 @@ impl From<Network> for zebra_chain::parameters::Network {
 impl From<&Network> for zebra_chain::parameters::Network {
     fn from(val: &Network) -> Self {
         (*val).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ActivationHeights;
+
+    #[test]
+    fn activation_heights_parse_nu6_2() {
+        let heights: ActivationHeights = toml::from_str(
+            r#"
+BeforeOverwinter = 1
+Overwinter = 1
+Sapling = 1
+Blossom = 1
+Heartwood = 1
+Canopy = 1
+NU5 = 1
+NU6 = 1
+"NU6.1" = 1
+"NU6.2" = 2
+NU7 = 1000
+"#,
+        )
+        .expect("activation heights should parse");
+
+        assert_eq!(heights.nu6_2, Some(2));
+
+        let zebra_heights: zebra_chain::parameters::testnet::ConfiguredActivationHeights =
+            heights.into();
+        assert_eq!(zebra_heights.nu6_2, Some(2));
     }
 }

--- a/packages/zaino-fetch/src/jsonrpsee/response.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response.rs
@@ -454,7 +454,9 @@ impl ResponseToError for GetTxOutSetInfoResponse {
 
 #[cfg(test)]
 mod get_tx_out_set_info_tests {
-    use super::{EmptyTxOutSetInfo, GetTxOutSetInfo, GetTxOutSetInfoResponse};
+    use super::{
+        EmptyTxOutSetInfo, GetBlockchainInfoResponse, GetTxOutSetInfo, GetTxOutSetInfoResponse,
+    };
 
     #[test]
     fn parses_zcashd_stats_response() {
@@ -512,6 +514,51 @@ mod get_tx_out_set_info_tests {
         let parsed: GetTxOutSetInfoResponse = serde_json::from_str("{}").unwrap();
 
         assert_eq!(parsed, GetTxOutSetInfoResponse::Empty(EmptyTxOutSetInfo {}));
+    }
+
+    #[test]
+    fn parses_get_blockchain_info_with_nu6_2_upgrade() {
+        let json = r#"{
+            "chain": "regtest",
+            "blocks": 2,
+            "bestblockhash": "0000000000000000000000000000000000000000000000000000000000000002",
+            "estimatedheight": 2,
+            "chainSupply": {
+                "chainValue": 0.0,
+                "chainValueZat": 0
+            },
+            "upgrades": {
+                "5437f330": {
+                    "name": "NU6.2",
+                    "activationheight": 2,
+                    "status": "active"
+                }
+            },
+            "valuePools": [
+                { "id": "transparent", "chainValue": 0.0, "chainValueZat": 0 },
+                { "id": "sprout", "chainValue": 0.0, "chainValueZat": 0 },
+                { "id": "sapling", "chainValue": 0.0, "chainValueZat": 0 },
+                { "id": "orchard", "chainValue": 0.0, "chainValueZat": 0 },
+                { "id": "deferred", "chainValue": 0.0, "chainValueZat": 0 }
+            ],
+            "consensus": {
+                "chaintip": "5437f330",
+                "nextblock": "5437f330"
+            }
+        }"#;
+
+        let parsed: GetBlockchainInfoResponse = serde_json::from_str(json).unwrap();
+        let (name, activation_height, status) = parsed
+            .upgrades
+            .values()
+            .next()
+            .unwrap()
+            .clone()
+            .into_parts();
+
+        assert_eq!(name, zebra_chain::parameters::NetworkUpgrade::Nu6_2);
+        assert_eq!(activation_height, zebra_chain::block::Height(2));
+        assert_eq!(status, zebra_rpc::methods::NetworkUpgradeStatus::Active);
     }
 }
 

--- a/packages/zaino-fetch/src/jsonrpsee/response.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response.rs
@@ -559,6 +559,7 @@ mod get_tx_out_set_info_tests {
         assert_eq!(name, zebra_chain::parameters::NetworkUpgrade::Nu6_2);
         assert_eq!(activation_height, zebra_chain::block::Height(2));
         assert_eq!(status, zebra_rpc::methods::NetworkUpgradeStatus::Active);
+        assert_eq!(parsed.consensus.into_parts(), (0x5437f330, 0x5437f330));
     }
 }
 

--- a/packages/zaino-fetch/src/jsonrpsee/response/address_deltas.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response/address_deltas.rs
@@ -278,7 +278,7 @@ mod tests {
 
     fn sample_delta_with_block_index(i: u32, bi: Option<u32>) -> AddressDelta {
         AddressDelta {
-            satoshis: if i.is_multiple_of(2) { 1_000 } else { -500 },
+            satoshis: if i % 2 == 0 { 1_000 } else { -500 },
             txid: format!("deadbeef{:02x}", i),
             index: i,
             height: 123_456 + i,

--- a/packages/zaino-fetch/src/jsonrpsee/response/address_deltas.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response/address_deltas.rs
@@ -278,7 +278,7 @@ mod tests {
 
     fn sample_delta_with_block_index(i: u32, bi: Option<u32>) -> AddressDelta {
         AddressDelta {
-            satoshis: if i % 2 == 0 { 1_000 } else { -500 },
+            satoshis: if i.is_multiple_of(2) { 1_000 } else { -500 },
             txid: format!("deadbeef{:02x}", i),
             index: i,
             height: 123_456 + i,

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -538,7 +538,7 @@ impl DbV1 {
                 tokio::task::block_in_place(|| self.env.sync(true))
                     .map_err(|e| FinalisedStateError::Custom(format!("LMDB sync failed: {e}")))?;
                 self.status.store(StatusType::Ready);
-                if block.context.index.height.0 % 100 == 0 {
+                if block.context.index.height.0.is_multiple_of(100) {
                     info!(
                         "Successfully committed block {} at height {} to ZainoDB.",
                         &block.context.index.hash, &block.context.index.height

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -538,7 +538,7 @@ impl DbV1 {
                 tokio::task::block_in_place(|| self.env.sync(true))
                     .map_err(|e| FinalisedStateError::Custom(format!("LMDB sync failed: {e}")))?;
                 self.status.store(StatusType::Ready);
-                if block.context.index.height.0.is_multiple_of(100) {
+                if block.context.index.height.0 % 100 == 0 {
                     info!(
                         "Successfully committed block {} at height {} to ZainoDB.",
                         &block.context.index.hash, &block.context.index.height

--- a/packages/zaino-state/src/chain_index/tests/vectors.rs
+++ b/packages/zaino-state/src/chain_index/tests/vectors.rs
@@ -110,6 +110,7 @@ pub(in crate::chain_index::tests) fn indexed_block_chain(
                     nu6: Some(1),
                     // see https://zips.z.cash/#nu6-1-candidate-zips for info on NU6.1
                     nu6_1: None,
+                    nu6_2: None,
                     nu7: None,
                 }
                 .into(),


### PR DESCRIPTION
Adds NU6.2 support to Zebra RPC parsing and preserves the NU6.2 activation height in zaino-common network config. This lets custom network activation heights flow through into Zaino's Zebra network setup.

Validation: cargo test -p zaino-common