### PR TITLE
rc-0.4.0: Speed up finalised-state sync & v1.1→v1.2 migration (sandblast-height stall fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this library adheres to Rust's notion of
   validator.
 
 ### Added
+- `storage.database.sync_write_batch_bytes` config (default 4 GiB) tunes the
+  finalised-state bulk-sync / migration write-batch size.
 - `zainod` gains an `allow_unencrypted_public_json_rpc_bind` build feature that
   lifts the new private-only JSON-RPC bind restriction for trusted
   private-network deployments (logs a `WARN` on startup when enabled).
@@ -24,6 +26,13 @@ and this library adheres to Rust's notion of
   `FinalisedTxOutSetInfoAccumulator` with the non-finalised state to produce
   the full `GetTxOutSetInfoResponse`.
 ### Changed
+- Finalised-state sync and the v1.1.0 -> v1.2.0 migration are substantially
+  faster on large/mainnet caches. The txout-set accumulator is built in bulk at
+  the tip instead of per block (removing an unbounded fan-out of random reads),
+  block validation is off the write path, and the random-keyed `spent` /
+  `txid_location` indexes are written in sorted batches — together removing the
+  random-fault stall around sandblast height. See the `zaino-state` changelog for
+  details; tune the write-batch size with `storage.database.sync_write_batch_bytes`.
 - The `zainod` JSON-RPC server now refuses to bind to public or unspecified
   (`0.0.0.0` / `::`) addresses by default; `check_config` enforces the same
   private/loopback rule already applied to gRPC. The unencrypted JSON-RPC

--- a/packages/zaino-common/CHANGELOG.md
+++ b/packages/zaino-common/CHANGELOG.md
@@ -8,6 +8,11 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+- `StorageConfig::database.sync_write_batch_bytes` (default 4 GiB) — byte budget
+  for the finalised-state bulk-sync / migration write batch. Larger batches
+  insert the random-keyed `spent` / `txid_location` indexes in bigger sorted
+  sweeps (fewer random B-tree faults once the DB exceeds RAM), at the cost of
+  more RAM; raise it on large-RAM hosts.
 ### Changed
 ### Deprecated
 ### Removed

--- a/packages/zaino-common/src/config/storage.rs
+++ b/packages/zaino-common/src/config/storage.rs
@@ -68,6 +68,23 @@ pub struct DatabaseConfig {
     /// Database size limit. Defaults to 128 GB.
     #[serde(default)]
     pub size: DatabaseSize,
+    /// Approximate in-memory byte budget for the finalised-state bulk-sync write batch.
+    ///
+    /// Bulk sync buffers fetched blocks up to this many bytes, then writes the whole batch in one
+    /// LMDB transaction with the random-keyed `spent` / `txid_location` entries inserted in **sorted**
+    /// key order. Sorting turns the random B-tree leaf faults (which dominate once the DB exceeds
+    /// RAM) into a sequential sweep; larger batches mean fewer sweeps.
+    ///
+    /// NOTE: peak RAM is roughly this budget (buffered blocks) plus the transaction's dirty pages,
+    /// and it competes with the OS page cache the sorted sweep relies on — larger is not always
+    /// better. Defaults to 4 GiB; raise it on large-RAM hosts.
+    #[serde(default = "default_sync_write_batch_bytes")]
+    pub sync_write_batch_bytes: u64,
+}
+
+/// Default [`DatabaseConfig::sync_write_batch_bytes`]: 4 GiB.
+fn default_sync_write_batch_bytes() -> u64 {
+    4 * 1024 * 1024 * 1024
 }
 
 impl Default for DatabaseConfig {
@@ -75,6 +92,7 @@ impl Default for DatabaseConfig {
         Self {
             path: resolve_path_with_xdg_cache_defaults("zaino"),
             size: DatabaseSize::default(),
+            sync_write_batch_bytes: default_sync_write_batch_bytes(),
         }
     }
 }

--- a/packages/zaino-state/CHANGELOG.md
+++ b/packages/zaino-state/CHANGELOG.md
@@ -50,6 +50,27 @@ and this library adheres to Rust's notion of
   `transactions`, `txouts`, `total_amount`, `height` and `bestblock` agree
   with zcashd's RPC; `bytes_serialized` and `hash_serialized` follow Zaino's
   own deterministic spec.
+- Finalised-state catch-up sync now ingests via `DbWrite::write_blocks_to_height`
+  (the tip->height fetch/build/write loop moved into the backend) and writes the
+  random-keyed `spent` / `txid_location` indexes in **sorted batches** within a
+  single transaction — a sequential B-tree sweep instead of a random fault per
+  insert once the DB exceeds RAM. The v1.1.0 -> v1.2.0 migration's `spent`
+  backfill does the same. Batches are bounded by
+  `storage.database.sync_write_batch_bytes` (default 4 GiB), a block-count cap,
+  and a time cap; each batch commits and fsyncs atomically, so sync and migration
+  stay crash-safe and resume gap-free.
+- The finalised txout-set accumulator is no longer maintained per block during
+  bulk sync or migration. It is deferred and rebuilt once at the tip via
+  sequential table scans (`DbV1::rebuild_tx_out_set_accumulator`), removing an
+  unbounded fan-out of random `spent` reads per block that stalled sync around
+  sandblast height. Single-block appends (`write_block`) still maintain it
+  incrementally; a `_tx_out_set_accumulator_built_height` watermark tracks
+  freshness.
+- Block validation moved off the write hot path: `write_block` now performs cheap
+  in-memory parent-hash continuity and merkle-root checks and advances
+  `validated_tip` directly, instead of a post-commit read-back. The full
+  `validate_block_blocking` re-read runs at startup only (the integrity gate for
+  untrusted on-disk data).
 ### Deprecated
 ### Removed
 ### Fixed
@@ -58,8 +79,14 @@ and this library adheres to Rust's notion of
   instead of a full scan of the `txids` table. This fixes a near-quadratic
   slowdown that made the v1.1.0 -> v1.2.0 migration appear to hang on large
   caches and progressively slowed clean sync. The migration is now a re-entrant
-  two-stage backfill (build `txid_location`, then `spent` + accumulator) with
-  per-stage progress trackers and progress logging.
+  **three-stage** backfill (build `txid_location`, then `spent`, then a bulk
+  txout-set accumulator rebuild) with per-stage progress trackers and progress
+  logging. Stage C never trusts an existing accumulator, so a partially-run
+  original migration is recomputed correctly rather than corrupted.
+- Finalised-state startup validation now scans blocks in ascending height order
+  (previously block-hash order via the `heights` table), so `validated_tip`
+  advances monotonically, gaps surface immediately, and startup no longer
+  thrashes the page cache with random-access reads.
 - Finalised-state DB v1.2.0: caches built by 0.4.0-alpha.1 (recorded at v1.2.0
   with an unbuilt `txid_location` index) are detected on open and self-heal by
   rolling back to v1.1.0 and rebuilding the indices in place (temporary shim,

--- a/packages/zaino-state/CHANGELOG.md
+++ b/packages/zaino-state/CHANGELOG.md
@@ -60,12 +60,16 @@ and this library adheres to Rust's notion of
   and a time cap; each batch commits and fsyncs atomically, so sync and migration
   stay crash-safe and resume gap-free.
 - The finalised txout-set accumulator is no longer maintained per block during
-  bulk sync or migration. It is deferred and rebuilt once at the tip via
-  sequential table scans (`DbV1::rebuild_tx_out_set_accumulator`), removing an
-  unbounded fan-out of random `spent` reads per block that stalled sync around
-  sandblast height. Single-block appends (`write_block`) still maintain it
-  incrementally; a `_tx_out_set_accumulator_built_height` watermark tracks
-  freshness.
+  bulk sync or migration. It is deferred and brought up to the tip after a
+  catch-up run: the first build (or an unusually large gap) does a full
+  sequential-scan rebuild (`DbV1::rebuild_tx_out_set_accumulator`), while a
+  steady-state catch-up applies just the delta for the newly-written range
+  (`DbV1::update_tx_out_set_accumulator_for_range`) — O(range) work that yields
+  the identical accumulator. This removes an unbounded fan-out of random `spent`
+  reads per block that stalled sync around sandblast height. Single-block appends
+  (`write_block`) still maintain it incrementally; a
+  `_tx_out_set_accumulator_built_height` watermark tracks freshness and selects
+  the rebuild-vs-incremental path.
 - Block validation moved off the write hot path: `write_block` now performs cheap
   in-memory parent-hash continuity and merkle-root checks and advances
   `validated_tip` directly, instead of a post-commit read-back. The full
@@ -74,6 +78,13 @@ and this library adheres to Rust's notion of
 ### Deprecated
 ### Removed
 ### Fixed
+- Finalised-state catch-up no longer rebuilds the txout-set accumulator from
+  genesis on every poll. Because `write_blocks_to_height` rebuilt it
+  unconditionally at the end of each run, every newly-finalised block triggered a
+  full-chain scan (~45 min on mainnet once the DB exceeds RAM), so the node could
+  never reach the tip and stayed stuck "Syncing". The accumulator is now advanced
+  incrementally over just the written range in steady state, falling back to the
+  full rebuild only for the first build or a large gap.
 - Finalised-state DB v1.2.0: added a reverse transaction-id index
   (`txid_location`) so previous-output resolution is an O(log n) point lookup
   instead of a full scan of the `txids` table. This fixes a near-quadratic

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -186,9 +186,7 @@ use tracing::{info, instrument};
 use zebra_chain::parameters::NetworkKind;
 
 use crate::{
-    chain_index::{
-        finalised_state::db::v1::DB_VERSION_V1, source::BlockchainSourceError,
-    },
+    chain_index::{finalised_state::db::v1::DB_VERSION_V1, source::BlockchainSourceError},
     config::BlockCacheConfig,
     error::FinalisedStateError,
     BlockHash, BlockMetadata, BlockWithMetadata, ChainWork, Height, IndexedBlock, StatusType,
@@ -232,8 +230,8 @@ pub(crate) async fn build_indexed_block_from_source<S: BlockchainSource>(
     // Fetch sapling / orchard commitment tree data if above the relevant network upgrade.
     let (sapling_opt, orchard_opt) = source.get_commitment_tree_roots(block_hash).await?;
     let is_sapling_active = height_int >= sapling_activation_height.0;
-    let is_orchard_active =
-        nu5_activation_height.is_some_and(|nu5_activation_height| height_int >= nu5_activation_height.0);
+    let is_orchard_active = nu5_activation_height
+        .is_some_and(|nu5_activation_height| height_int >= nu5_activation_height.0);
 
     let (sapling_root, sapling_size) = if is_sapling_active {
         sapling_opt.ok_or_else(|| {

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -662,6 +662,18 @@ impl ZainoDB {
         // Await the reporter to ensure clean shutdown; ignore errors if it panicked/was aborted.
         let _ = reporter_handle.await;
 
+        // The env is opened with `NO_SYNC`, so the blocks written above are committed but may not
+        // be on disk yet. Force a durability checkpoint at the end of a completed batch: a
+        // `sync_to_height` that returns `Ok` is then guaranteed durable, so a later crash can only
+        // roll back to this height, never lose a range already reported as synced. On the error
+        // path the partial progress stays committed and is flushed by the next checkpoint /
+        // shutdown, so we leave the original error unmasked.
+        if result.is_ok() {
+            let env = self.db.backend(CapabilityRequest::WriteCore)?.env();
+            tokio::task::block_in_place(|| env.sync(true))
+                .map_err(FinalisedStateError::LmdbError)?;
+        }
+
         result
     }
 

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -188,24 +188,92 @@ use zebra_chain::parameters::NetworkKind;
 use crate::{
     chain_index::{
         finalised_state::db::v1::DB_VERSION_V1, source::BlockchainSourceError,
-        types::GENESIS_HEIGHT,
     },
     config::BlockCacheConfig,
     error::FinalisedStateError,
     BlockHash, BlockMetadata, BlockWithMetadata, ChainWork, Height, IndexedBlock, StatusType,
 };
 
-use std::{
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 use tokio::{
     sync::watch,
     time::{interval, MissedTickBehavior},
 };
+
+/// Fetches the block at `height_int` from `source` and builds its [`IndexedBlock`], threading
+/// `parent_chainwork` into the block metadata.
+///
+/// Shared by every backend's [`capability::DbWrite::write_blocks_to_height`] ingestion loop so the
+/// fetch + commitment-tree-root + metadata assembly lives in one place regardless of which backend
+/// owns the loop.
+pub(crate) async fn build_indexed_block_from_source<S: BlockchainSource>(
+    source: &S,
+    network: zaino_common::Network,
+    sapling_activation_height: zebra_chain::block::Height,
+    nu5_activation_height: Option<zebra_chain::block::Height>,
+    height_int: u32,
+    parent_chainwork: ChainWork,
+) -> Result<IndexedBlock, FinalisedStateError> {
+    let block = match source
+        .get_block(zebra_state::HashOrHeight::Height(
+            zebra_chain::block::Height(height_int),
+        ))
+        .await?
+    {
+        Some(block) => block,
+        None => {
+            return Err(FinalisedStateError::BlockchainSourceError(
+                BlockchainSourceError::Unrecoverable(format!(
+                    "error fetching block at height {height_int} from validator"
+                )),
+            ));
+        }
+    };
+
+    let block_hash = BlockHash::from(block.hash().0);
+
+    // Fetch sapling / orchard commitment tree data if above the relevant network upgrade.
+    let (sapling_opt, orchard_opt) = source.get_commitment_tree_roots(block_hash).await?;
+    let is_sapling_active = height_int >= sapling_activation_height.0;
+    let is_orchard_active =
+        nu5_activation_height.is_some_and(|nu5_activation_height| height_int >= nu5_activation_height.0);
+
+    let (sapling_root, sapling_size) = if is_sapling_active {
+        sapling_opt.ok_or_else(|| {
+            FinalisedStateError::BlockchainSourceError(BlockchainSourceError::Unrecoverable(
+                format!("missing Sapling commitment tree root for block {block_hash}"),
+            ))
+        })?
+    } else {
+        (zebra_chain::sapling::tree::Root::default(), 0)
+    };
+
+    let (orchard_root, orchard_size) = if is_orchard_active {
+        orchard_opt.ok_or_else(|| {
+            FinalisedStateError::BlockchainSourceError(BlockchainSourceError::Unrecoverable(
+                format!("missing Orchard commitment tree root for block {block_hash}"),
+            ))
+        })?
+    } else {
+        (zebra_chain::orchard::tree::Root::default(), 0)
+    };
+
+    let metadata = BlockMetadata::new(
+        sapling_root,
+        sapling_size as u32,
+        orchard_root,
+        orchard_size as u32,
+        parent_chainwork,
+        network.to_zebra_network(),
+    );
+
+    let block_with_metadata = BlockWithMetadata::new(block.as_ref(), metadata);
+    IndexedBlock::try_from(block_with_metadata).map_err(|_| {
+        FinalisedStateError::BlockchainSourceError(BlockchainSourceError::Unrecoverable(format!(
+            "error building block data at height {height_int}"
+        )))
+    })
+}
 
 use super::source::BlockchainSource;
 
@@ -510,151 +578,40 @@ impl ZainoDB {
         T: BlockchainSource,
     {
         let network = self.cfg.network;
-        let db_height_opt = self.db_height().await?;
-        let mut db_height = db_height_opt.unwrap_or(GENESIS_HEIGHT);
-
-        let zebra_network = network.to_zebra_network();
-        let sapling_activation_height = zebra_chain::parameters::NetworkUpgrade::Sapling
-            .activation_height(&zebra_network)
-            .expect("Sapling activation height must be set");
-        let nu5_activation_height =
-            zebra_chain::parameters::NetworkUpgrade::Nu5.activation_height(&zebra_network);
-
-        let mut parent_chainwork = if db_height_opt.is_none() {
-            ChainWork::from_u256(0.into())
-        } else {
-            db_height.0 += 1;
-            match self
-                .db
-                .backend(CapabilityRequest::BlockCoreExt)?
-                .get_block_header(height)
-                .await
-            {
-                Ok(header) => header.context.chainwork,
-                // V0 does not hold or use chainwork, and does not serve header data,
-                // can we handle this better?
-                //
-                // can we get this data from zebra blocks?
-                Err(_) => ChainWork::from_u256(0.into()),
-            }
-        };
-
-        // Track last time we emitted an info log so we only print every 10s.
-        let current_height = Arc::new(AtomicU64::new(db_height.0 as u64));
-        let target_height = height.0 as u64;
+        let target_height = height.0;
 
         // Shutdown signal for the reporter task.
-        let (shutdown_tx, shutdown_rx) = watch::channel(());
-        // Spawn reporter task that logs every 10 seconds, even while write_block() is running.
-        let reporter_current = Arc::clone(&current_height);
-        let reporter_network = network;
-        let mut reporter_shutdown = shutdown_rx.clone();
+        let (shutdown_tx, mut shutdown_rx) = watch::channel(());
+        // Spawn a reporter that logs sync progress every 10s by polling the db tip, while the
+        // backend owns the ingestion loop below.
+        let reporter_db = Arc::clone(&self.db);
         let reporter_handle = tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(10));
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
-                        let cur = reporter_current.load(Ordering::Relaxed);
+                        let current = reporter_db
+                            .db_height()
+                            .await
+                            .ok()
+                            .flatten()
+                            .map_or(0, |height| height.0);
                         tracing::info!(
-                            "sync_to_height: syncing height {current} / {target} on network = {:?}",
-                            reporter_network,
-                            current = cur,
-                            target = target_height
+                            "sync_to_height: syncing height {current} / {target_height} on network = {:?}",
+                            network,
                         );
                     }
                     // stop when we receive a shutdown signal
-                    _ = reporter_shutdown.changed() => {
+                    _ = shutdown_rx.changed() => {
                         break;
                     }
                 }
             }
         });
 
-        // Run the main sync logic inside an inner async block so we always get
-        // a chance to shutdown the reporter task regardless of how this block exits.
-        let result: Result<(), FinalisedStateError> = (async {
-            for height_int in (db_height.0)..=height.0 {
-                // Update the shared progress value as soon as we start processing this height.
-                current_height.store(height_int as u64, Ordering::Relaxed);
-
-                let block = match source
-                    .get_block(zebra_state::HashOrHeight::Height(
-                        zebra_chain::block::Height(height_int),
-                    ))
-                    .await?
-                {
-                    Some(block) => block,
-                    None => {
-                        return Err(FinalisedStateError::BlockchainSourceError(
-                            BlockchainSourceError::Unrecoverable(format!(
-                                "error fetching block at height {} from validator",
-                                height.0
-                            )),
-                        ));
-                    }
-                };
-
-                let block_hash = BlockHash::from(block.hash().0);
-
-                // Fetch sapling / orchard commitment tree data if above relevant network upgrade.
-                let (sapling_opt, orchard_opt) =
-                    source.get_commitment_tree_roots(block_hash).await?;
-                let is_sapling_active = height_int >= sapling_activation_height.0;
-                let is_orchard_active = nu5_activation_height
-                    .is_some_and(|nu5_activation_height| height_int >= nu5_activation_height.0);
-                let (sapling_root, sapling_size) = if is_sapling_active {
-                    sapling_opt.ok_or_else(|| {
-                        FinalisedStateError::BlockchainSourceError(
-                            BlockchainSourceError::Unrecoverable(format!(
-                                "missing Sapling commitment tree root for block {block_hash}"
-                            )),
-                        )
-                    })?
-                } else {
-                    (zebra_chain::sapling::tree::Root::default(), 0)
-                };
-
-                let (orchard_root, orchard_size) = if is_orchard_active {
-                    orchard_opt.ok_or_else(|| {
-                        FinalisedStateError::BlockchainSourceError(
-                            BlockchainSourceError::Unrecoverable(format!(
-                                "missing Orchard commitment tree root for block {block_hash}"
-                            )),
-                        )
-                    })?
-                } else {
-                    (zebra_chain::orchard::tree::Root::default(), 0)
-                };
-
-                let metadata = BlockMetadata::new(
-                    sapling_root,
-                    sapling_size as u32,
-                    orchard_root,
-                    orchard_size as u32,
-                    parent_chainwork,
-                    network.to_zebra_network(),
-                );
-
-                let block_with_metadata = BlockWithMetadata::new(block.as_ref(), metadata);
-                let chain_block = match IndexedBlock::try_from(block_with_metadata) {
-                    Ok(block) => block,
-                    Err(_) => {
-                        return Err(FinalisedStateError::BlockchainSourceError(
-                            BlockchainSourceError::Unrecoverable(format!(
-                                "error building block data at height {}",
-                                height.0
-                            )),
-                        ));
-                    }
-                };
-                parent_chainwork = chain_block.context.chainwork;
-
-                self.write_block(chain_block).await?;
-            }
-
-            Ok(())
-        })
-        .await;
+        // Backends own the ingestion loop (fetch → build → write) so they can batch and defer
+        // secondary-index maintenance; see `DbWrite::write_blocks_to_height`.
+        let result = self.db.write_blocks_to_height(height, source).await;
 
         // Signal the reporter to shut down and wait for it to finish.
         // Ignore send error if receiver already dropped.
@@ -896,7 +853,7 @@ impl ZainoDB {
 
         let mut parent_chainwork = ChainWork::from_u256(0.into());
 
-        for height in GENESIS_HEIGHT.0..=tip.0 {
+        for height in crate::chain_index::types::GENESIS_HEIGHT.0..=tip.0 {
             let block = source
                 .get_block(zebra_state::HashOrHeight::Height(
                     zebra_chain::block::Height(height),

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -195,10 +195,7 @@ use crate::{
 };
 
 use std::{sync::Arc, time::Duration};
-use tokio::{
-    sync::watch,
-    time::{interval, MissedTickBehavior},
-};
+use tokio::time::{interval, MissedTickBehavior};
 
 /// Fetches the block at `height_int` from `source` and builds its [`IndexedBlock`], threading
 /// `parent_chainwork` into the block metadata.
@@ -577,47 +574,12 @@ impl ZainoDB {
     where
         T: BlockchainSource,
     {
-        let network = self.cfg.network;
-        let target_height = height.0;
-
-        // Shutdown signal for the reporter task.
-        let (shutdown_tx, mut shutdown_rx) = watch::channel(());
-        // Spawn a reporter that logs sync progress every 10s by polling the db tip, while the
-        // backend owns the ingestion loop below.
-        let reporter_db = Arc::clone(&self.db);
-        let reporter_handle = tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(10));
-            loop {
-                tokio::select! {
-                    _ = interval.tick() => {
-                        let current = reporter_db
-                            .db_height()
-                            .await
-                            .ok()
-                            .flatten()
-                            .map_or(0, |height| height.0);
-                        tracing::info!(
-                            "sync_to_height: syncing height {current} / {target_height} on network = {:?}",
-                            network,
-                        );
-                    }
-                    // stop when we receive a shutdown signal
-                    _ = shutdown_rx.changed() => {
-                        break;
-                    }
-                }
-            }
-        });
-
         // Backends own the ingestion loop (fetch → build → write) so they can batch and defer
-        // secondary-index maintenance; see `DbWrite::write_blocks_to_height`.
+        // secondary-index maintenance; see `DbWrite::write_blocks_to_height`. Progress is logged
+        // from within that loop (in-flight height + per-batch commit), so there is no separate
+        // reporter task here — the previous one polled the *committed* db tip, which sits at 0 while
+        // the first batch is still being buffered and read as a stall.
         let result = self.db.write_blocks_to_height(height, source).await;
-
-        // Signal the reporter to shut down and wait for it to finish.
-        // Ignore send error if receiver already dropped.
-        let _ = shutdown_tx.send(());
-        // Await the reporter to ensure clean shutdown; ignore errors if it panicked/was aborted.
-        let _ = reporter_handle.await;
 
         // The env is opened with `NO_SYNC`, so the blocks written above are committed but may not
         // be on disk yet. Force a durability checkpoint at the end of a completed batch: a

--- a/packages/zaino-state/src/chain_index/finalised_state/CHANGELOG.md
+++ b/packages/zaino-state/src/chain_index/finalised_state/CHANGELOG.md
@@ -185,9 +185,14 @@ Summary
   scan of the height-keyed `txids` table. This fixes a near-quadratic slowdown
   in both the migration backfill and clean-sync write path.
 - Backfill the new structures from existing per-block transparent transaction
-  data via a single in-place, two-stage migration.
+  data via a single in-place, three-stage migration (`txid_location`, then
+  `spent`, then a bulk txout-set accumulator rebuild).
 - Add resumable in-place migration progress tracking using temporary metadata
-  entries (one per stage).
+  entries (one per backfill stage).
+- The random-keyed `spent` / `txid_location` indexes are written in sorted
+  batches (sequential B-tree sweep instead of a random fault per insert once the
+  DB exceeds RAM), and the txout-set accumulator is rebuilt in bulk from the
+  finalised tables rather than maintained per block.
 
 On-disk schema
 - Layout:
@@ -218,6 +223,10 @@ On-disk schema
     - `spent` entries are checksum-protected using the encoded `Outpoint` key.
     - `txid_location` entries are checksum-protected using the txid key.
     - The accumulator entry is checksum-protected using its singleton key.
+    - The height the accumulator was last fully built to is recorded in the
+      metadata DB under `_tx_out_set_accumulator_built_height` as
+      `StoredEntryFixed<Height>` — a freshness watermark letting readers detect
+      a stale accumulator after a sync was interrupted before its bulk rebuild.
     - Migration progress is temporarily stored as `StoredEntryFixed<Height>` in
       the metadata DB under `_migration_spent_progress_1_2_0_next_height`
       (Stage B) and `_migration_txid_location_progress_1_2_0_next_height`
@@ -258,19 +267,24 @@ API / capabilities
     - Existing spent/outpoint-spender functionality can be backed by the core `spent` table.
 
 Migration
-- Strategy: in-place index backfill, run as two sequential stages with
-  independent progress trackers (single migration step, re-entrant).
+- Strategy: in-place index backfill, run as three sequential stages
+  (single migration step, re-entrant).
 - Backfill:
   - Stage A (`txid_location`): scans the existing `txids` table from genesis
     through the current finalised DB tip and writes
-    `txid -> StoredEntryFixed<TxLocation>`. Runs first because Stage B's
-    previous-output resolution depends on it.
-  - Stage B (`spent` + accumulator): iterates existing transparent block data;
-    for each non-null transparent input writes
-    `Outpoint -> StoredEntryFixed<TxLocation>` to `spent`, and for each block
-    advances the singleton `tx_out_set_info_accumulator` via the same calculator
-    used by the write path (`calculate_tx_out_set_info_accumulator_after_block`),
-    skipping NonStandard outputs.
+    `txid -> StoredEntryFixed<TxLocation>`.
+  - Stage B (`spent`): iterates existing transparent block data and writes
+    `Outpoint -> StoredEntryFixed<TxLocation>` for each non-null transparent
+    input. Entries are buffered and inserted in sorted key order in batches
+    (bounded by `storage.database.sync_write_batch_bytes`); each batch commits
+    its `spent` entries together with the Stage B progress watermark in one
+    transaction.
+  - Stage C (`tx_out_set_info_accumulator`): rebuilds the accumulator in bulk
+    from the finalised `transparent` + `spent` tables via sequential scans
+    (skipping NonStandard outputs) and overwrites the singleton. It never trusts
+    an existing accumulator — so a partially-run prior (2-stage) migration is
+    recomputed correctly rather than corrupted — and is idempotent / re-runnable,
+    so it needs no per-height progress key.
 - 0.4.0-alpha.1 compatibility (temporary):
   - A cache built by 0.4.0-alpha.1 is recorded at v1.2.0 but has an empty
     `txid_location` index. On open, a non-empty database at version >= 1.2.0
@@ -284,8 +298,14 @@ Migration
   - Both temporary migration progress keys are deleted.
   - `DbMetadata.version` is advanced to v1.2.0 and `migration_status` is reset to `Empty`.
 - Failure handling:
-  - Each stage resumes from its own temporary metadata progress height.
-  - Per height, `spent` entries, the accumulator, and the progress update are committed in the same LMDB transaction; `txid_location` entries and their progress update likewise.
+  - Stages A and B resume from their own temporary metadata progress heights.
+  - `spent` entries and the Stage B progress watermark commit together per batch;
+    `txid_location` entries and their Stage A progress likewise. The watermark is
+    never advanced past committed data, so a crash resumes from the last committed
+    batch (re-doing only uncommitted heights).
+  - Stage C is a separate idempotent bulk rebuild, so on resume the accumulator
+    is recomputed from the (already-built) finalised tables rather than tracked
+    per height.
   - Existing matching `spent` / `txid_location` entries are accepted after checksum and `TxLocation` verification.
   - Existing conflicting or corrupt entries fail the migration.
 
@@ -300,6 +320,20 @@ Bug Fixes / Optimisations
 - `write_block` no longer issues two redundant `env.sync(true)` calls around
   per-block validation; the durable `txn.commit()` already fsyncs, so crash
   safety is unchanged.
+- The txout-set accumulator is no longer maintained per block during bulk sync /
+  migration: it is deferred and rebuilt once at the tip, removing an unbounded
+  fan-out of random `spent` reads per block that stalled sync around sandblast
+  height. Single-block appends still maintain it incrementally.
+- Block validation is off the write hot path: writes do cheap in-memory
+  parent-hash + merkle-root checks and advance `validated_tip` directly; the full
+  read-back validation runs only at startup.
+- Startup validation scans in ascending height order (was block-hash order via
+  `heights`), so `validated_tip` advances monotonically and startup avoids
+  random-access cache thrash.
+- The random-keyed `spent` / `txid_location` writes (clean sync and migration)
+  are batched and inserted in sorted key order, turning per-insert random B-tree
+  faults into a sequential sweep once the DB exceeds RAM. Tunable via
+  `storage.database.sync_write_batch_bytes` (default 4 GiB).
 
 Bug Fixes / Optimisations
 - Avoids a shadow rebuild by deriving the new core `spent` index from existing transparent transaction data.

--- a/packages/zaino-state/src/chain_index/finalised_state/capability.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/capability.rs
@@ -697,6 +697,20 @@ pub trait DbWrite: Send + Sync {
     /// Invariant: `block` must be the next height after the current tip (no gaps, no rewrites).
     async fn write_block(&self, block: IndexedBlock) -> Result<(), FinalisedStateError>;
 
+    /// Ingests blocks from `source`, writing every height from the current tip up to and including
+    /// `height` in order.
+    ///
+    /// This is the bulk catch-up path. Implementations own the ingestion loop so they can choose an
+    /// efficient strategy: the v1 backend defers expensive secondary-index maintenance (the
+    /// txout-set accumulator) across the run and rebuilds it once at the tip, whereas legacy
+    /// backends may simply loop [`DbWrite::write_block`]. A no-op is valid when the tip already
+    /// meets or exceeds `height`.
+    async fn write_blocks_to_height<S: crate::chain_index::source::BlockchainSource>(
+        &self,
+        height: Height,
+        source: &S,
+    ) -> Result<(), FinalisedStateError>;
+
     /// Deletes the tip block identified by `height` from every finalised table.
     ///
     /// Invariant: `height` must be the current database tip height.

--- a/packages/zaino-state/src/chain_index/finalised_state/db.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db.rs
@@ -339,6 +339,22 @@ impl DbBackend {
             )),
         }
     }
+
+    /// Bulk-rebuilds the finalised txout-set accumulator to the current tip and persists it (V1
+    /// only).
+    ///
+    /// Recomputes the accumulator from the finalised `transparent` + `spent` tables via sequential
+    /// scans and writes the singleton plus its freshness watermark. Replaces the per-block
+    /// accumulator maintenance that dominated sync time at sandblast height; used by
+    /// `sync_to_height` after a catch-up run and by the v1.2 migration's accumulator stage.
+    pub(crate) async fn rebuild_tx_out_set_accumulator(&self) -> Result<(), FinalisedStateError> {
+        match self {
+            Self::V1(database) => database.rebuild_tx_out_set_accumulator().await,
+            Self::V0(_) => Err(FinalisedStateError::FeatureUnavailable(
+                "v1 txout-set accumulator builder",
+            )),
+        }
+    }
 }
 
 impl From<DbV0> for DbBackend {
@@ -832,6 +848,23 @@ impl DbBackend {
     /// through the current startup / migration path.
     pub(crate) async fn spawn_v1_0_0(cfg: &BlockCacheConfig) -> Result<Self, FinalisedStateError> {
         Ok(Self::V1(DbV1::spawn_v1_0_0(cfg).await?))
+    }
+
+    /// Computes (without persisting) the bulk-built txout-set accumulator to `db_tip` (V1 only).
+    ///
+    /// Test hook for asserting the sequential bulk builder matches the incrementally-maintained
+    /// accumulator across shard counts.
+    pub(crate) fn build_tx_out_set_accumulator_blocking(
+        &self,
+        db_tip: Height,
+        shards: u16,
+    ) -> Result<FinalisedTxOutSetInfoAccumulator, FinalisedStateError> {
+        match self {
+            Self::V1(database) => database.build_tx_out_set_accumulator_blocking(db_tip, shards),
+            Self::V0(_) => Err(FinalisedStateError::FeatureUnavailable(
+                "v1 txout-set accumulator builder",
+            )),
+        }
     }
 
     /// Writes a block using the v1.0.0 format.

--- a/packages/zaino-state/src/chain_index/finalised_state/db.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db.rs
@@ -862,6 +862,14 @@ impl DbBackend {
         Ok(Self::V1(DbV1::spawn_v1_0_0(cfg).await?))
     }
 
+    /// Current contiguous validated-tip height (v1 only; 0 for v0). Test hook.
+    pub(crate) fn validated_tip_height(&self) -> u32 {
+        match self {
+            Self::V1(db) => db.validated_tip_height(),
+            Self::V0(_) => 0,
+        }
+    }
+
     /// Computes (without persisting) the bulk-built txout-set accumulator to `db_tip` (V1 only).
     ///
     /// Test hook for asserting the sequential bulk builder matches the incrementally-maintained

--- a/packages/zaino-state/src/chain_index/finalised_state/db.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db.rs
@@ -456,6 +456,18 @@ impl DbWrite for DbBackend {
         }
     }
 
+    /// Bulk catch-up ingestion, delegated to the concrete backend's strategy.
+    async fn write_blocks_to_height<S: crate::chain_index::source::BlockchainSource>(
+        &self,
+        height: Height,
+        source: &S,
+    ) -> Result<(), FinalisedStateError> {
+        match self {
+            Self::V0(db) => db.write_blocks_to_height(height, source).await,
+            Self::V1(db) => db.write_blocks_to_height(height, source).await,
+        }
+    }
+
     /// Delete the block at a given height, if present.
     ///
     /// This is a thin delegation wrapper over the concrete implementation.

--- a/packages/zaino-state/src/chain_index/finalised_state/db.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db.rs
@@ -870,6 +870,21 @@ impl DbBackend {
         }
     }
 
+    /// Reads the height the persisted txout-set accumulator currently reflects (V1 only).
+    ///
+    /// `None` means it has never been built. Test hook for asserting the incremental range-update
+    /// path advances the watermark (and is therefore taken, rather than a silent rebuild fallback).
+    pub(crate) async fn read_tx_out_set_accumulator_built_height(
+        &self,
+    ) -> Result<Option<Height>, FinalisedStateError> {
+        match self {
+            Self::V1(database) => database.read_tx_out_set_accumulator_built_height().await,
+            Self::V0(_) => Err(FinalisedStateError::FeatureUnavailable(
+                "v1 txout-set accumulator builder",
+            )),
+        }
+    }
+
     /// Computes (without persisting) the bulk-built txout-set accumulator to `db_tip` (V1 only).
     ///
     /// Test hook for asserting the sequential bulk builder matches the incrementally-maintained

--- a/packages/zaino-state/src/chain_index/finalised_state/db.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db.rs
@@ -321,6 +321,15 @@ impl DbBackend {
         }
     }
 
+    /// Provides access to the transparent DB table, required for Migration1_1_0To1_2_0 Stage B to
+    /// read block transparent data directly (bypassing per-height block re-validation).
+    pub(crate) fn transparent_db(&self) -> Result<Database, FinalisedStateError> {
+        match self {
+            Self::V1(db) => Ok(db.transparent_db()),
+            Self::V0(_) => Err(FinalisedStateError::FeatureUnavailable("v1 transparent db")),
+        }
+    }
+
     /// Provides access to the finalised txout-set accumulator DB table.
     pub(crate) fn tx_out_set_info_accumulator_db(&self) -> Result<Database, FinalisedStateError> {
         match self {

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v0.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v0.rs
@@ -144,6 +144,49 @@ impl DbWrite for DbV0 {
         self.write_block(block).await
     }
 
+    /// Bulk catch-up for the legacy backend: simply loops [`DbWrite::write_block`] over
+    /// `tip+1..=height`. v0 maintains no txout-set accumulator and does not serve chainwork, so the
+    /// chainwork seed is zero (matching the prior `sync_to_height` behaviour). This code path is
+    /// retired with the v0 backend.
+    async fn write_blocks_to_height<S: crate::chain_index::source::BlockchainSource>(
+        &self,
+        height: crate::Height,
+        source: &S,
+    ) -> Result<(), FinalisedStateError> {
+        use crate::chain_index::finalised_state::build_indexed_block_from_source;
+        use zebra_chain::parameters::NetworkUpgrade;
+
+        let network = self.config.network;
+        let zebra_network = network.to_zebra_network();
+        let sapling_activation_height = NetworkUpgrade::Sapling
+            .activation_height(&zebra_network)
+            .expect("Sapling activation height must be set");
+        let nu5_activation_height = NetworkUpgrade::Nu5.activation_height(&zebra_network);
+
+        let start_height = match self.tip_height().await? {
+            None => crate::chain_index::types::GENESIS_HEIGHT.0,
+            Some(tip) => tip.0 + 1,
+        };
+        let mut parent_chainwork = crate::ChainWork::from_u256(0.into());
+
+        for height_int in start_height..=height.0 {
+            let block = build_indexed_block_from_source(
+                source,
+                network,
+                sapling_activation_height,
+                nu5_activation_height,
+                height_int,
+                parent_chainwork,
+            )
+            .await?;
+            parent_chainwork = block.context.chainwork;
+
+            self.write_block(block).await?;
+        }
+
+        Ok(())
+    }
+
     /// Deletes a block at the given height, enforcing that it is the current tip.
     async fn delete_block_at_height(
         &self,

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -676,7 +676,16 @@ impl DbV1 {
         .map_err(|e| FinalisedStateError::Custom(format!("spawn_blocking failed: {e}")))?
     }
 
-    /// Scans the whole finalised chain once at start-up and validates every block by checksum and continuity.
+    /// Scans the whole finalised chain once at start-up and validates every block by checksum and
+    /// continuity.
+    ///
+    /// Iterates the height-keyed `headers` table, which LMDB orders by big-endian height — i.e. in
+    /// **ascending block-height order**. This lets `validated_tip` advance monotonically as each
+    /// height is validated (every height is `validated_tip + 1` in turn), and surfaces any gap
+    /// immediately (the parent-hash continuity check in `validate_block_blocking` fails at the first
+    /// missing height). The previous implementation iterated the hash-keyed `heights` table, which
+    /// validated in pseudo-random height order — thrashing the cache and preventing the tip from
+    /// advancing until the whole set had been validated.
     async fn initial_block_scan(&self) -> Result<(), FinalisedStateError> {
         let zaino_db = Self {
             env: Arc::clone(&self.env),
@@ -703,13 +712,17 @@ impl DbV1 {
 
         tokio::task::spawn_blocking(move || {
             let ro = zaino_db.env.begin_ro_txn()?;
-            let mut cursor = ro.open_ro_cursor(zaino_db.heights)?;
+            let mut cursor = ro.open_ro_cursor(zaino_db.headers)?;
 
-            for (hash_bytes, height_entry_bytes) in cursor.iter() {
-                let hash = BlockHash::from_bytes(hash_bytes)?;
-                let height = *StoredEntryFixed::<Height>::from_bytes(height_entry_bytes)
-                    .map_err(|e| FinalisedStateError::Custom(format!("corrupt height entry: {e}")))?
-                    .inner();
+            // `headers` is keyed by big-endian height, so the cursor yields blocks in ascending
+            // height order. Both the height and hash are read from the header entry itself.
+            for (height_bytes, header_entry_bytes) in cursor.iter() {
+                let height = Height::from_bytes(height_bytes)?;
+                let header_entry = StoredEntryVar::<BlockHeaderData>::from_bytes(header_entry_bytes)
+                    .map_err(|e| {
+                        FinalisedStateError::Custom(format!("corrupt header entry: {e}"))
+                    })?;
+                let hash = *header_entry.inner().context.hash();
 
                 zaino_db.validate_block_blocking(height, hash)?
             }

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -143,6 +143,26 @@ pub(crate) const TX_OUT_SET_INFO_ACCUMULATOR_DATABASE_NAME: &str =
 /// Singleton key for the finalised txout-set accumulator table.
 pub(crate) const TX_OUT_SET_INFO_ACCUMULATOR_KEY: &[u8] = b"tx_out_set_info_accumulator";
 
+/// Metadata key recording the height the finalised txout-set accumulator was last *fully* built to.
+///
+/// Stored in the `metadata` table as `StoredEntryFixed<Height>`. The accumulator is no longer
+/// maintained per block on the sync write path; it is rebuilt in bulk (see
+/// [`DbV1::rebuild_tx_out_set_accumulator`]) once a sync run reaches the tip. This watermark lets
+/// readers detect a *stale* accumulator (watermark `<` db tip) after a sync was interrupted before
+/// the rebuild ran, rather than serving incorrect `gettxoutsetinfo` data.
+pub(crate) const TX_OUT_SET_ACCUMULATOR_BUILT_HEIGHT_KEY: &[u8] =
+    b"_tx_out_set_accumulator_built_height";
+
+/// Number of txid-prefix shards used by the bulk txout-set accumulator builder.
+///
+/// The builder holds the set of spent outpoints in memory while scanning the block data. Sharding
+/// on the creating-txid's first byte bounds that working set to roughly `1 / shards` of the total
+/// spent index, at the cost of one extra sequential pass over the block data per shard. The
+/// per-shard partials recombine exactly (XOR commitment + additive counters), so the result is
+/// independent of the shard count. `1` is a single optimal pass and is correct on any host with
+/// enough RAM for the full spent set; raise it on memory-constrained deployments.
+pub(crate) const ACCUMULATOR_BUILD_SHARDS: u16 = 1;
+
 /// Number of committed block writes / migration heights between explicit
 /// `env.sync(true)` durability checkpoints.
 ///

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -143,15 +143,30 @@ pub(crate) const TX_OUT_SET_INFO_ACCUMULATOR_DATABASE_NAME: &str =
 /// Singleton key for the finalised txout-set accumulator table.
 pub(crate) const TX_OUT_SET_INFO_ACCUMULATOR_KEY: &[u8] = b"tx_out_set_info_accumulator";
 
-/// Metadata key recording the height the finalised txout-set accumulator was last *fully* built to.
+/// Metadata key recording the height the finalised txout-set accumulator currently reflects.
 ///
-/// Stored in the `metadata` table as `StoredEntryFixed<Height>`. The accumulator is no longer
-/// maintained per block on the sync write path; it is rebuilt in bulk (see
-/// [`DbV1::rebuild_tx_out_set_accumulator`]) once a sync run reaches the tip. This watermark lets
-/// readers detect a *stale* accumulator (watermark `<` db tip) after a sync was interrupted before
-/// the rebuild ran, rather than serving incorrect `gettxoutsetinfo` data.
+/// Stored in the `metadata` table as `StoredEntryFixed<Height>`. The accumulator is not maintained
+/// per block on the bulk-sync write path. After a catch-up run it is brought up to the tip either by
+/// a full from-genesis rebuild ([`DbV1::rebuild_tx_out_set_accumulator`], used for the first build /
+/// an unusually large gap) or, in steady state, by applying just the delta for the newly-written
+/// range ([`DbV1::update_tx_out_set_accumulator_for_range`]). Both advance this watermark to the new
+/// tip in the same transaction as the accumulator. It lets the dispatch pick the cheap incremental
+/// path and lets readers detect a *stale* accumulator (watermark `<` db tip) after a sync was
+/// interrupted before the accumulator step ran, rather than serving incorrect `gettxoutsetinfo` data.
 pub(crate) const TX_OUT_SET_ACCUMULATOR_BUILT_HEIGHT_KEY: &[u8] =
     b"_tx_out_set_accumulator_built_height";
+
+/// Maximum accumulator staleness (`db_tip - watermark`, in blocks) still updated incrementally.
+///
+/// Below this gap, [`DbV1::write_blocks_to_height`] advances the persisted txout-set accumulator by
+/// applying only the delta for the just-written range — O(range) work, independent of chain length.
+/// At or above it (the first build, or a sync interrupted far behind the on-disk tip) it falls back
+/// to the full from-genesis [`DbV1::rebuild_tx_out_set_accumulator`]. The incremental path does
+/// ~O(range outputs) random `spent`/prev-output lookups (page faults once the DB exceeds RAM), so
+/// this is set conservatively — well under the fixed full-scan cost — while still covering a
+/// multi-hour offline catch-up. It is a performance knob, not a correctness one:
+/// both paths produce the identical accumulator at the tip.
+pub(crate) const ACCUMULATOR_INCREMENTAL_MAX_GAP: u32 = 1_000;
 
 /// Number of txid-prefix shards used by the bulk txout-set accumulator builder.
 ///

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -718,10 +718,10 @@ impl DbV1 {
             // height order. Both the height and hash are read from the header entry itself.
             for (height_bytes, header_entry_bytes) in cursor.iter() {
                 let height = Height::from_bytes(height_bytes)?;
-                let header_entry = StoredEntryVar::<BlockHeaderData>::from_bytes(header_entry_bytes)
-                    .map_err(|e| {
-                        FinalisedStateError::Custom(format!("corrupt header entry: {e}"))
-                    })?;
+                let header_entry = StoredEntryVar::<BlockHeaderData>::from_bytes(
+                    header_entry_bytes,
+                )
+                .map_err(|e| FinalisedStateError::Custom(format!("corrupt header entry: {e}")))?;
                 let hash = *header_entry.inner().context.hash();
 
                 zaino_db.validate_block_blocking(height, hash)?

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -698,6 +698,16 @@ impl DbV1 {
         self.txids
     }
 
+    /// Provides access to the transparent DB table, required for Migration1_1_0To1_2_0 Stage B to
+    /// read stored block transparent data directly. Reading the table raw (rather than via the
+    /// `BlockTransparentExt` accessor) deliberately bypasses `validate_block_blocking`: the
+    /// migration backfills from already-on-disk, already-trusted data, so per-height block
+    /// re-validation (merkle-root recompute + full-payload checksums) is redundant cost. The
+    /// background validator started at spawn is responsible for validating the on-disk chain.
+    pub(crate) fn transparent_db(&self) -> Database {
+        self.transparent
+    }
+
     /// **Temporary 0.4.0-alpha.1 cache compatibility.**
     ///
     /// The 0.4.0-alpha.1 build shipped a v1.1.0 → v1.2.0 migration (and write path) that did not

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -143,6 +143,19 @@ pub(crate) const TX_OUT_SET_INFO_ACCUMULATOR_DATABASE_NAME: &str =
 /// Singleton key for the finalised txout-set accumulator table.
 pub(crate) const TX_OUT_SET_INFO_ACCUMULATOR_KEY: &[u8] = b"tx_out_set_info_accumulator";
 
+/// Number of committed block writes / migration heights between explicit
+/// `env.sync(true)` durability checkpoints.
+///
+/// The LMDB environment is opened with `MDB_NOSYNC` (see [`DbV1::spawn`]), so an individual
+/// `txn.commit()` is *not* flushed to disk. Because the environment does not use `WRITE_MAP`,
+/// LMDB still guarantees ACI on crash — only durability (D) is lost: a crash rolls the database
+/// back to the last on-disk-consistent transaction, it never corrupts it (copy-on-write + dual
+/// meta pages always leave a recoverable committed snapshot). Forcing a sync every
+/// `SYNC_CHECKPOINT_INTERVAL` writes bounds how much committed-but-unflushed tail a crash can
+/// discard. The tail is always safe to re-do: clean sync resumes from the on-disk tip and
+/// re-fetches the missing blocks, and migrations resume idempotently from their progress keys.
+pub(crate) const SYNC_CHECKPOINT_INTERVAL: u32 = 1000;
+
 /// [`DbCore`] capability implementation for [`DbV1`].
 ///
 /// This trait exposes lifecycle operations and a high-level status indicator.
@@ -330,11 +343,23 @@ impl DbV1 {
             .expect("max_readers was clamped to fit in u32");
 
         // Open LMDB environment and set environmental details.
+        //
+        // `NO_SYNC`: commits are not fsynced. The core write path now does many random-key
+        // inserts per block (the `spent` and `txid_location` B-trees are keyed by 32-byte
+        // hashes), which made per-commit fsync the dominant sync cost once those trees outgrew
+        // the page cache. Under `NO_SYNC` the OS batches that write-back; we force durability at
+        // explicit checkpoints (`SYNC_CHECKPOINT_INTERVAL`) and on graceful shutdown instead.
+        // `WRITE_MAP` is unset, so a crash never corrupts the database — it only discards the
+        // unflushed tail of recent commits, which clean sync and migrations safely re-do.
         let env = Environment::new()
             .set_max_dbs(15)
             .set_map_size(db_size_bytes)
             .set_max_readers(max_readers)
-            .set_flags(EnvironmentFlags::NO_TLS | EnvironmentFlags::NO_READAHEAD)
+            .set_flags(
+                EnvironmentFlags::NO_TLS
+                    | EnvironmentFlags::NO_READAHEAD
+                    | EnvironmentFlags::NO_SYNC,
+            )
             .open(&db_path)?;
 
         // Open individual LMDB DBs.
@@ -873,11 +898,23 @@ impl DbV1 {
             .expect("max_readers was clamped to fit in u32");
 
         // Open LMDB environment and set environmental details.
+        //
+        // `NO_SYNC`: commits are not fsynced. The core write path now does many random-key
+        // inserts per block (the `spent` and `txid_location` B-trees are keyed by 32-byte
+        // hashes), which made per-commit fsync the dominant sync cost once those trees outgrew
+        // the page cache. Under `NO_SYNC` the OS batches that write-back; we force durability at
+        // explicit checkpoints (`SYNC_CHECKPOINT_INTERVAL`) and on graceful shutdown instead.
+        // `WRITE_MAP` is unset, so a crash never corrupts the database — it only discards the
+        // unflushed tail of recent commits, which clean sync and migrations safely re-do.
         let env = Environment::new()
             .set_max_dbs(15)
             .set_map_size(db_size_bytes)
             .set_max_readers(max_readers)
-            .set_flags(EnvironmentFlags::NO_TLS | EnvironmentFlags::NO_READAHEAD)
+            .set_flags(
+                EnvironmentFlags::NO_TLS
+                    | EnvironmentFlags::NO_READAHEAD
+                    | EnvironmentFlags::NO_SYNC,
+            )
             .open(&db_path)?;
 
         // Open individual LMDB DBs.

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/transparent_address_history.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/transparent_address_history.rs
@@ -1924,6 +1924,391 @@ impl DbV1 {
 
         Ok(total)
     }
+
+    /// Reads the height the persisted txout-set accumulator currently reflects, or `None` if it has
+    /// never been built (fresh database / pre-migration). Drives the rebuild-vs-incremental dispatch
+    /// in [`DbV1::write_blocks_to_height`].
+    pub(crate) async fn read_tx_out_set_accumulator_built_height(
+        &self,
+    ) -> Result<Option<Height>, FinalisedStateError> {
+        tokio::task::block_in_place(|| {
+            let txn = self.env.begin_ro_txn()?;
+            match txn.get(self.metadata, &TX_OUT_SET_ACCUMULATOR_BUILT_HEIGHT_KEY) {
+                Ok(bytes) => {
+                    let entry = StoredEntryFixed::<Height>::from_bytes(bytes).map_err(|error| {
+                        FinalisedStateError::Custom(format!(
+                            "accumulator built-height decode error: {error}"
+                        ))
+                    })?;
+                    if !entry.verify(TX_OUT_SET_ACCUMULATOR_BUILT_HEIGHT_KEY) {
+                        return Err(FinalisedStateError::Custom(
+                            "accumulator built-height checksum mismatch".to_string(),
+                        ));
+                    }
+                    Ok(Some(*entry.inner()))
+                }
+                Err(lmdb::Error::NotFound) => Ok(None),
+                Err(error) => Err(FinalisedStateError::LmdbError(error)),
+            }
+        })
+    }
+
+    /// Advances the persisted txout-set accumulator from `built` to `tip` by applying only the delta
+    /// of the just-written blocks `(built, tip]`, then persists the accumulator and its watermark.
+    ///
+    /// This is the steady-state alternative to [`DbV1::rebuild_tx_out_set_accumulator`]: instead of
+    /// re-scanning the whole chain it reads only the range's blocks plus a bounded number of point
+    /// lookups, so its cost is O(range) and independent of chain length. The result is identical to a
+    /// from-genesis rebuild at `tip`: the stored accumulator already reflects the UTXO set at `built`
+    /// (the watermark invariant), and the UTXO set at `tip` differs from it only by outputs created
+    /// in the range and still unspent (added), minus outputs that were unspent at `built` and spent
+    /// within the range (removed); a create-and-spend within the range cancels.
+    ///
+    /// The four additive/XOR fields are exactly `created − spent` over the range. `transactions`
+    /// (count of txs with ≥1 unspent spendable output) is the only non-additive field; its delta is
+    /// computed against the *final* on-disk state — the `spent` table already covers every spend up
+    /// to `tip`, so "unspent at the tip" is a direct lookup and no per-block "as of height"
+    /// bookkeeping is needed:
+    /// - **Set A** — each tx created in the range: `+1` iff it still has a live output at the tip.
+    /// - **Set B** — each prior tx (created at/before `built`) we spent a *spendable* output of: it
+    ///   was necessarily counted at `built` (that output was live then), so `-1` iff its last live
+    ///   output is now gone. The two sets are disjoint by creation height and cover every change.
+    ///
+    /// WARNING: must be called only from the single DB control task (it does an unsynchronised
+    /// read-modify-write of the accumulator singleton), and only when the accumulator has already
+    /// been built to `built` (`built < tip`).
+    pub(crate) async fn update_tx_out_set_accumulator_for_range(
+        &self,
+        built: Height,
+        tip: Height,
+    ) -> Result<(), FinalisedStateError> {
+        let accumulator = tokio::task::block_in_place(|| {
+            let txn = self.env.begin_ro_txn()?;
+
+            // Load the accumulator the stored watermark refers to (it must exist on this path).
+            let mut accumulator = {
+                let raw = match txn
+                    .get(self.tx_out_set_info_accumulator, &TX_OUT_SET_INFO_ACCUMULATOR_KEY)
+                {
+                    Ok(value) => value,
+                    Err(lmdb::Error::NotFound) => {
+                        return Err(FinalisedStateError::Custom(
+                            "txout-set accumulator missing during incremental update".to_string(),
+                        ))
+                    }
+                    Err(error) => return Err(FinalisedStateError::LmdbError(error)),
+                };
+                let entry =
+                    StoredEntryFixed::<FinalisedTxOutSetInfoAccumulator>::from_bytes(raw)
+                        .map_err(|error| {
+                            FinalisedStateError::Custom(format!(
+                                "txout-set accumulator decode error: {error}"
+                            ))
+                        })?;
+                if !entry.verify(TX_OUT_SET_INFO_ACCUMULATOR_KEY) {
+                    return Err(FinalisedStateError::Custom(
+                        "txout-set accumulator checksum mismatch".to_string(),
+                    ));
+                }
+                entry.item
+            };
+
+            // ---- Pass 1: scan the range blocks `(built, tip]`. ----
+            // Each created spendable output is XORed in immediately; spends are removed in pass 2.
+            let mut range_txids: HashSet<[u8; 32]> = HashSet::new();
+            // Spendable created outputs keyed by outpoint bytes, to resolve same-range spends with no
+            // disk read.
+            let mut range_outputs: HashMap<Vec<u8>, TxOutCompact> = HashMap::new();
+            // Spendable created outpoints grouped by creating txid, for the Set A recount.
+            let mut created_outpoints_by_tx: HashMap<[u8; 32], Vec<Outpoint>> = HashMap::new();
+            // Every (non-null) prev-outpoint spent by the range.
+            let mut spends: Vec<Outpoint> = Vec::new();
+
+            let mut height = built.0 + 1;
+            while height <= tip.0 {
+                let height_bytes = Height(height).to_bytes()?;
+
+                let transparent_tx_list = {
+                    let raw = txn
+                        .get(self.transparent, &height_bytes)
+                        .map_err(FinalisedStateError::LmdbError)?;
+                    let entry = StoredEntryVar::<TransparentTxList>::from_bytes(raw)
+                        .map_err(|error| {
+                            FinalisedStateError::Custom(format!(
+                                "transparent corrupt data: {error}"
+                            ))
+                        })?;
+                    if !entry.verify(&height_bytes) {
+                        return Err(FinalisedStateError::Custom(
+                            "transparent checksum mismatch".to_string(),
+                        ));
+                    }
+                    entry.inner().clone()
+                };
+
+                let txids = {
+                    let raw = txn
+                        .get(self.txids, &height_bytes)
+                        .map_err(FinalisedStateError::LmdbError)?;
+                    let entry = StoredEntryVar::<TxidList>::from_bytes(raw).map_err(|error| {
+                        FinalisedStateError::Custom(format!("txids corrupt data: {error}"))
+                    })?;
+                    if !entry.verify(&height_bytes) {
+                        return Err(FinalisedStateError::Custom(
+                            "txids checksum mismatch".to_string(),
+                        ));
+                    }
+                    entry.inner().txids().to_vec()
+                };
+
+                for (tx_index, tx_opt) in transparent_tx_list.tx().iter().enumerate() {
+                    let txid = txids.get(tx_index).ok_or_else(|| {
+                        FinalisedStateError::Custom(format!(
+                            "txid/transparent length mismatch at height {height}"
+                        ))
+                    })?;
+                    range_txids.insert(txid.0);
+
+                    let Some(transparent_tx) = tx_opt else {
+                        continue;
+                    };
+
+                    for (out_index, output) in transparent_tx.outputs().iter().enumerate() {
+                        if is_unspendable_tx_out(output) {
+                            continue;
+                        }
+                        let outpoint = Outpoint::new(txid.0, out_index as u32);
+                        accumulator
+                            .apply_added_output(&outpoint, output)
+                            .map_err(|error| FinalisedStateError::Custom(error.to_string()))?;
+                        range_outputs.insert(outpoint.to_bytes()?, *output);
+                        created_outpoints_by_tx
+                            .entry(txid.0)
+                            .or_default()
+                            .push(outpoint);
+                    }
+
+                    for input in transparent_tx.inputs().iter() {
+                        if input.is_null_prevout() {
+                            continue;
+                        }
+                        spends.push(Outpoint::new(*input.prevout_txid(), input.prevout_index()));
+                    }
+                }
+
+                height += 1;
+            }
+
+            // ---- Pass 2: remove spent outputs (XOR out) and collect prior spent txids for Set B. ----
+            let mut prior_spent_txids: HashSet<[u8; 32]> = HashSet::new();
+            for outpoint in &spends {
+                let prev_txid = *outpoint.prev_txid();
+                let outpoint_bytes = outpoint.to_bytes()?;
+
+                let prev_output = if range_txids.contains(&prev_txid) {
+                    // Created within the range: resolve from memory. A miss means the referenced
+                    // output was unspendable (never added), so there is nothing to remove.
+                    match range_outputs.get(&outpoint_bytes) {
+                        Some(output) => *output,
+                        None => continue,
+                    }
+                } else {
+                    // Created at/before `built`: resolve from disk. An unspendable prev-output was
+                    // never in the set, so it is neither removed nor a Set B trigger.
+                    let Some(output) = self.resolve_prev_output_in_txn(&txn, *outpoint)? else {
+                        return Err(FinalisedStateError::Custom(format!(
+                            "incremental accumulator update: previous output {outpoint:?} not found"
+                        )));
+                    };
+                    if is_unspendable_tx_out(&output) {
+                        continue;
+                    }
+                    prior_spent_txids.insert(prev_txid);
+                    output
+                };
+
+                accumulator
+                    .apply_removed_output(outpoint, &prev_output)
+                    .map_err(|error| FinalisedStateError::Custom(error.to_string()))?;
+            }
+
+            // ---- Pass 3: `transactions` delta (the only non-additive field). ----
+            // An outpoint is "unspent at the tip" iff it is absent from the `spent` table, which now
+            // covers all spends up to `tip`.
+            let mut transactions_delta: i64 = 0;
+
+            // Set A: a tx created in the range contributes +1 iff it still has a live output.
+            for outpoints in created_outpoints_by_tx.values() {
+                let mut has_unspent = false;
+                for outpoint in outpoints {
+                    if self.is_outpoint_unspent_in_txn(&txn, outpoint)? {
+                        has_unspent = true;
+                        break;
+                    }
+                }
+                if has_unspent {
+                    transactions_delta += 1;
+                }
+            }
+
+            // Set B: a prior tx we spent a spendable output of contributes -1 iff its last live
+            // output is now gone.
+            for prev_txid in &prior_spent_txids {
+                let Some(prev_tx) =
+                    self.get_transparent_tx_in_txn(&txn, &TransactionHash(*prev_txid))?
+                else {
+                    return Err(FinalisedStateError::Custom(format!(
+                        "incremental accumulator update: spent transaction {prev_txid:?} missing"
+                    )));
+                };
+                let mut all_spent = true;
+                for (out_index, output) in prev_tx.outputs().iter().enumerate() {
+                    if is_unspendable_tx_out(output) {
+                        continue;
+                    }
+                    let outpoint = Outpoint::new(*prev_txid, out_index as u32);
+                    if self.is_outpoint_unspent_in_txn(&txn, &outpoint)? {
+                        all_spent = false;
+                        break;
+                    }
+                }
+                if all_spent {
+                    transactions_delta -= 1;
+                }
+            }
+
+            accumulator.transactions = i64::try_from(accumulator.transactions)
+                .ok()
+                .and_then(|count| count.checked_add(transactions_delta))
+                .and_then(|count| u64::try_from(count).ok())
+                .ok_or_else(|| {
+                    FinalisedStateError::Custom(
+                        "txout-set accumulator transactions delta under/overflow".to_string(),
+                    )
+                })?;
+
+            Ok::<_, FinalisedStateError>(accumulator)
+        })?;
+
+        // Persist the updated accumulator and advance the watermark to `tip` atomically, then force
+        // durability — mirroring `rebuild_tx_out_set_accumulator`.
+        tokio::task::block_in_place(|| {
+            let mut txn = self.env.begin_rw_txn()?;
+
+            let accumulator_entry =
+                StoredEntryFixed::new(TX_OUT_SET_INFO_ACCUMULATOR_KEY, accumulator);
+            txn.put(
+                self.tx_out_set_info_accumulator,
+                &TX_OUT_SET_INFO_ACCUMULATOR_KEY,
+                &accumulator_entry.to_bytes()?,
+                WriteFlags::empty(),
+            )?;
+
+            let watermark = StoredEntryFixed::new(TX_OUT_SET_ACCUMULATOR_BUILT_HEIGHT_KEY, tip);
+            txn.put(
+                self.metadata,
+                &TX_OUT_SET_ACCUMULATOR_BUILT_HEIGHT_KEY,
+                &watermark.to_bytes()?,
+                WriteFlags::empty(),
+            )?;
+
+            txn.commit()?;
+            self.env.sync(true)?;
+
+            Ok::<_, FinalisedStateError>(())
+        })
+    }
+
+    /// `true` iff `outpoint` is absent from the `spent` table (read through `txn`).
+    fn is_outpoint_unspent_in_txn<T: lmdb::Transaction>(
+        &self,
+        txn: &T,
+        outpoint: &Outpoint,
+    ) -> Result<bool, FinalisedStateError> {
+        match txn.get(self.spent, &outpoint.to_bytes()?) {
+            Ok(_) => Ok(false),
+            Err(lmdb::Error::NotFound) => Ok(true),
+            Err(error) => Err(FinalisedStateError::LmdbError(error)),
+        }
+    }
+
+    /// Resolves a txid to its [`TxLocation`] via the `txid_location` index, read through `txn`.
+    fn find_txid_location_in_txn<T: lmdb::Transaction>(
+        &self,
+        txn: &T,
+        txid: &TransactionHash,
+    ) -> Result<Option<TxLocation>, FinalisedStateError> {
+        let key: [u8; 32] = (*txid).into();
+        match txn.get(self.txid_location, &key) {
+            Ok(bytes) => {
+                let entry = StoredEntryFixed::<TxLocation>::from_bytes(bytes).map_err(|error| {
+                    FinalisedStateError::Custom(format!("corrupt txid_location entry: {error}"))
+                })?;
+                if !entry.verify(key) {
+                    return Err(FinalisedStateError::Custom(
+                        "txid_location entry checksum mismatch".to_string(),
+                    ));
+                }
+                Ok(Some(*entry.inner()))
+            }
+            Err(lmdb::Error::NotFound) => Ok(None),
+            Err(error) => Err(FinalisedStateError::LmdbError(error)),
+        }
+    }
+
+    /// Resolves the previous [`TxOutCompact`] for `outpoint`, read through `txn` (no new txn).
+    fn resolve_prev_output_in_txn<T: lmdb::Transaction>(
+        &self,
+        txn: &T,
+        outpoint: Outpoint,
+    ) -> Result<Option<TxOutCompact>, FinalisedStateError> {
+        let prev_txid = TransactionHash::from(*outpoint.prev_txid());
+        let Some(location) = self.find_txid_location_in_txn(txn, &prev_txid)? else {
+            return Ok(None);
+        };
+        let height_bytes = Height(location.block_height()).to_bytes()?;
+        let stored = match txn.get(self.transparent, &height_bytes) {
+            Ok(bytes) => bytes,
+            Err(lmdb::Error::NotFound) => return Ok(None),
+            Err(error) => return Err(FinalisedStateError::LmdbError(error)),
+        };
+        Ok(Self::find_txout_in_stored_transparent_tx_list(
+            stored,
+            location.tx_index() as usize,
+            outpoint.prev_index() as usize,
+        ))
+    }
+
+    /// Fetches the full [`TransparentCompactTx`] for `txid`, read through `txn` (no new txn).
+    fn get_transparent_tx_in_txn<T: lmdb::Transaction>(
+        &self,
+        txn: &T,
+        txid: &TransactionHash,
+    ) -> Result<Option<TransparentCompactTx>, FinalisedStateError> {
+        let Some(location) = self.find_txid_location_in_txn(txn, txid)? else {
+            return Ok(None);
+        };
+        let height_bytes = Height(location.block_height()).to_bytes()?;
+        let raw = match txn.get(self.transparent, &height_bytes) {
+            Ok(bytes) => bytes,
+            Err(lmdb::Error::NotFound) => return Ok(None),
+            Err(error) => return Err(FinalisedStateError::LmdbError(error)),
+        };
+        let entry = StoredEntryVar::<TransparentTxList>::from_bytes(raw).map_err(|error| {
+            FinalisedStateError::Custom(format!("transparent corrupt data: {error}"))
+        })?;
+        if !entry.verify(&height_bytes) {
+            return Err(FinalisedStateError::Custom(
+                "transparent checksum mismatch".to_string(),
+            ));
+        }
+        Ok(entry
+            .inner()
+            .tx()
+            .get(location.tx_index() as usize)
+            .cloned()
+            .flatten())
+    }
 }
 
 #[cfg(test)]

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/transparent_address_history.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/transparent_address_history.rs
@@ -1802,9 +1802,11 @@ impl DbV1 {
                     let raw = txn
                         .get(self.transparent, &height_bytes)
                         .map_err(FinalisedStateError::LmdbError)?;
-                    let entry = StoredEntryVar::<TransparentTxList>::from_bytes(raw)
-                        .map_err(|error| {
-                            FinalisedStateError::Custom(format!("transparent corrupt data: {error}"))
+                    let entry =
+                        StoredEntryVar::<TransparentTxList>::from_bytes(raw).map_err(|error| {
+                            FinalisedStateError::Custom(format!(
+                                "transparent corrupt data: {error}"
+                            ))
                         })?;
                     if !entry.verify(&height_bytes) {
                         return Err(FinalisedStateError::Custom(

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/transparent_address_history.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/transparent_address_history.rs
@@ -1,6 +1,9 @@
 //! ZainoDB::V1 transparent address history indexing functionality.
 
-use crate::chain_index::finalised_state::db::v1::TX_OUT_SET_INFO_ACCUMULATOR_KEY;
+use crate::chain_index::finalised_state::db::v1::{
+    ACCUMULATOR_BUILD_SHARDS, TX_OUT_SET_ACCUMULATOR_BUILT_HEIGHT_KEY,
+    TX_OUT_SET_INFO_ACCUMULATOR_KEY,
+};
 use crate::chain_index::types::db::metadata::{
     is_unspendable_tx_out, tx_out_set_entry_digest, FinalisedTxOutSetInfoAccumulator,
     ZAINO_TXOUTSET_ENTRY_LEN,
@@ -1688,6 +1691,236 @@ impl DbV1 {
         )?;
 
         Ok(accumulator)
+    }
+}
+
+impl DbV1 {
+    //! *** Bulk txout-set accumulator builder ***
+    //!
+    //! Replaces the per-block, random-read accumulator maintenance that dominated sync time at
+    //! sandblast height. The accumulator over the UTXO set at the current tip is recomputed from
+    //! scratch with (almost entirely) sequential scans, exploiting the fact that the
+    //! `hash_serialized` field is an XOR multiset commitment: an output created and later spent is
+    //! XORed in then out and cancels, so the live set is exactly the created-and-not-spent outputs.
+
+    /// Rebuilds the finalised txout-set accumulator to the current db tip and persists it.
+    ///
+    /// Atomically writes the recomputed accumulator singleton and the
+    /// [`TX_OUT_SET_ACCUMULATOR_BUILT_HEIGHT_KEY`] watermark, then forces a durability sync. This is
+    /// idempotent — it never trusts a pre-existing accumulator — so it is safe to call after an
+    /// interrupted sync, and is reused by the v1.2 migration's accumulator stage.
+    pub(crate) async fn rebuild_tx_out_set_accumulator(&self) -> Result<(), FinalisedStateError> {
+        let Some(db_tip) = self.tip_height().await? else {
+            // Empty database: nothing to build.
+            return Ok(());
+        };
+
+        tokio::task::block_in_place(|| {
+            let accumulator =
+                self.build_tx_out_set_accumulator_blocking(db_tip, ACCUMULATOR_BUILD_SHARDS)?;
+
+            let mut txn = self.env.begin_rw_txn()?;
+
+            let accumulator_entry =
+                StoredEntryFixed::new(TX_OUT_SET_INFO_ACCUMULATOR_KEY, accumulator);
+            txn.put(
+                self.tx_out_set_info_accumulator,
+                &TX_OUT_SET_INFO_ACCUMULATOR_KEY,
+                &accumulator_entry.to_bytes()?,
+                WriteFlags::empty(),
+            )?;
+
+            let watermark = StoredEntryFixed::new(TX_OUT_SET_ACCUMULATOR_BUILT_HEIGHT_KEY, db_tip);
+            txn.put(
+                self.metadata,
+                &TX_OUT_SET_ACCUMULATOR_BUILT_HEIGHT_KEY,
+                &watermark.to_bytes()?,
+                WriteFlags::empty(),
+            )?;
+
+            txn.commit()?;
+            self.env.sync(true)?;
+
+            Ok::<_, FinalisedStateError>(())
+        })
+    }
+
+    /// Computes the finalised txout-set accumulator over the UTXO set at `db_tip`.
+    ///
+    /// Strategy (per shard): scan the `spent` table once to collect the spent outpoints whose
+    /// creating txid falls in the shard, then scan the block `transparent` + `txids` tables in
+    /// ascending height order, adding every spendable output that is not in that spent set. The
+    /// `transactions` count is derived locally per transaction (all of a tx's outputs live in one
+    /// height entry). Sharding bounds the in-memory spent set; partials recombine exactly.
+    ///
+    /// WARNING: blocking — call from a blocking context. Builds to `db_tip` only (the spent table
+    /// is assumed to cover spends up to the same tip).
+    pub(crate) fn build_tx_out_set_accumulator_blocking(
+        &self,
+        db_tip: Height,
+        shards: u16,
+    ) -> Result<FinalisedTxOutSetInfoAccumulator, FinalisedStateError> {
+        let shards = shards.max(1) as usize;
+        let mut total = FinalisedTxOutSetInfoAccumulator::empty();
+
+        for shard in 0..shards {
+            // First-byte range [lo, hi) of the creating-txid assigned to this shard.
+            let lo = (shard * 256 / shards) as u16;
+            let hi = ((shard + 1) * 256 / shards) as u16;
+            let in_shard = |first_byte: u8| -> bool {
+                let b = first_byte as u16;
+                b >= lo && b < hi
+            };
+
+            // One read snapshot for the whole shard pass (subsumes the per-lookup RO-txn churn the
+            // old per-block path incurred).
+            let txn = self.env.begin_ro_txn()?;
+
+            // (1) Spent outpoints in this shard. The `spent` key is `Outpoint::to_bytes()` =
+            //     `[version tag][32-byte prev_txid][4-byte index]`, so the prev-txid's first byte
+            //     (which equals the creating txid's first byte) is at index 1.
+            let mut spent_set: HashSet<Box<[u8]>> = HashSet::new();
+            {
+                let mut cursor = txn.open_ro_cursor(self.spent)?;
+                for (key_bytes, _value) in cursor.iter() {
+                    if key_bytes.len() < 2 || !in_shard(key_bytes[1]) {
+                        continue;
+                    }
+                    spent_set.insert(Box::from(key_bytes));
+                }
+            }
+
+            // (2) Sequential pass over block transparent data, height-ascending.
+            let mut shard_acc = FinalisedTxOutSetInfoAccumulator::empty();
+            let mut height = GENESIS_HEIGHT.0;
+            while height <= db_tip.0 {
+                let block_height = Height::try_from(height)
+                    .map_err(|error| FinalisedStateError::Custom(error.to_string()))?;
+                let height_bytes = block_height.to_bytes()?;
+
+                let transparent_tx_list = {
+                    let raw = txn
+                        .get(self.transparent, &height_bytes)
+                        .map_err(FinalisedStateError::LmdbError)?;
+                    let entry = StoredEntryVar::<TransparentTxList>::from_bytes(raw)
+                        .map_err(|error| {
+                            FinalisedStateError::Custom(format!("transparent corrupt data: {error}"))
+                        })?;
+                    if !entry.verify(&height_bytes) {
+                        return Err(FinalisedStateError::Custom(
+                            "transparent checksum mismatch".to_string(),
+                        ));
+                    }
+                    entry.inner().clone()
+                };
+
+                let txids = {
+                    let raw = txn
+                        .get(self.txids, &height_bytes)
+                        .map_err(FinalisedStateError::LmdbError)?;
+                    let entry = StoredEntryVar::<TxidList>::from_bytes(raw).map_err(|error| {
+                        FinalisedStateError::Custom(format!("txids corrupt data: {error}"))
+                    })?;
+                    if !entry.verify(&height_bytes) {
+                        return Err(FinalisedStateError::Custom(
+                            "txids checksum mismatch".to_string(),
+                        ));
+                    }
+                    entry.inner().txids().to_vec()
+                };
+
+                for (tx_index, tx_opt) in transparent_tx_list.tx().iter().enumerate() {
+                    let txid = txids.get(tx_index).ok_or_else(|| {
+                        FinalisedStateError::Custom(format!(
+                            "txid/transparent length mismatch at height {height}"
+                        ))
+                    })?;
+
+                    // A tx's outputs are removed by spends keyed under the same txid, so the whole
+                    // tx belongs to exactly one shard.
+                    if !in_shard(txid.0[0]) {
+                        continue;
+                    }
+
+                    let Some(transparent_tx) = tx_opt else {
+                        continue;
+                    };
+
+                    let mut tx_has_unspent = false;
+                    for (out_index, output) in transparent_tx.outputs().iter().enumerate() {
+                        if is_unspendable_tx_out(output) {
+                            continue;
+                        }
+
+                        let outpoint = Outpoint::new(txid.0, out_index as u32);
+                        let outpoint_key = outpoint.to_bytes()?;
+                        if spent_set.contains(outpoint_key.as_slice()) {
+                            // Created then spent at/below the tip: cancels out of the live set.
+                            continue;
+                        }
+
+                        shard_acc
+                            .apply_added_output(&outpoint, output)
+                            .map_err(|error| FinalisedStateError::Custom(error.to_string()))?;
+                        tx_has_unspent = true;
+                    }
+
+                    if tx_has_unspent {
+                        shard_acc.transactions =
+                            shard_acc.transactions.checked_add(1).ok_or_else(|| {
+                                FinalisedStateError::Custom(
+                                    "txout-set accumulator transactions overflow".to_string(),
+                                )
+                            })?;
+                    }
+                }
+
+                height += 1;
+            }
+
+            // Recombine: XOR the multiset commitments, sum the additive counters.
+            for (dst, src) in total
+                .hash_serialized
+                .iter_mut()
+                .zip(shard_acc.hash_serialized.iter())
+            {
+                *dst ^= *src;
+            }
+            total.transactions = total
+                .transactions
+                .checked_add(shard_acc.transactions)
+                .ok_or_else(|| {
+                    FinalisedStateError::Custom(
+                        "txout-set accumulator transactions overflow".to_string(),
+                    )
+                })?;
+            total.transaction_outputs = total
+                .transaction_outputs
+                .checked_add(shard_acc.transaction_outputs)
+                .ok_or_else(|| {
+                    FinalisedStateError::Custom(
+                        "txout-set accumulator transaction_outputs overflow".to_string(),
+                    )
+                })?;
+            total.bytes_serialized = total
+                .bytes_serialized
+                .checked_add(shard_acc.bytes_serialized)
+                .ok_or_else(|| {
+                    FinalisedStateError::Custom(
+                        "txout-set accumulator bytes_serialized overflow".to_string(),
+                    )
+                })?;
+            total.total_zatoshis = total
+                .total_zatoshis
+                .checked_add(shard_acc.total_zatoshis)
+                .ok_or_else(|| {
+                    FinalisedStateError::Custom(
+                        "txout-set accumulator total_zatoshis overflow".to_string(),
+                    )
+                })?;
+        }
+
+        Ok(total)
     }
 }
 

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/validation.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/validation.rs
@@ -460,7 +460,7 @@ impl DbV1 {
     /// Behavior:
     /// - Duplicates the final element when the layer width is odd, matching Bitcoin/Zcash merkle rules.
     /// - Uses SHA256d over 64-byte concatenated pairs at each layer.
-    fn calculate_block_merkle_root(txids: &[[u8; 32]]) -> [u8; 32] {
+    pub(super) fn calculate_block_merkle_root(txids: &[[u8; 32]]) -> [u8; 32] {
         assert!(
             !txids.is_empty(),
             "block must contain at least the coinbase"

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/validation.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/validation.rs
@@ -63,7 +63,7 @@ impl DbV1 {
     ///
     /// NOTE:
     /// - This function is intentionally tolerant of races: redundant inserts / removals are benign.
-    fn mark_validated(&self, h: u32) {
+    pub(super) fn mark_validated(&self, h: u32) {
         let mut next = h;
         loop {
             let tip = self.validated_tip.load(Ordering::Acquire);

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -21,6 +21,23 @@ fn approx_indexed_block_bytes(block: &IndexedBlock) -> u64 {
         })
         .sum()
 }
+
+/// Maximum number of blocks buffered in a single bulk-sync write batch, regardless of the byte
+/// budget. Early-chain blocks are tiny, so the byte budget alone could buffer an enormous number of
+/// blocks before the first commit — delaying durability/progress and inflating memory. This caps
+/// the time-to-first-commit and the crash-loss window.
+#[cfg(not(feature = "transparent_address_history_experimental"))]
+const SYNC_WRITE_BATCH_MAX_BLOCKS: usize = 100_000;
+
+/// Maximum wall-clock time spent buffering a single bulk-sync write batch before flushing, so
+/// commits (and progress) happen regularly even when block fetches are slow.
+#[cfg(not(feature = "transparent_address_history_experimental"))]
+const SYNC_WRITE_BATCH_MAX_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Interval between in-flight "syncing height" progress logs during bulk sync.
+#[cfg(not(feature = "transparent_address_history_experimental"))]
+const SYNC_PROGRESS_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+
 #[cfg(test)]
 use crate::version;
 
@@ -103,12 +120,21 @@ impl DbWrite for DbV1 {
         {
             let batch_budget = self.config.storage.database.sync_write_batch_bytes.max(1);
             let mut next = start_height;
+            let mut last_progress_log = std::time::Instant::now();
             while next <= height.0 {
                 // Fetch blocks (async; an LMDB write txn is `!Send` and cannot be held across the
-                // await) until the byte budget is reached.
+                // await) into a buffer, flushing on the *first* of: byte budget, block-count cap, or
+                // time cap. The count/time caps keep the first commit (and progress, and crash-loss
+                // window) prompt even on the tiny early-chain blocks, where the byte budget alone
+                // would buffer a huge number of blocks before committing.
                 let mut batch: Vec<IndexedBlock> = Vec::new();
                 let mut batch_bytes: u64 = 0;
-                while next <= height.0 && batch_bytes < batch_budget {
+                let batch_started = std::time::Instant::now();
+                while next <= height.0
+                    && batch_bytes < batch_budget
+                    && batch.len() < SYNC_WRITE_BATCH_MAX_BLOCKS
+                    && batch_started.elapsed() < SYNC_WRITE_BATCH_MAX_INTERVAL
+                {
                     let block = build_indexed_block_from_source(
                         source,
                         network,
@@ -122,6 +148,22 @@ impl DbWrite for DbV1 {
                     batch_bytes = batch_bytes.saturating_add(approx_indexed_block_bytes(&block));
                     batch.push(block);
                     next += 1;
+
+                    // In-flight progress: the block being fetched, throttled by time. (The committed
+                    // tip is reported by the per-batch commit log below.)
+                    if last_progress_log.elapsed() >= SYNC_PROGRESS_LOG_INTERVAL {
+                        info!(
+                            "write_blocks_to_height: syncing height {} / {} on {:?}",
+                            next - 1,
+                            height.0,
+                            network
+                        );
+                        last_progress_log = std::time::Instant::now();
+                    }
+                }
+
+                if batch.is_empty() {
+                    break;
                 }
 
                 // Write + sort + commit the batch atomically, then force durability. The on-disk
@@ -284,12 +326,14 @@ impl DbV1 {
                     // one of the two cheap, in-memory correctness checks (the other is the merkle
                     // root below) that justify marking the block validated after a successful write
                     // without the expensive post-commit re-read.
-                    let last_entry = StoredEntryVar::<BlockHeaderData>::from_bytes(last_header_bytes)
-                        .map_err(|e| {
-                            FinalisedStateError::Custom(format!(
-                                "tip header decode error during continuity check: {e}"
-                            ))
-                        })?;
+                    let last_entry = StoredEntryVar::<BlockHeaderData>::from_bytes(
+                        last_header_bytes,
+                    )
+                    .map_err(|e| {
+                        FinalisedStateError::Custom(format!(
+                            "tip header decode error during continuity check: {e}"
+                        ))
+                    })?;
                     if last_entry.inner().context.hash() != block.context.parent_hash() {
                         return Err(FinalisedStateError::InvalidBlock {
                             height: block_height.0,
@@ -1025,11 +1069,16 @@ impl DbV1 {
                     let last_height = Height::from_bytes(
                         last_height_bytes.expect("Height is always some in the finalised state"),
                     )?;
-                    let last_entry =
-                        StoredEntryVar::<BlockHeaderData>::from_bytes(last_header_bytes).map_err(
-                            |e| FinalisedStateError::Custom(format!("tip header decode error: {e}")),
-                        )?;
-                    (Some(last_height.0), Some(*last_entry.inner().context.hash()))
+                    let last_entry = StoredEntryVar::<BlockHeaderData>::from_bytes(
+                        last_header_bytes,
+                    )
+                    .map_err(|e| {
+                        FinalisedStateError::Custom(format!("tip header decode error: {e}"))
+                    })?;
+                    (
+                        Some(last_height.0),
+                        Some(*last_entry.inner().context.hash()),
+                    )
                 }
                 Err(lmdb::Error::NotFound) => (None, None),
                 Err(e) => return Err(FinalisedStateError::LmdbError(e)),
@@ -1133,8 +1182,7 @@ impl DbV1 {
                     if input.is_null_prevout() {
                         continue;
                     }
-                    let prev_outpoint =
-                        Outpoint::new(*input.prevout_txid(), input.prevout_index());
+                    let prev_outpoint = Outpoint::new(*input.prevout_txid(), input.prevout_index());
                     spent_batch.push((prev_outpoint.to_bytes()?, tx_location));
                 }
 
@@ -1161,17 +1209,42 @@ impl DbV1 {
                 StoredEntryVar::new(&block_height_bytes, OrchardTxList::new(orchard));
 
             // Height-keyed tables (+ the hash-keyed `heights`, one entry/block) written per block.
-            put_idempotent(&mut txn, self.headers, &block_height_bytes, &header_entry.to_bytes()?)?;
-            put_idempotent(&mut txn, self.heights, &block_hash_bytes, &height_entry.to_bytes()?)?;
-            put_idempotent(&mut txn, self.txids, &block_height_bytes, &txid_entry.to_bytes()?)?;
+            put_idempotent(
+                &mut txn,
+                self.headers,
+                &block_height_bytes,
+                &header_entry.to_bytes()?,
+            )?;
+            put_idempotent(
+                &mut txn,
+                self.heights,
+                &block_hash_bytes,
+                &height_entry.to_bytes()?,
+            )?;
+            put_idempotent(
+                &mut txn,
+                self.txids,
+                &block_height_bytes,
+                &txid_entry.to_bytes()?,
+            )?;
             put_idempotent(
                 &mut txn,
                 self.transparent,
                 &block_height_bytes,
                 &transparent_entry.to_bytes()?,
             )?;
-            put_idempotent(&mut txn, self.sapling, &block_height_bytes, &sapling_entry.to_bytes()?)?;
-            put_idempotent(&mut txn, self.orchard, &block_height_bytes, &orchard_entry.to_bytes()?)?;
+            put_idempotent(
+                &mut txn,
+                self.sapling,
+                &block_height_bytes,
+                &sapling_entry.to_bytes()?,
+            )?;
+            put_idempotent(
+                &mut txn,
+                self.orchard,
+                &block_height_bytes,
+                &orchard_entry.to_bytes()?,
+            )?;
             put_idempotent(
                 &mut txn,
                 self.commitment_tree_data,
@@ -1679,7 +1752,8 @@ impl DbV1 {
     /// Returns the current contiguous validated-tip height. Test hook for asserting that the write
     /// path advances the validated tip without relying on the background validator.
     pub(crate) fn validated_tip_height(&self) -> u32 {
-        self.validated_tip.load(std::sync::atomic::Ordering::Acquire)
+        self.validated_tip
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 
     /// Writes a block using the v1.0.0 format.

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -23,9 +23,7 @@ impl DbWrite for DbV1 {
         height: Height,
         source: &S,
     ) -> Result<(), FinalisedStateError> {
-        use crate::chain_index::finalised_state::{
-            build_indexed_block_from_source, capability::BlockCoreExt,
-        };
+        use crate::chain_index::finalised_state::build_indexed_block_from_source;
         use zebra_chain::parameters::NetworkUpgrade;
 
         let network = self.config.network;
@@ -36,17 +34,45 @@ impl DbWrite for DbV1 {
         let nu5_activation_height = NetworkUpgrade::Nu5.activation_height(&zebra_network);
 
         // Seed `parent_chainwork` from the current tip header (the block before the first one we
-        // write). On an empty database this is genesis with zero chainwork.
+        // write). On an empty database this is genesis with zero chainwork. Read raw rather than via
+        // `get_block_header`, which routes through `resolve_validated_hash_or_height` →
+        // `validate_block_blocking` (a full re-validation for any height above `validated_tip`); the
+        // tip is already on disk and trusted here, exactly as the v1.2 migration reads block data.
         let (start_height, mut parent_chainwork) = match self.tip_height().await? {
             None => (GENESIS_HEIGHT.0, crate::ChainWork::from_u256(0.into())),
             Some(tip) => {
-                let chainwork = <Self as BlockCoreExt>::get_block_header(self, tip)
-                    .await
-                    .map(|header| header.context.chainwork)
-                    .unwrap_or_else(|_| crate::ChainWork::from_u256(0.into()));
+                let tip_bytes = tip.to_bytes()?;
+                let chainwork = tokio::task::block_in_place(|| {
+                    let ro = self.env.begin_ro_txn()?;
+                    match ro.get(self.headers, &tip_bytes) {
+                        Ok(raw) => {
+                            let entry = StoredEntryVar::<BlockHeaderData>::from_bytes(raw)
+                                .map_err(|e| {
+                                    FinalisedStateError::Custom(format!(
+                                        "tip header decode error: {e}"
+                                    ))
+                                })?;
+                            Ok::<_, FinalisedStateError>(entry.inner().context.chainwork)
+                        }
+                        Err(lmdb::Error::NotFound) => Ok(crate::ChainWork::from_u256(0.into())),
+                        Err(e) => Err(FinalisedStateError::LmdbError(e)),
+                    }
+                })?;
                 (tip.0 + 1, chainwork)
             }
         };
+
+        // Nothing to do when the tip already meets the target. Importantly, this means a steady-state
+        // poll (the indexer calls `sync_to_height` repeatedly) does *not* trigger the bulk accumulator
+        // rebuild below when no new blocks finalised.
+        if start_height > height.0 {
+            return Ok(());
+        }
+
+        info!(
+            "write_blocks_to_height: syncing finalised blocks {start_height}..={} on {:?}",
+            height.0, network
+        );
 
         for height_int in start_height..=height.0 {
             let block = build_indexed_block_from_source(
@@ -60,10 +86,14 @@ impl DbWrite for DbV1 {
             .await?;
             parent_chainwork = block.context.chainwork;
 
-            self.write_block_with_options(block, false, false).await?;
+            self.write_block_with_options(block, false).await?;
         }
 
         // Rebuild the deferred txout-set accumulator once, at the tip, via sequential scans.
+        info!(
+            "write_blocks_to_height: rebuilding txout-set accumulator to height {}",
+            height.0
+        );
         self.rebuild_tx_out_set_accumulator().await?;
 
         Ok(())
@@ -95,19 +125,21 @@ impl DbV1 {
     ///
     /// NOTE: This method should never leave a block partially written to the database.
     pub(crate) async fn write_block(&self, block: IndexedBlock) -> Result<(), FinalisedStateError> {
-        self.write_block_with_options(block, true, true).await
+        self.write_block_with_options(block, true).await
     }
 
-    /// Writes a single finalised [`IndexedBlock`], optionally maintaining the txout-set accumulator
-    /// and validating the written block.
+    /// Writes a single finalised [`IndexedBlock`], optionally maintaining the txout-set accumulator.
     ///
     /// - `update_tx_out_set`: when `true`, the accumulator is recomputed incrementally for this
     ///   block and persisted (with its freshness watermark) inside the block's write transaction.
     ///   When `false`, accumulator maintenance is deferred — the caller is responsible for a bulk
     ///   rebuild (see [`DbV1::rebuild_tx_out_set_accumulator`]).
-    /// - `validate`: when `true`, the block is re-read and structurally validated after commit;
-    ///   when `false`, the height is marked validated directly (the in-session writer trusts the
-    ///   block it just built — startup is the integrity gate for untrusted on-disk data).
+    ///
+    /// Validation is *not* a read-back pass on this path. Two cheap in-memory correctness checks run
+    /// before commit — parent-hash continuity (tip-check) and the header merkle root (vs. the
+    /// block's txids) — after which the height is marked validated directly. The expensive
+    /// [`DbV1::validate_block_blocking`] re-read is reserved for startup, where on-disk data is
+    /// untrusted.
     ///
     /// NOTE: This method should never leave a block partially written to the database.
     // `u32::is_multiple_of` is only stable from Rust 1.87; the `% 100 == 0` form below keeps the
@@ -117,7 +149,6 @@ impl DbV1 {
         &self,
         block: IndexedBlock,
         update_tx_out_set: bool,
-        validate: bool,
     ) -> Result<(), FinalisedStateError> {
         self.status.store(StatusType::Syncing);
         let block_hash = block.context.index.hash;
@@ -164,7 +195,7 @@ impl DbV1 {
             let cur = ro.open_ro_cursor(self.headers)?;
             match cur.get(None, None, lmdb_sys::MDB_LAST) {
                 // Database already has blocks
-                Ok((last_height_bytes, _last_header_bytes)) => {
+                Ok((last_height_bytes, last_header_bytes)) => {
                     let last_height = Height::from_bytes(
                         last_height_bytes.expect("Height is always some in the finalised state"),
                     )?;
@@ -175,6 +206,28 @@ impl DbV1 {
                             "cannot write block at height {block_height:?}; \
                      current tip is {last_height:?}"
                         )));
+                    }
+
+                    // Parent-hash continuity: the new block must extend the current tip. This is
+                    // one of the two cheap, in-memory correctness checks (the other is the merkle
+                    // root below) that justify marking the block validated after a successful write
+                    // without the expensive post-commit re-read.
+                    let last_entry = StoredEntryVar::<BlockHeaderData>::from_bytes(last_header_bytes)
+                        .map_err(|e| {
+                            FinalisedStateError::Custom(format!(
+                                "tip header decode error during continuity check: {e}"
+                            ))
+                        })?;
+                    if last_entry.inner().context.hash() != block.context.parent_hash() {
+                        return Err(FinalisedStateError::InvalidBlock {
+                            height: block_height.0,
+                            hash: block_hash,
+                            reason: format!(
+                                "parent hash does not extend current tip (tip: {:?}, parent: {:?})",
+                                last_entry.inner().context.hash(),
+                                block.context.parent_hash()
+                            ),
+                        });
                     }
                 }
                 // no block in db, this must be genesis block.
@@ -401,6 +454,23 @@ impl DbV1 {
         // Split the paired vector into the per-table shapes used for storage.
         let (txids, transparent): (Vec<TransactionHash>, Vec<Option<TransparentCompactTx>>) =
             transactions.into_iter().unzip();
+
+        // Cheap, in-memory correctness check: the block's txids must reproduce the header's merkle
+        // root. Together with the parent-hash continuity check in the tip-check above, this is what
+        // lets us mark the block validated after a successful write without the expensive
+        // post-commit re-read + spent-index cross-check (which only re-verifies on-disk integrity of
+        // bytes we just wrote from memory, and is redundant for our own writes).
+        {
+            let txid_bytes: Vec<[u8; 32]> = txids.iter().map(|txid| txid.0).collect();
+            let computed_merkle_root = Self::calculate_block_merkle_root(&txid_bytes);
+            if &computed_merkle_root != block.data().merkle_root() {
+                return Err(FinalisedStateError::InvalidBlock {
+                    height: block_height.0,
+                    hash: block_hash,
+                    reason: "header merkle root does not match block txids".to_string(),
+                });
+            }
+        }
 
         // Reverse txid index entries (`txid -> TxLocation`). Built before `txids` is moved into
         // the `TxidList` below, and sorted by txid so the random-keyed `txid_location` B-tree
@@ -642,19 +712,16 @@ impl DbV1 {
 
             // `txn.commit()` makes the block visible to subsequent readers (LMDB MVCC), but the
             // env is opened with `NO_SYNC`, so it is *not* fsynced here. Durability is forced at
-            // `SYNC_CHECKPOINT_INTERVAL` boundaries below and on graceful shutdown. Validation
-            // is read-only and observes the just-committed state from the map regardless of sync.
+            // `SYNC_CHECKPOINT_INTERVAL` boundaries below and on graceful shutdown.
             txn.commit()?;
 
-            if validate {
-                zaino_db.validate_block_blocking(block_height, block_hash)?;
-            } else {
-                // Deferred (bulk-sync) path: we built this block from the source this session and
-                // trust it, so skip the read-back validation pass and just advance the validated
-                // tip. Reads then see `is_validated` and never re-validate; startup remains the
-                // integrity gate for untrusted on-disk data.
-                zaino_db.mark_validated(block_height.0);
-            }
+            // Advance the validated tip directly. The block was built from a trusted source this
+            // session and passed the cheap in-memory correctness checks (parent-hash continuity and
+            // merkle root) before commit, so the expensive read-back validation pass is redundant
+            // here — it only re-verifies on-disk integrity of bytes we just wrote. Startup remains
+            // the integrity gate for untrusted on-disk data (`validate_block_blocking` via
+            // `initial_block_scan`). Marking validated keeps reads on the `is_validated` fast path.
+            zaino_db.mark_validated(block_height.0);
 
             Ok::<_, FinalisedStateError>(())
         });
@@ -1292,6 +1359,12 @@ impl DbV1 {
 
 #[cfg(test)]
 impl DbV1 {
+    /// Returns the current contiguous validated-tip height. Test hook for asserting that the write
+    /// path advances the validated tip without relying on the background validator.
+    pub(crate) fn validated_tip_height(&self) -> u32 {
+        self.validated_tip.load(std::sync::atomic::Ordering::Acquire)
+    }
+
     /// Writes a block using the v1.0.0 format.
     ///
     /// This intentionally writes only the core v1 tables and uses v1 item encodings.

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -1265,7 +1265,7 @@ impl DbV1 {
             put_idempotent(&mut txn, self.spent, key, &entry_bytes)?;
         }
 
-        txid_location_batch.sort_by(|a, b| a.0.cmp(&b.0));
+        txid_location_batch.sort_by_key(|entry| entry.0);
         for (key, tx_location) in &txid_location_batch {
             let entry_bytes = StoredEntryFixed::new(key, *tx_location).to_bytes()?;
             put_idempotent(&mut txn, self.txid_location, key, &entry_bytes)?;

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -203,12 +203,30 @@ impl DbWrite for DbV1 {
             }
         }
 
-        // Rebuild the deferred txout-set accumulator once, at the tip, via sequential scans.
-        info!(
-            "write_blocks_to_height: rebuilding txout-set accumulator to height {}",
-            height.0
-        );
-        self.rebuild_tx_out_set_accumulator().await?;
+        // Bring the deferred txout-set accumulator up to the new tip. The full from-genesis rebuild
+        // is a fixed chain-length scan, so running it on every catch-up poll stalls the sync loop
+        // once the chain is large. Use it only for the first build or an unusually large gap (e.g. a
+        // sync interrupted far behind the on-disk tip); in steady state apply just the delta for the
+        // blocks we wrote — O(range) work — which produces the identical accumulator at the tip.
+        match self.read_tx_out_set_accumulator_built_height().await? {
+            Some(built) if built.0 >= height.0 => {}
+            Some(built) if height.0.saturating_sub(built.0) <= ACCUMULATOR_INCREMENTAL_MAX_GAP => {
+                info!(
+                    "write_blocks_to_height: updating txout-set accumulator {}..={}",
+                    built.0 + 1,
+                    height.0
+                );
+                self.update_tx_out_set_accumulator_for_range(built, height)
+                    .await?;
+            }
+            _ => {
+                info!(
+                    "write_blocks_to_height: rebuilding txout-set accumulator to height {}",
+                    height.0
+                );
+                self.rebuild_tx_out_set_accumulator().await?;
+            }
+        }
 
         Ok(())
     }

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -14,6 +14,61 @@ impl DbWrite for DbV1 {
         self.write_block(block).await
     }
 
+    /// Bulk catch-up: ingests `tip+1..=height` from `source`, deferring txout-set accumulator
+    /// maintenance across the run and rebuilding it once at the end. Each block is written with
+    /// `update_tx_out_set = false` (deferred) and `validate = false` (the height is marked
+    /// validated directly, since we built the block from the source this session).
+    async fn write_blocks_to_height<S: crate::chain_index::source::BlockchainSource>(
+        &self,
+        height: Height,
+        source: &S,
+    ) -> Result<(), FinalisedStateError> {
+        use crate::chain_index::finalised_state::{
+            build_indexed_block_from_source, capability::BlockCoreExt,
+        };
+        use zebra_chain::parameters::NetworkUpgrade;
+
+        let network = self.config.network;
+        let zebra_network = network.to_zebra_network();
+        let sapling_activation_height = NetworkUpgrade::Sapling
+            .activation_height(&zebra_network)
+            .expect("Sapling activation height must be set");
+        let nu5_activation_height = NetworkUpgrade::Nu5.activation_height(&zebra_network);
+
+        // Seed `parent_chainwork` from the current tip header (the block before the first one we
+        // write). On an empty database this is genesis with zero chainwork.
+        let (start_height, mut parent_chainwork) = match self.tip_height().await? {
+            None => (GENESIS_HEIGHT.0, crate::ChainWork::from_u256(0.into())),
+            Some(tip) => {
+                let chainwork = <Self as BlockCoreExt>::get_block_header(self, tip)
+                    .await
+                    .map(|header| header.context.chainwork)
+                    .unwrap_or_else(|_| crate::ChainWork::from_u256(0.into()));
+                (tip.0 + 1, chainwork)
+            }
+        };
+
+        for height_int in start_height..=height.0 {
+            let block = build_indexed_block_from_source(
+                source,
+                network,
+                sapling_activation_height,
+                nu5_activation_height,
+                height_int,
+                parent_chainwork,
+            )
+            .await?;
+            parent_chainwork = block.context.chainwork;
+
+            self.write_block_with_options(block, false, false).await?;
+        }
+
+        // Rebuild the deferred txout-set accumulator once, at the tip, via sequential scans.
+        self.rebuild_tx_out_set_accumulator().await?;
+
+        Ok(())
+    }
+
     async fn delete_block_at_height(&self, height: Height) -> Result<(), FinalisedStateError> {
         self.delete_block_at_height(height).await
     }
@@ -33,11 +88,37 @@ impl DbV1 {
 
     /// Writes a given (finalised) [`IndexedBlock`] to ZainoDB.
     ///
+    /// Single-block append: the txout-set accumulator is maintained incrementally and the written
+    /// block is validated before the height advances. Bulk catch-up uses
+    /// [`DbV1::write_blocks_to_height`], which defers the accumulator (see
+    /// [`DbV1::write_block_with_options`]) and rebuilds it once at the tip.
+    ///
+    /// NOTE: This method should never leave a block partially written to the database.
+    pub(crate) async fn write_block(&self, block: IndexedBlock) -> Result<(), FinalisedStateError> {
+        self.write_block_with_options(block, true, true).await
+    }
+
+    /// Writes a single finalised [`IndexedBlock`], optionally maintaining the txout-set accumulator
+    /// and validating the written block.
+    ///
+    /// - `update_tx_out_set`: when `true`, the accumulator is recomputed incrementally for this
+    ///   block and persisted (with its freshness watermark) inside the block's write transaction.
+    ///   When `false`, accumulator maintenance is deferred — the caller is responsible for a bulk
+    ///   rebuild (see [`DbV1::rebuild_tx_out_set_accumulator`]).
+    /// - `validate`: when `true`, the block is re-read and structurally validated after commit;
+    ///   when `false`, the height is marked validated directly (the in-session writer trusts the
+    ///   block it just built — startup is the integrity gate for untrusted on-disk data).
+    ///
     /// NOTE: This method should never leave a block partially written to the database.
     // `u32::is_multiple_of` is only stable from Rust 1.87; the `% 100 == 0` form below keeps the
     // crate buildable on our older minimum supported Rust version.
     #[allow(clippy::manual_is_multiple_of)]
-    pub(crate) async fn write_block(&self, block: IndexedBlock) -> Result<(), FinalisedStateError> {
+    async fn write_block_with_options(
+        &self,
+        block: IndexedBlock,
+        update_tx_out_set: bool,
+        validate: bool,
+    ) -> Result<(), FinalisedStateError> {
         self.status.store(StatusType::Syncing);
         let block_hash = block.context.index.hash;
         let block_hash_bytes = block_hash.to_bytes()?;
@@ -302,13 +383,20 @@ impl DbV1 {
             }
         }
 
-        let tx_out_set_info_accumulator = self
-            .calculate_tx_out_set_info_accumulator_after_block(
-                block_height,
-                &transactions,
-                &spent_map,
+        // Accumulator maintenance is deferred on the bulk-sync path (`update_tx_out_set == false`)
+        // and rebuilt once at the tip; only the single-block append path maintains it incrementally.
+        let tx_out_set_info_accumulator = if update_tx_out_set {
+            Some(
+                self.calculate_tx_out_set_info_accumulator_after_block(
+                    block_height,
+                    &transactions,
+                    &spent_map,
+                )
+                .await?,
             )
-            .await?;
+        } else {
+            None
+        };
 
         // Split the paired vector into the per-table shapes used for storage.
         let (txids, transparent): (Vec<TransactionHash>, Vec<Option<TransparentCompactTx>>) =
@@ -436,15 +524,31 @@ impl DbV1 {
                 )?;
             }
 
-            let tx_out_set_info_accumulator_entry =
-                StoredEntryFixed::new(TX_OUT_SET_INFO_ACCUMULATOR_KEY, tx_out_set_info_accumulator);
+            // Persist the incrementally-maintained accumulator and advance its freshness watermark
+            // in the same transaction as the block, so the watermark always tracks the height the
+            // accumulator reflects. Skipped on the deferred (bulk-sync) path.
+            if let Some(tx_out_set_info_accumulator) = tx_out_set_info_accumulator {
+                let tx_out_set_info_accumulator_entry = StoredEntryFixed::new(
+                    TX_OUT_SET_INFO_ACCUMULATOR_KEY,
+                    tx_out_set_info_accumulator,
+                );
 
-            txn.put(
-                zaino_db.tx_out_set_info_accumulator,
-                &TX_OUT_SET_INFO_ACCUMULATOR_KEY,
-                &tx_out_set_info_accumulator_entry.to_bytes()?,
-                WriteFlags::empty(),
-            )?;
+                txn.put(
+                    zaino_db.tx_out_set_info_accumulator,
+                    &TX_OUT_SET_INFO_ACCUMULATOR_KEY,
+                    &tx_out_set_info_accumulator_entry.to_bytes()?,
+                    WriteFlags::empty(),
+                )?;
+
+                let watermark =
+                    StoredEntryFixed::new(TX_OUT_SET_ACCUMULATOR_BUILT_HEIGHT_KEY, block_height);
+                txn.put(
+                    zaino_db.metadata,
+                    &TX_OUT_SET_ACCUMULATOR_BUILT_HEIGHT_KEY,
+                    &watermark.to_bytes()?,
+                    WriteFlags::empty(),
+                )?;
+            }
 
             #[cfg(feature = "transparent_address_history_experimental")]
             {
@@ -542,7 +646,15 @@ impl DbV1 {
             // is read-only and observes the just-committed state from the map regardless of sync.
             txn.commit()?;
 
-            zaino_db.validate_block_blocking(block_height, block_hash)?;
+            if validate {
+                zaino_db.validate_block_blocking(block_height, block_hash)?;
+            } else {
+                // Deferred (bulk-sync) path: we built this block from the source this session and
+                // trust it, so skip the read-back validation pass and just advance the validated
+                // tip. Reads then see `is_validated` and never re-validate; startup remains the
+                // integrity gate for untrusted on-disk data.
+                zaino_db.mark_validated(block_height.0);
+            }
 
             Ok::<_, FinalisedStateError>(())
         });

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -536,9 +536,10 @@ impl DbV1 {
                 }
             }
 
-            // `txn.commit()` is durable: the LMDB env is opened without NO_SYNC, so commit
-            // fsyncs the data and meta pages. Validation below is read-only and observes the
-            // committed state without any further sync, so no explicit `env.sync` is needed here.
+            // `txn.commit()` makes the block visible to subsequent readers (LMDB MVCC), but the
+            // env is opened with `NO_SYNC`, so it is *not* fsynced here. Durability is forced at
+            // `SYNC_CHECKPOINT_INTERVAL` boundaries below and on graceful shutdown. Validation
+            // is read-only and observes the just-committed state from the map regardless of sync.
             txn.commit()?;
 
             zaino_db.validate_block_blocking(block_height, block_hash)?;
@@ -565,9 +566,17 @@ impl DbV1 {
 
         match post_result {
             Ok(_) => {
-                // The block (and its `txid_location` entries) were durably committed inside the
-                // blocking task above; validation succeeded and wrote nothing, so no extra sync.
+                // The block was committed inside the blocking task above. Under `NO_SYNC` that
+                // commit is not yet on disk; force a durability checkpoint every
+                // `SYNC_CHECKPOINT_INTERVAL` blocks so a crash can only lose a bounded tail (which
+                // the syncer re-fetches from the on-disk tip). Genesis is checkpointed too so a
+                // brand-new cache has a durable root.
                 self.status.store(StatusType::Ready);
+                if block_height.0 % SYNC_CHECKPOINT_INTERVAL == 0 {
+                    tokio::task::block_in_place(|| self.env.sync(true)).map_err(|e| {
+                        FinalisedStateError::Custom(format!("LMDB checkpoint sync failed: {e}"))
+                    })?;
+                }
                 if block.context.index.height.0 % 100 == 0 {
                     info!(
                         "Successfully committed block {} at height {} to ZainoDB.",

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -1,6 +1,26 @@
 //! ZainoDB::V1 core write functionality.
 
 use super::*;
+
+/// Cheap heap-size estimate for a buffered [`IndexedBlock`], used only to bound the bulk-sync write
+/// batch in [`DbV1::write_blocks_to_height`]. Exactness is not required — it just keeps the batch's
+/// peak memory roughly within the configured budget.
+#[cfg(not(feature = "transparent_address_history_experimental"))]
+fn approx_indexed_block_bytes(block: &IndexedBlock) -> u64 {
+    block
+        .transactions()
+        .iter()
+        .map(|tx| {
+            let transparent = tx.transparent();
+            let items = transparent.inputs().len()
+                + transparent.outputs().len()
+                + tx.sapling().spends().len()
+                + tx.sapling().outputs().len()
+                + tx.orchard().actions().len();
+            256 + items as u64 * 128
+        })
+        .sum()
+}
 #[cfg(test)]
 use crate::version;
 
@@ -74,19 +94,71 @@ impl DbWrite for DbV1 {
             height.0, network
         );
 
-        for height_int in start_height..=height.0 {
-            let block = build_indexed_block_from_source(
-                source,
-                network,
-                sapling_activation_height,
-                nu5_activation_height,
-                height_int,
-                parent_chainwork,
-            )
-            .await?;
-            parent_chainwork = block.context.chainwork;
+        // Bulk path: buffer blocks up to a byte budget, then write the whole batch in one
+        // transaction with the random-keyed `spent` / `txid_location` indexes inserted in sorted
+        // order (sequential B-tree sweep instead of random faults once the DB exceeds RAM). The
+        // address-history feature can't be batched (its prev-output resolution can't see
+        // earlier-in-batch uncommitted blocks), so it keeps the per-block path.
+        #[cfg(not(feature = "transparent_address_history_experimental"))]
+        {
+            let batch_budget = self.config.storage.database.sync_write_batch_bytes.max(1);
+            let mut next = start_height;
+            while next <= height.0 {
+                // Fetch blocks (async; an LMDB write txn is `!Send` and cannot be held across the
+                // await) until the byte budget is reached.
+                let mut batch: Vec<IndexedBlock> = Vec::new();
+                let mut batch_bytes: u64 = 0;
+                while next <= height.0 && batch_bytes < batch_budget {
+                    let block = build_indexed_block_from_source(
+                        source,
+                        network,
+                        sapling_activation_height,
+                        nu5_activation_height,
+                        next,
+                        parent_chainwork,
+                    )
+                    .await?;
+                    parent_chainwork = block.context.chainwork;
+                    batch_bytes = batch_bytes.saturating_add(approx_indexed_block_bytes(&block));
+                    batch.push(block);
+                    next += 1;
+                }
 
-            self.write_block_with_options(block, false).await?;
+                // Write + sort + commit the batch atomically, then force durability. The on-disk
+                // `headers` tip never runs ahead of the indexes, so resume is gap-free.
+                tokio::task::block_in_place(|| self.write_block_batch_blocking(&batch))?;
+                tokio::task::block_in_place(|| self.env.sync(true)).map_err(|e| {
+                    FinalisedStateError::Custom(format!("LMDB checkpoint sync failed: {e}"))
+                })?;
+
+                // Only after the batch is committed + synced do we advance the validated tip.
+                for block in &batch {
+                    self.mark_validated(block.context.index.height.0);
+                }
+                self.status.store(StatusType::Ready);
+                info!(
+                    "write_blocks_to_height: committed batch to height {} ({} blocks)",
+                    next - 1,
+                    batch.len()
+                );
+            }
+        }
+        #[cfg(feature = "transparent_address_history_experimental")]
+        {
+            for height_int in start_height..=height.0 {
+                let block = build_indexed_block_from_source(
+                    source,
+                    network,
+                    sapling_activation_height,
+                    nu5_activation_height,
+                    height_int,
+                    parent_chainwork,
+                )
+                .await?;
+                parent_chainwork = block.context.chainwork;
+
+                self.write_block_with_options(block, false).await?;
+            }
         }
 
         // Rebuild the deferred txout-set accumulator once, at the tip, via sequential scans.
@@ -883,6 +955,251 @@ impl DbV1 {
                 })
             }
         }
+    }
+
+    /// Writes a batch of strictly-consecutive blocks in a single LMDB transaction, inserting the
+    /// random-keyed `spent` and `txid_location` entries in **sorted key order**.
+    ///
+    /// Once the DB exceeds RAM, the per-block path's random-key inserts fault a different B-tree
+    /// leaf almost every time. Buffering a batch and inserting its index entries in ascending key
+    /// order turns that into a sequential sweep — each leaf is faulted in once, filled, and written
+    /// once. The height-keyed tables (`headers`/`txids`/`transparent`/`sapling`/`orchard`/
+    /// `commitment_tree_data`) are written per block in ascending height (already sequential).
+    ///
+    /// Crash-safety: the whole batch — every block's height-keyed tables **and** the batch's sorted
+    /// index entries — commits in one transaction, so the `headers` tip never runs ahead of the
+    /// indexes. A crash discards the uncommitted batch (and, under `NO_SYNC`, rolls back to the last
+    /// `env.sync`), leaving a consistent prefix the syncer resumes from. The txout-set accumulator
+    /// is **not** maintained here (deferred; the caller rebuilds it at the tip).
+    ///
+    /// Heights must be strictly consecutive and extend the current tip; this is the bulk-sync path,
+    /// which assumes a single writer. Re-writing identical data on resume is a no-op (idempotent
+    /// puts), so it is safe to re-run after an interrupted sync.
+    ///
+    /// WARNING: blocking — call from a blocking context. Only built when the experimental
+    /// address-history feature is **off**; that feature uses the per-block path (its prev-output
+    /// resolution cannot see earlier-in-batch uncommitted blocks).
+    #[cfg(not(feature = "transparent_address_history_experimental"))]
+    pub(crate) fn write_block_batch_blocking(
+        &self,
+        blocks: &[IndexedBlock],
+    ) -> Result<(), FinalisedStateError> {
+        use lmdb::Transaction as _;
+
+        if blocks.is_empty() {
+            return Ok(());
+        }
+
+        // Idempotent `NO_OVERWRITE` put: a re-seen key whose stored bytes are identical is a no-op
+        // (safe resume); a key with conflicting bytes is a genuine error.
+        fn put_idempotent(
+            txn: &mut lmdb::RwTransaction<'_>,
+            db: Database,
+            key: &[u8],
+            value: &[u8],
+        ) -> Result<(), FinalisedStateError> {
+            match txn.put(db, &key, &value, WriteFlags::NO_OVERWRITE) {
+                Ok(()) => Ok(()),
+                Err(lmdb::Error::KeyExist) => {
+                    let existing = txn.get(db, &key).map_err(FinalisedStateError::LmdbError)?;
+                    if existing == value {
+                        Ok(())
+                    } else {
+                        Err(FinalisedStateError::Custom(
+                            "conflicting existing entry during batched block write".to_string(),
+                        ))
+                    }
+                }
+                Err(e) => Err(FinalisedStateError::LmdbError(e)),
+            }
+        }
+
+        self.status.store(StatusType::Syncing);
+        let mut txn = self.env.begin_rw_txn()?;
+
+        // Seed the continuity chain from the current on-disk tip (genesis if empty).
+        let (mut prev_height, mut prev_hash): (Option<u32>, Option<BlockHash>) = {
+            let cursor = txn.open_ro_cursor(self.headers)?;
+            match cursor.get(None, None, lmdb_sys::MDB_LAST) {
+                Ok((last_height_bytes, last_header_bytes)) => {
+                    let last_height = Height::from_bytes(
+                        last_height_bytes.expect("Height is always some in the finalised state"),
+                    )?;
+                    let last_entry =
+                        StoredEntryVar::<BlockHeaderData>::from_bytes(last_header_bytes).map_err(
+                            |e| FinalisedStateError::Custom(format!("tip header decode error: {e}")),
+                        )?;
+                    (Some(last_height.0), Some(*last_entry.inner().context.hash()))
+                }
+                Err(lmdb::Error::NotFound) => (None, None),
+                Err(e) => return Err(FinalisedStateError::LmdbError(e)),
+            }
+        };
+
+        // Batch-level collectors for the random-keyed indexes; sorted before insertion below.
+        let mut spent_batch: Vec<(Vec<u8>, TxLocation)> = Vec::new();
+        let mut txid_location_batch: Vec<([u8; 32], TxLocation)> = Vec::new();
+
+        for block in blocks {
+            let block_hash = block.context.index.hash;
+            let block_hash_bytes = block_hash.to_bytes()?;
+            let block_height = block.context.index.height;
+            let block_height_bytes = block_height.to_bytes()?;
+
+            // Continuity: height = prev + 1 and parent extends the current tip (genesis if empty).
+            match prev_height {
+                Some(tip) => {
+                    if block_height.0 != tip + 1 {
+                        return Err(FinalisedStateError::Custom(format!(
+                            "cannot write block at height {block_height:?}; current tip is {tip}"
+                        )));
+                    }
+                    if Some(*block.context.parent_hash()) != prev_hash {
+                        return Err(FinalisedStateError::InvalidBlock {
+                            height: block_height.0,
+                            hash: block_hash,
+                            reason: "parent hash does not extend current tip".to_string(),
+                        });
+                    }
+                }
+                None => {
+                    if block_height.0 != GENESIS_HEIGHT.0 {
+                        return Err(FinalisedStateError::Custom(format!(
+                            "first block must be height 0, got {block_height:?}"
+                        )));
+                    }
+                }
+            }
+
+            let height_entry = StoredEntryFixed::new(&block_hash_bytes, block_height);
+            let header_entry = StoredEntryVar::new(
+                &block_height_bytes,
+                BlockHeaderData::new(block.context, *block.data()),
+            );
+            let commitment_tree_entry =
+                StoredEntryFixed::new(&block_height_bytes, *block.commitment_tree_data());
+
+            let tx_len = block.transactions().len();
+            let mut txids: Vec<TransactionHash> = Vec::with_capacity(tx_len);
+            let mut txid_set: HashSet<TransactionHash> = HashSet::with_capacity(tx_len);
+            let mut transparent: Vec<Option<TransparentCompactTx>> = Vec::with_capacity(tx_len);
+            let mut sapling = Vec::with_capacity(tx_len);
+            let mut orchard = Vec::with_capacity(tx_len);
+
+            for (tx_index, tx) in block.transactions().iter().enumerate() {
+                let hash = tx.txid();
+                if !txid_set.insert(*hash) {
+                    return Err(FinalisedStateError::InvalidBlock {
+                        height: block_height.0,
+                        hash: block_hash,
+                        reason: format!("duplicate transaction hash in block: {hash:?}"),
+                    });
+                }
+                txids.push(*hash);
+
+                let transparent_data = if tx.transparent().inputs().is_empty()
+                    && tx.transparent().outputs().is_empty()
+                {
+                    None
+                } else {
+                    Some(tx.transparent().clone())
+                };
+                transparent.push(transparent_data);
+
+                let sapling_data =
+                    if tx.sapling().spends().is_empty() && tx.sapling().outputs().is_empty() {
+                        None
+                    } else {
+                        Some(tx.sapling().clone())
+                    };
+                sapling.push(sapling_data);
+
+                let orchard_data = if tx.orchard().actions().is_empty() {
+                    None
+                } else {
+                    Some(tx.orchard().clone())
+                };
+                orchard.push(orchard_data);
+
+                let tx_index =
+                    u16::try_from(tx_index).map_err(|_| FinalisedStateError::InvalidBlock {
+                        height: block_height.0,
+                        hash: block_hash,
+                        reason: format!("transaction index {tx_index} does not fit into u16"),
+                    })?;
+                let tx_location = TxLocation::new(block_height.0, tx_index);
+
+                for input in tx.transparent().inputs().iter() {
+                    if input.is_null_prevout() {
+                        continue;
+                    }
+                    let prev_outpoint =
+                        Outpoint::new(*input.prevout_txid(), input.prevout_index());
+                    spent_batch.push((prev_outpoint.to_bytes()?, tx_location));
+                }
+
+                txid_location_batch.push(((*hash).into(), tx_location));
+            }
+
+            // Cheap in-memory correctness check: txids must reproduce the header merkle root.
+            let txid_bytes: Vec<[u8; 32]> = txids.iter().map(|t| t.0).collect();
+            let computed_merkle_root = Self::calculate_block_merkle_root(&txid_bytes);
+            if &computed_merkle_root != block.data().merkle_root() {
+                return Err(FinalisedStateError::InvalidBlock {
+                    height: block_height.0,
+                    hash: block_hash,
+                    reason: "header merkle root does not match block txids".to_string(),
+                });
+            }
+
+            let txid_entry = StoredEntryVar::new(&block_height_bytes, TxidList::new(txids));
+            let transparent_entry =
+                StoredEntryVar::new(&block_height_bytes, TransparentTxList::new(transparent));
+            let sapling_entry =
+                StoredEntryVar::new(&block_height_bytes, SaplingTxList::new(sapling));
+            let orchard_entry =
+                StoredEntryVar::new(&block_height_bytes, OrchardTxList::new(orchard));
+
+            // Height-keyed tables (+ the hash-keyed `heights`, one entry/block) written per block.
+            put_idempotent(&mut txn, self.headers, &block_height_bytes, &header_entry.to_bytes()?)?;
+            put_idempotent(&mut txn, self.heights, &block_hash_bytes, &height_entry.to_bytes()?)?;
+            put_idempotent(&mut txn, self.txids, &block_height_bytes, &txid_entry.to_bytes()?)?;
+            put_idempotent(
+                &mut txn,
+                self.transparent,
+                &block_height_bytes,
+                &transparent_entry.to_bytes()?,
+            )?;
+            put_idempotent(&mut txn, self.sapling, &block_height_bytes, &sapling_entry.to_bytes()?)?;
+            put_idempotent(&mut txn, self.orchard, &block_height_bytes, &orchard_entry.to_bytes()?)?;
+            put_idempotent(
+                &mut txn,
+                self.commitment_tree_data,
+                &block_height_bytes,
+                &commitment_tree_entry.to_bytes()?,
+            )?;
+
+            prev_height = Some(block_height.0);
+            prev_hash = Some(block_hash);
+        }
+
+        // Insert the random-keyed indexes in ascending key order so the B-tree is swept
+        // sequentially rather than faulting on scattered leaves. A duplicate key with a
+        // conflicting value (a double-spend / inconsistency) is rejected by `put_idempotent`.
+        spent_batch.sort_by(|a, b| a.0.cmp(&b.0));
+        for (key, tx_location) in &spent_batch {
+            let entry_bytes = StoredEntryFixed::new(key, *tx_location).to_bytes()?;
+            put_idempotent(&mut txn, self.spent, key, &entry_bytes)?;
+        }
+
+        txid_location_batch.sort_by(|a, b| a.0.cmp(&b.0));
+        for (key, tx_location) in &txid_location_batch {
+            let entry_bytes = StoredEntryFixed::new(key, *tx_location).to_bytes()?;
+            put_idempotent(&mut txn, self.txid_location, key, &entry_bytes)?;
+        }
+
+        txn.commit()?;
+        Ok(())
     }
 
     /// Deletes a block identified height from every finalised table.

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -187,17 +187,16 @@ use crate::{
     chain_index::{
         finalised_state::{
             capability::{CapabilityRequest, DbMetadata},
-            db::v1::{DB_VERSION_V1, SYNC_CHECKPOINT_INTERVAL, TX_OUT_SET_INFO_ACCUMULATOR_KEY},
+            db::v1::{DB_VERSION_V1, SYNC_CHECKPOINT_INTERVAL},
             entry::{StoredEntryFixed, StoredEntryVar},
         },
         source::BlockchainSource,
-        types::{db::metadata::FinalisedTxOutSetInfoAccumulator, GENESIS_HEIGHT},
+        types::GENESIS_HEIGHT,
     },
     config::BlockCacheConfig,
     error::FinalisedStateError,
     BlockHash, BlockMetadata, BlockWithMetadata, ChainWork, Height, IndexedBlock, Outpoint,
-    TransactionHash, TransparentCompactTx, TransparentTxList, TxLocation, TxidList,
-    ZainoVersionedSerde as _,
+    TransparentTxList, TxLocation, TxidList, ZainoVersionedSerde as _,
 };
 
 use lmdb::{Transaction, WriteFlags};
@@ -655,12 +654,20 @@ impl<T: BlockchainSource> Migration<T> for Migration1_0_0To1_1_0 {
 
 /// Minor migration: v1.1.0 → v1.2.0.
 ///
+/// Three stages, each rebuilt deterministically from the existing transparent block data:
+/// - **Stage A** — build the `txid_location` reverse index.
+/// - **Stage B** — build the `spent` outpoint index.
+/// - **Stage C** — build the txout-set accumulator in bulk (sequential scans) once Stage B is
+///   complete, via [`DbBackend::rebuild_tx_out_set_accumulator`].
+///
 /// Safety and resumability:
-/// - Deterministic: rebuilds the spent outpoint index and txout-set accumulator from the existing
-///   transparent block data.
-/// - Resumable: stores the next height to migrate in the metadata DB under a temporary migration key.
-/// - Crash-safe: each block's spent entries, txout-set accumulator, and progress update are
-///   committed in the same LMDB transaction.
+/// - Stages A and B are resumable from per-stage progress watermarks in the metadata DB; each
+///   height's index entries and its progress update commit in the same LMDB transaction.
+/// - Stage C **always recomputes the accumulator from scratch** from the finalised `transparent` +
+///   `spent` tables and overwrites the singleton atomically. It therefore never trusts a partial or
+///   stale accumulator — including one left behind by an interrupted *original* 2-stage migration
+///   that maintained the accumulator per block — so a partial run of either the old or new
+///   migration converges to a correct, uncorrupted result.
 /// - No shadow database.
 struct Migration1_1_0To1_2_0;
 
@@ -685,8 +692,9 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
         _source: T,
     ) -> Result<(), FinalisedStateError> {
         // Per-stage progress keys. Both are temporary metadata entries removed on completion.
-        // Stage A (`txid_location`) and Stage B (`spent` + accumulator) are tracked independently
-        // so a crash, or a part-built 0.4.0-alpha.1 cache, resumes each stage from its own marker.
+        // Stage A (`txid_location`) and Stage B (`spent`) are tracked independently so a crash, or a
+        // part-built 0.4.0-alpha.1 cache, resumes each stage from its own marker. Stage C (the
+        // accumulator) needs no progress key: it is an idempotent full rebuild keyed off the tip.
         const MIGRATION_TXID_LOCATION_PROGRESS_KEY: &[u8] =
             b"_migration_txid_location_progress_1_2_0_next_height";
         const MIGRATION_SPENT_PROGRESS_KEY: &[u8] = b"_migration_spent_progress_1_2_0_next_height";
@@ -704,7 +712,6 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
         let transparent_db = backend.transparent_db()?;
         let spent_db = backend.spent_db()?;
         let txid_location_db = backend.txid_location_db()?;
-        let tx_out_set_info_accumulator_db = backend.tx_out_set_info_accumulator_db()?;
 
         // Record that a migration is in progress (observability only; the migration resumes from
         // the per-stage progress keys below, not from `migration_status`).
@@ -879,11 +886,13 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
                 "v1.2.0 migration Stage A complete"
             );
 
-            // ===== Stage B: backfill `spent` + txout-set accumulator. =====
+            // ===== Stage B: backfill the `spent` outpoint index. =====
             //
-            // Resumes from its own progress key, preserving partial work from an interrupted alpha
+            // Resumes from its own progress key, preserving partial work from an interrupted
             // migration. If the key is absent (fresh, or a completed alpha cache rolled back to
-            // v1.1.0) it starts at genesis with an empty accumulator.
+            // v1.1.0) it starts at genesis. The accumulator is intentionally *not* touched here — it
+            // is built in full by Stage C below, so an interrupted original 2-stage migration that
+            // left a partial per-block accumulator is simply overwritten, never trusted.
             let mut next_height_to_migrate = match read_progress(MIGRATION_SPENT_PROGRESS_KEY)? {
                 Some(height) => height,
                 None => {
@@ -895,17 +904,6 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
                         metadata_db,
                         &MIGRATION_SPENT_PROGRESS_KEY,
                         &progress.to_bytes()?,
-                        WriteFlags::empty(),
-                    )?;
-
-                    let accumulator = StoredEntryFixed::new(
-                        TX_OUT_SET_INFO_ACCUMULATOR_KEY,
-                        FinalisedTxOutSetInfoAccumulator::empty(),
-                    );
-                    txn.put(
-                        tx_out_set_info_accumulator_db,
-                        &TX_OUT_SET_INFO_ACCUMULATOR_KEY,
-                        &accumulator.to_bytes()?,
                         WriteFlags::empty(),
                     )?;
 
@@ -957,30 +955,6 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
                     entry.inner().clone()
                 };
 
-                let txids = {
-                    let mut txids = Vec::with_capacity(transparent_tx_list.tx().len());
-
-                    for tx_index in 0..transparent_tx_list.tx().len() {
-                        let tx_index = u16::try_from(tx_index).map_err(|_| {
-                            FinalisedStateError::Custom(format!(
-                                "transaction index out of range at height {}",
-                                height.0
-                            ))
-                        })?;
-
-                        let tx_location = TxLocation::new(height.0, tx_index);
-
-                        let txid = router
-                            .backend(CapabilityRequest::BlockCoreExt)?
-                            .get_txid(tx_location)
-                            .await?;
-
-                        txids.push(txid);
-                    }
-
-                    txids
-                };
-
                 let transparent = transparent_tx_list.tx().to_vec();
 
                 let mut spent_map = std::collections::HashMap::new();
@@ -1015,33 +989,8 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
                     }
                 }
 
-                let tx_out_set_info_accumulator = match backend.as_ref() {
-                    DbBackend::V1(database) => {
-                        // Pair `txids` and `transparent` for the accumulator API.
-                        let transactions: Vec<(TransactionHash, Option<TransparentCompactTx>)> =
-                            txids
-                                .iter()
-                                .copied()
-                                .zip(transparent.iter().cloned())
-                                .collect();
-
-                        database
-                            .calculate_tx_out_set_info_accumulator_after_block(
-                                height,
-                                &transactions,
-                                &spent_map,
-                            )
-                            .await?
-                    }
-                    DbBackend::V0(_) => {
-                        return Err(FinalisedStateError::FeatureUnavailable(
-                            "v1 txout-set accumulator migration",
-                        ));
-                    }
-                };
-
-                // Write spent data, txout-set accumulator, and Stage B progress in the same LMDB
-                // transaction, ensuring they never drift if migration is stopped by a system crash.
+                // Write the height's spent entries and the Stage B progress watermark in the same
+                // LMDB transaction, so they never drift if the migration is stopped by a crash.
                 {
                     let mut txn = env.begin_rw_txn()?;
 
@@ -1091,18 +1040,6 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
                         }
                     }
 
-                    let tx_out_set_info_accumulator_entry = StoredEntryFixed::new(
-                        TX_OUT_SET_INFO_ACCUMULATOR_KEY,
-                        tx_out_set_info_accumulator,
-                    );
-
-                    txn.put(
-                        tx_out_set_info_accumulator_db,
-                        &TX_OUT_SET_INFO_ACCUMULATOR_KEY,
-                        &tx_out_set_info_accumulator_entry.to_bytes()?,
-                        WriteFlags::empty(),
-                    )?;
-
                     let progress = StoredEntryFixed::new(MIGRATION_SPENT_PROGRESS_KEY, height + 1);
                     txn.put(
                         metadata_db,
@@ -1137,6 +1074,24 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
                 db_tip,
                 elapsed = ?stage_b_started.elapsed(),
                 "v1.2.0 migration Stage B complete"
+            );
+
+            // ===== Stage C: build the txout-set accumulator in bulk. =====
+            //
+            // Recomputes the accumulator from scratch over the finalised `transparent` + `spent`
+            // tables (built by Stage B) and overwrites the singleton atomically. This is the step
+            // that makes the migration robust to partial prior runs: it never reads or trusts an
+            // existing accumulator, so a stale per-block accumulator from an interrupted original
+            // migration is discarded and replaced with a correct value. It is idempotent, so a crash
+            // mid-Stage-C is recovered by simply re-running the (skipped) earlier stages and
+            // rebuilding again.
+            let stage_c_started = std::time::Instant::now();
+            info!(db_tip, "v1.2.0 migration Stage C: building txout-set accumulator");
+            backend.rebuild_tx_out_set_accumulator().await?;
+            info!(
+                db_tip,
+                elapsed = ?stage_c_started.elapsed(),
+                "v1.2.0 migration Stage C complete"
             );
         }
 

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -187,7 +187,7 @@ use crate::{
     chain_index::{
         finalised_state::{
             capability::{CapabilityRequest, DbMetadata},
-            db::v1::{DB_VERSION_V1, TX_OUT_SET_INFO_ACCUMULATOR_KEY},
+            db::v1::{DB_VERSION_V1, SYNC_CHECKPOINT_INTERVAL, TX_OUT_SET_INFO_ACCUMULATOR_KEY},
             entry::{StoredEntryFixed, StoredEntryVar},
         },
         source::BlockchainSource,
@@ -576,6 +576,12 @@ impl<T: BlockchainSource> Migration<T> for Migration0To1 {
 
         info!("promoting v1 database to primary.");
 
+        // The migrated v1 data is about to become primary and v0 is wiped below. Under `NO_SYNC`
+        // the shadow's tail blocks and its `Complete` status may not be on disk yet; force them
+        // durable now so a crash during or after promotion can never lose migrated blocks that
+        // exist only in v1 (v0 is removed and cannot serve as a fallback).
+        shadow.env().sync(true)?;
+
         // Promote V1 to primary
         let db_v0 = router.promote_shadow()?;
 
@@ -844,6 +850,13 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
                     txn.commit()?;
                 }
 
+                // Durability checkpoint (the env is opened with `NO_SYNC`): bound how much
+                // backfill a crash can discard. The lost tail is re-done idempotently from the
+                // Stage A progress key on resume.
+                if next_height % SYNC_CHECKPOINT_INTERVAL == 0 {
+                    env.sync(true)?;
+                }
+
                 if next_height % 50_000 == 0 {
                     info!(
                         height = next_height,
@@ -855,6 +868,10 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
 
                 next_height = height.0 + 1;
             }
+
+            // Make the completed `txid_location` index a durable boundary so a crash during
+            // Stage B never has to re-run Stage A.
+            env.sync(true)?;
 
             info!(
                 db_tip,
@@ -1097,6 +1114,13 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
                     txn.commit()?;
                 }
 
+                // Durability checkpoint (the env is opened with `NO_SYNC`): bound how much
+                // backfill a crash can discard. The lost tail is re-done idempotently from the
+                // Stage B progress key on resume.
+                if next_height_to_migrate % SYNC_CHECKPOINT_INTERVAL == 0 {
+                    env.sync(true)?;
+                }
+
                 if next_height_to_migrate % 10_000 == 0 {
                     info!(
                         height = next_height_to_migrate,
@@ -1116,7 +1140,28 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
             );
         }
 
-        // ===== Finalise: remove both progress keys and advance metadata to v1.2.0. =====
+        // ===== Finalise: advance metadata to v1.2.0, then remove the progress keys. =====
+        //
+        // Ordering matters under `NO_SYNC`. The recorded version is the migration's completion
+        // gate, so it must become durable *before* the progress keys are removed:
+        //
+        // 1. Flush all backfilled `spent` / accumulator work so the version we are about to
+        //    record truthfully reflects on-disk state.
+        // 2. Record version v1.2.0 and force it durable. A crash before this leaves the version
+        //    < v1.2.0 with the progress keys intact, so the migration is re-selected and resumes
+        //    cheaply (the stages skip past `db_tip`, then re-finalise).
+        // 3. Only now remove the progress keys: the version gate is durably set, so they are
+        //    dead metadata. Removing them last guarantees a crash never leaves "keys deleted but
+        //    version still v1.1.0", which would force a full, wasteful re-migration.
+        env.sync(true)?;
+
+        let mut metadata: DbMetadata = router.get_metadata().await?;
+        metadata.version = <Self as Migration<T>>::TO_VERSION;
+        metadata.schema_hash = crate::chain_index::finalised_state::db::v1::DB_SCHEMA_V1_HASH;
+        metadata.migration_status = MigrationStatus::Empty;
+        router.update_metadata(metadata).await?;
+        env.sync(true)?;
+
         {
             let mut txn = env.begin_rw_txn()?;
 
@@ -1132,12 +1177,7 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
 
             txn.commit()?;
         }
-
-        let mut metadata: DbMetadata = router.get_metadata().await?;
-        metadata.version = <Self as Migration<T>>::TO_VERSION;
-        metadata.schema_hash = crate::chain_index::finalised_state::db::v1::DB_SCHEMA_V1_HASH;
-        metadata.migration_status = MigrationStatus::Empty;
-        router.update_metadata(metadata).await?;
+        env.sync(true)?;
 
         // Turn transparent history extension back on now the indices are built.
         router.extend_primary_caps(Capability::TRANSPARENT_HIST_EXT);

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -652,6 +652,59 @@ impl<T: BlockchainSource> Migration<T> for Migration1_0_0To1_1_0 {
     };
 }
 
+/// Flushes a buffered batch of `spent` entries (inserted in **sorted key order**) and advances the
+/// Stage B progress watermark to `up_to_height + 1`, all in one LMDB transaction, then forces
+/// durability.
+///
+/// Sorting turns the random-keyed `spent` B-tree inserts into a sequential sweep (each leaf faulted
+/// in once, filled, written once) instead of a random fault per insert — the cost that dominates
+/// once the DB exceeds RAM. Committing the watermark together with the entries keeps resumption
+/// exact: a crash resumes from the last committed height, re-doing only uncommitted work
+/// (idempotent via `NO_OVERWRITE` + verify-match). `buffer` is cleared on success.
+fn flush_migration_spent_batch(
+    env: &lmdb::Environment,
+    spent_db: lmdb::Database,
+    metadata_db: lmdb::Database,
+    progress_key: &[u8],
+    buffer: &mut Vec<(Vec<u8>, TxLocation)>,
+    up_to_height: Height,
+) -> Result<(), FinalisedStateError> {
+    buffer.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut txn = env.begin_rw_txn()?;
+    for (outpoint_bytes, tx_location) in buffer.iter() {
+        let entry_bytes = StoredEntryFixed::new(outpoint_bytes, *tx_location).to_bytes()?;
+        match txn.put(spent_db, outpoint_bytes, &entry_bytes, WriteFlags::NO_OVERWRITE) {
+            Ok(()) => {}
+            Err(lmdb::Error::KeyExist) => {
+                let existing = txn
+                    .get(spent_db, outpoint_bytes)
+                    .map_err(FinalisedStateError::LmdbError)?;
+                if existing != entry_bytes {
+                    return Err(FinalisedStateError::Custom(format!(
+                        "conflicting existing spent entry during batched migration for outpoint {}",
+                        hex::encode(outpoint_bytes)
+                    )));
+                }
+            }
+            Err(error) => return Err(FinalisedStateError::LmdbError(error)),
+        }
+    }
+
+    let progress = StoredEntryFixed::new(progress_key, up_to_height + 1);
+    txn.put(
+        metadata_db,
+        &progress_key,
+        &progress.to_bytes()?,
+        WriteFlags::empty(),
+    )?;
+
+    txn.commit()?;
+    env.sync(true)?;
+    buffer.clear();
+    Ok(())
+}
+
 /// Minor migration: v1.1.0 → v1.2.0.
 ///
 /// Three stages, each rebuilt deterministically from the existing transparent block data:
@@ -688,7 +741,7 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
     async fn migrate(
         &self,
         router: Arc<Router>,
-        _cfg: BlockCacheConfig,
+        cfg: BlockCacheConfig,
         _source: T,
     ) -> Result<(), FinalisedStateError> {
         // Per-stage progress keys. Both are temporary metadata entries removed on completion.
@@ -925,6 +978,13 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
             );
             let stage_b_started = std::time::Instant::now();
 
+            // Buffer spent entries across heights, then flush them in sorted key order so the
+            // random-keyed `spent` B-tree fills via a sequential sweep instead of a random fault per
+            // insert. Each flush commits the entries together with the progress watermark.
+            let batch_budget = cfg.storage.database.sync_write_batch_bytes.max(1);
+            let mut spent_buffer: Vec<(Vec<u8>, TxLocation)> = Vec::new();
+            let mut spent_buffer_bytes: u64 = 0;
+
             while next_height_to_migrate <= db_tip {
                 let height = Height::try_from(next_height_to_migrate)
                     .map_err(|error| FinalisedStateError::Custom(error.to_string()))?;
@@ -989,73 +1049,28 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
                     }
                 }
 
-                // Write the height's spent entries and the Stage B progress watermark in the same
-                // LMDB transaction, so they never drift if the migration is stopped by a crash.
-                {
-                    let mut txn = env.begin_rw_txn()?;
-
-                    for (outpoint, tx_location) in &spent_map {
-                        let outpoint_bytes = outpoint.to_bytes()?;
-                        let tx_location_entry_bytes =
-                            StoredEntryFixed::new(&outpoint_bytes, *tx_location).to_bytes()?;
-
-                        match txn.put(
-                            spent_db,
-                            &outpoint_bytes,
-                            &tx_location_entry_bytes,
-                            WriteFlags::NO_OVERWRITE,
-                        ) {
-                            Ok(()) => {}
-
-                            Err(lmdb::Error::KeyExist) => {
-                                let existing_bytes = txn
-                                    .get(spent_db, &outpoint_bytes)
-                                    .map_err(FinalisedStateError::LmdbError)?;
-
-                                let existing_entry =
-                                    StoredEntryFixed::<TxLocation>::from_bytes(existing_bytes)
-                                        .map_err(|error| {
-                                            FinalisedStateError::Custom(format!(
-                                        "corrupt existing spent entry for outpoint {:?}: {error}",
-                                        outpoint
-                                    ))
-                                        })?;
-
-                                if !existing_entry.verify(&outpoint_bytes) {
-                                    return Err(FinalisedStateError::Custom(format!(
-                                        "existing spent entry checksum mismatch for outpoint {:?}",
-                                        outpoint
-                                    )));
-                                }
-
-                                if existing_entry.inner() != tx_location {
-                                    return Err(FinalisedStateError::Custom(format!(
-                                        "conflicting spent entry for outpoint {:?} at height {}",
-                                        outpoint, height.0
-                                    )));
-                                }
-                            }
-
-                            Err(error) => return Err(FinalisedStateError::LmdbError(error)),
-                        }
-                    }
-
-                    let progress = StoredEntryFixed::new(MIGRATION_SPENT_PROGRESS_KEY, height + 1);
-                    txn.put(
-                        metadata_db,
-                        &MIGRATION_SPENT_PROGRESS_KEY,
-                        &progress.to_bytes()?,
-                        WriteFlags::empty(),
-                    )?;
-
-                    txn.commit()?;
+                // Append this height's spent entries to the batch buffer. The flush (below) sorts
+                // them by key and commits them with the progress watermark in one transaction.
+                for (outpoint, tx_location) in &spent_map {
+                    let outpoint_bytes = outpoint.to_bytes()?;
+                    spent_buffer_bytes =
+                        spent_buffer_bytes.saturating_add(outpoint_bytes.len() as u64 + 64);
+                    spent_buffer.push((outpoint_bytes, *tx_location));
                 }
 
-                // Durability checkpoint (the env is opened with `NO_SYNC`): bound how much
-                // backfill a crash can discard. The lost tail is re-done idempotently from the
-                // Stage B progress key on resume.
-                if next_height_to_migrate % SYNC_CHECKPOINT_INTERVAL == 0 {
-                    env.sync(true)?;
+                // Flush a full batch: sorted `spent` insert + progress watermark = `height + 1`,
+                // committed atomically and fsynced (env is `NO_SYNC`). A crash resumes from the last
+                // committed height; re-done work is idempotent (`NO_OVERWRITE` + verify-match).
+                if spent_buffer_bytes >= batch_budget {
+                    flush_migration_spent_batch(
+                        &env,
+                        spent_db,
+                        metadata_db,
+                        MIGRATION_SPENT_PROGRESS_KEY,
+                        &mut spent_buffer,
+                        height,
+                    )?;
+                    spent_buffer_bytes = 0;
                 }
 
                 if next_height_to_migrate % 10_000 == 0 {
@@ -1068,6 +1083,20 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
                 }
 
                 next_height_to_migrate = height.0 + 1;
+            }
+
+            // Flush the trailing partial batch (progress watermark = db tip).
+            if !spent_buffer.is_empty() {
+                let tip_height = Height::try_from(db_tip)
+                    .map_err(|error| FinalisedStateError::Custom(error.to_string()))?;
+                flush_migration_spent_batch(
+                    &env,
+                    spent_db,
+                    metadata_db,
+                    MIGRATION_SPENT_PROGRESS_KEY,
+                    &mut spent_buffer,
+                    tip_height,
+                )?;
             }
 
             info!(

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -186,7 +186,7 @@ use super::{
 use crate::{
     chain_index::{
         finalised_state::{
-            capability::{BlockTransparentExt as _, CapabilityRequest, DbMetadata},
+            capability::{CapabilityRequest, DbMetadata},
             db::v1::{DB_VERSION_V1, TX_OUT_SET_INFO_ACCUMULATOR_KEY},
             entry::{StoredEntryFixed, StoredEntryVar},
         },
@@ -196,7 +196,8 @@ use crate::{
     config::BlockCacheConfig,
     error::FinalisedStateError,
     BlockHash, BlockMetadata, BlockWithMetadata, ChainWork, Height, IndexedBlock, Outpoint,
-    TransactionHash, TransparentCompactTx, TxLocation, TxidList, ZainoVersionedSerde as _,
+    TransactionHash, TransparentCompactTx, TransparentTxList, TxLocation, TxidList,
+    ZainoVersionedSerde as _,
 };
 
 use lmdb::{Transaction, WriteFlags};
@@ -694,6 +695,7 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
         let env = backend.env();
         let metadata_db = backend.metadata_db()?;
         let txids_db = backend.txids_db()?;
+        let transparent_db = backend.transparent_db()?;
         let spent_db = backend.spent_db()?;
         let txid_location_db = backend.txid_location_db()?;
         let tx_out_set_info_accumulator_db = backend.tx_out_set_info_accumulator_db()?;
@@ -911,11 +913,32 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
             while next_height_to_migrate <= db_tip {
                 let height = Height::try_from(next_height_to_migrate)
                     .map_err(|error| FinalisedStateError::Custom(error.to_string()))?;
+                let height_bytes = height.to_bytes()?;
 
-                let transparent_tx_list = router
-                    .backend(CapabilityRequest::BlockTransparentExt)?
-                    .get_block_transparent(height)
-                    .await?;
+                // Read the stored transparent list directly from the table. This intentionally
+                // bypasses the `BlockTransparentExt` accessor, which routes through
+                // `resolve_validated_hash_or_height` → `validate_block_blocking` (merkle-root
+                // recompute + full-payload checksum verification) for every height above
+                // `validated_tip`. During migration `validated_tip` is still climbing on the
+                // background validator, so that path would re-validate the whole chain inside the
+                // backfill loop — pure redundant CPU. The data here is already on disk and trusted;
+                // Stage A reads `txids` the same raw way.
+                let transparent_tx_list = {
+                    let txn = env.begin_ro_txn()?;
+                    let raw = txn
+                        .get(transparent_db, &height_bytes)
+                        .map_err(FinalisedStateError::LmdbError)?;
+                    let entry =
+                        StoredEntryVar::<TransparentTxList>::from_bytes(raw).map_err(|error| {
+                            FinalisedStateError::Custom(format!("transparent corrupt data: {error}"))
+                        })?;
+                    if !entry.verify(&height_bytes) {
+                        return Err(FinalisedStateError::Custom(
+                            "transparent checksum mismatch".to_string(),
+                        ));
+                    }
+                    entry.inner().clone()
+                };
 
                 let txids = {
                     let mut txids = Vec::with_capacity(transparent_tx_list.tx().len());

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -674,7 +674,12 @@ fn flush_migration_spent_batch(
     let mut txn = env.begin_rw_txn()?;
     for (outpoint_bytes, tx_location) in buffer.iter() {
         let entry_bytes = StoredEntryFixed::new(outpoint_bytes, *tx_location).to_bytes()?;
-        match txn.put(spent_db, outpoint_bytes, &entry_bytes, WriteFlags::NO_OVERWRITE) {
+        match txn.put(
+            spent_db,
+            outpoint_bytes,
+            &entry_bytes,
+            WriteFlags::NO_OVERWRITE,
+        ) {
             Ok(()) => {}
             Err(lmdb::Error::KeyExist) => {
                 let existing = txn
@@ -1005,7 +1010,9 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
                         .map_err(FinalisedStateError::LmdbError)?;
                     let entry =
                         StoredEntryVar::<TransparentTxList>::from_bytes(raw).map_err(|error| {
-                            FinalisedStateError::Custom(format!("transparent corrupt data: {error}"))
+                            FinalisedStateError::Custom(format!(
+                                "transparent corrupt data: {error}"
+                            ))
                         })?;
                     if !entry.verify(&height_bytes) {
                         return Err(FinalisedStateError::Custom(
@@ -1115,7 +1122,10 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
             // mid-Stage-C is recovered by simply re-running the (skipped) earlier stages and
             // rebuilding again.
             let stage_c_started = std::time::Instant::now();
-            info!(db_tip, "v1.2.0 migration Stage C: building txout-set accumulator");
+            info!(
+                db_tip,
+                "v1.2.0 migration Stage C: building txout-set accumulator"
+            );
             backend.rebuild_tx_out_set_accumulator().await?;
             info!(
                 db_tip,

--- a/packages/zaino-state/src/chain_index/finalised_state/router.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/router.rs
@@ -353,6 +353,17 @@ impl DbWrite for Router {
             .await
     }
 
+    /// Bulk catch-up ingestion via the backend currently serving `WRITE_CORE`.
+    async fn write_blocks_to_height<S: crate::chain_index::source::BlockchainSource>(
+        &self,
+        height: Height,
+        source: &S,
+    ) -> Result<(), FinalisedStateError> {
+        self.backend(CapabilityRequest::WriteCore)?
+            .write_blocks_to_height(height, source)
+            .await
+    }
+
     /// Deletes the block at height `h` via the backend currently serving `WRITE_CORE`.
     async fn delete_block_at_height(&self, h: Height) -> Result<(), FinalisedStateError> {
         self.backend(CapabilityRequest::WriteCore)?

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -1062,6 +1062,34 @@ async fn bulk_tx_out_set_accumulator_builder_matches_incremental() {
     }
 }
 
+/// The write path must advance the validated tip itself (via the cheap in-memory parent + merkle
+/// checks), so reads never fall back to the expensive read-back validation. This must hold right
+/// after a sync completes, independent of the background validator.
+#[tokio::test(flavor = "multi_thread")]
+async fn write_path_advances_validated_tip() {
+    init_tracing();
+
+    let (_data, _db_dir, zaino_db) = load_vectors_and_spawn_and_sync_v1_zaino_db().await;
+
+    // Intentionally do NOT call `wait_until_ready` (which would let the background validator run):
+    // the bulk write path should have marked every synced height validated by the time
+    // `sync_to_height` returned.
+    let backend = zaino_db
+        .backend_for_cap(
+            crate::chain_index::finalised_state::capability::CapabilityRequest::WriteCore,
+        )
+        .unwrap();
+
+    use crate::chain_index::finalised_state::capability::DbRead;
+    let db_tip = backend.db_height().await.unwrap().unwrap();
+
+    assert_eq!(
+        backend.validated_tip_height(),
+        db_tip.0,
+        "write path must advance validated_tip to the synced tip"
+    );
+}
+
 /// Computes the canonical [`FinalisedTxOutSetInfoAccumulator`] for a fully-resolved UTXO set,
 /// used as the source of truth by the write/delete accumulator tests.
 fn accumulator_from_unspent_map(

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -1154,6 +1154,82 @@ async fn batched_sync_is_batch_size_independent() {
     );
 }
 
+/// The incremental range-update path — taken when a catch-up advances an already-built accumulator
+/// by a small range (`write_blocks_to_height`'s steady-state branch) — must produce exactly the
+/// accumulator a full from-genesis rebuild produces at the same tip, for all five fields. This is
+/// the correctness gate for `update_tx_out_set_accumulator_for_range`: with regtest coinbase
+/// maturity of 100, splitting the sync at height 100 guarantees the second segment spends outputs
+/// created in the first (exercising the `transactions` "Set B" decrement) as well as outputs both
+/// created and spent within the range (the XOR-cancel case).
+#[tokio::test(flavor = "multi_thread")]
+async fn incremental_accumulator_update_matches_full_rebuild() {
+    init_tracing();
+
+    use crate::chain_index::finalised_state::capability::{
+        CapabilityRequest, DbRead, TransparentHistExt,
+    };
+
+    let blocks = load_test_vectors().unwrap().blocks;
+    let source = build_mockchain_source(blocks);
+    let temp_dir: TempDir = tempfile::tempdir().unwrap();
+    let config = BlockCacheConfig {
+        storage: StorageConfig {
+            database: DatabaseConfig {
+                path: temp_dir.path().to_path_buf(),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        db_version: 1,
+        network: Network::Regtest(ActivationHeights::default()),
+    };
+
+    let zaino_db = ZainoDB::spawn(config, source.clone()).await.unwrap();
+
+    // First segment builds the accumulator to height 100 (no watermark yet => full rebuild),
+    // the second advances it by a 100-block range => the incremental update path under test.
+    zaino_db.sync_to_height(Height(100), &source).await.unwrap();
+
+    let backend = zaino_db
+        .backend_for_cap(CapabilityRequest::WriteCore)
+        .unwrap();
+
+    // The watermark must sit at 100 here: that (together with gap 100 <= the incremental cap)
+    // pins the next sync to the incremental branch rather than a silent rebuild fallback that
+    // would make the comparison below trivial.
+    assert_eq!(
+        backend
+            .read_tx_out_set_accumulator_built_height()
+            .await
+            .unwrap(),
+        Some(Height(100)),
+        "first segment must leave the accumulator watermark at the synced tip"
+    );
+
+    zaino_db.sync_to_height(Height(200), &source).await.unwrap();
+
+    let db_tip = backend.db_height().await.unwrap().unwrap();
+    assert_eq!(db_tip, Height(200), "both segments must have been synced");
+    assert_eq!(
+        backend
+            .read_tx_out_set_accumulator_built_height()
+            .await
+            .unwrap(),
+        Some(Height(200)),
+        "incremental update must advance the watermark to the new tip"
+    );
+
+    let incremental = backend.get_tx_out_set_info_accumulator().await.unwrap();
+    let from_genesis =
+        tokio::task::block_in_place(|| backend.build_tx_out_set_accumulator_blocking(db_tip, 1))
+            .unwrap();
+
+    assert_eq!(
+        incremental, from_genesis,
+        "incremental range-update accumulator must equal the from-genesis rebuild at the tip"
+    );
+}
+
 /// Computes the canonical [`FinalisedTxOutSetInfoAccumulator`] for a fully-resolved UTXO set,
 /// used as the source of truth by the write/delete accumulator tests.
 fn accumulator_from_unspent_map(

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -1090,6 +1090,70 @@ async fn write_path_advances_validated_tip() {
     );
 }
 
+/// Syncs the vector chain to height 200 with the given bulk-write batch budget and returns the
+/// resulting `(db tip, validated tip, txout-set accumulator)`.
+async fn sync_with_batch_budget(
+    blocks: Vec<TestVectorBlockData>,
+    sync_write_batch_bytes: u64,
+) -> (Height, u32, FinalisedTxOutSetInfoAccumulator) {
+    use crate::chain_index::finalised_state::capability::{
+        CapabilityRequest, DbRead, TransparentHistExt,
+    };
+
+    let source = build_mockchain_source(blocks);
+    let temp_dir: TempDir = tempfile::tempdir().unwrap();
+    let config = BlockCacheConfig {
+        storage: StorageConfig {
+            database: DatabaseConfig {
+                path: temp_dir.path().to_path_buf(),
+                sync_write_batch_bytes,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        db_version: 1,
+        network: Network::Regtest(ActivationHeights::default()),
+    };
+
+    let zaino_db = ZainoDB::spawn(config, source.clone()).await.unwrap();
+    zaino_db.sync_to_height(Height(200), &source).await.unwrap();
+
+    let backend = zaino_db
+        .backend_for_cap(CapabilityRequest::WriteCore)
+        .unwrap();
+    let db_tip = backend.db_height().await.unwrap().unwrap();
+    let validated_tip = backend.validated_tip_height();
+    let accumulator = backend.get_tx_out_set_info_accumulator().await.unwrap();
+
+    (db_tip, validated_tip, accumulator)
+}
+
+/// The bulk-sync result must be independent of the write-batch budget: a single huge batch and a
+/// one-block-per-batch sync of the same chain must produce an identical db tip, validated tip, and
+/// txout-set accumulator. This exercises the cross-batch continuity chaining, per-batch
+/// `validated_tip` advance, and sorted-insert flush boundaries that a single-batch sync does not.
+#[tokio::test(flavor = "multi_thread")]
+async fn batched_sync_is_batch_size_independent() {
+    init_tracing();
+
+    let blocks = load_test_vectors().unwrap().blocks;
+
+    // u64::MAX => the whole sync is one batch; 1 => every block exceeds the budget => one block per
+    // batch (a flush + commit + fsync after each block).
+    let single_batch = sync_with_batch_budget(blocks.clone(), u64::MAX).await;
+    let per_block_batches = sync_with_batch_budget(blocks, 1).await;
+
+    assert_eq!(single_batch.0, per_block_batches.0, "db tip must match");
+    assert_eq!(
+        single_batch.1, per_block_batches.1,
+        "validated tip must match"
+    );
+    assert_eq!(
+        single_batch.2, per_block_batches.2,
+        "txout-set accumulator must be independent of the write-batch budget"
+    );
+}
+
 /// Computes the canonical [`FinalisedTxOutSetInfoAccumulator`] for a fully-resolved UTXO set,
 /// used as the source of truth by the write/delete accumulator tests.
 fn accumulator_from_unspent_map(

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -1025,6 +1025,43 @@ async fn tx_out_set_info_accumulator_updates_on_write() {
     assert_eq!(expected_accumulator, actual_accumulator);
 }
 
+/// The bulk sequential accumulator builder must produce exactly the accumulator that the
+/// per-block incremental write path maintained, for every shard count. Sharding partitions the
+/// work by creating-txid prefix and recombines the partials; the result must be shard-count
+/// independent.
+#[tokio::test(flavor = "multi_thread")]
+async fn bulk_tx_out_set_accumulator_builder_matches_incremental() {
+    init_tracing();
+
+    let (_data, _db_dir, zaino_db) = load_vectors_and_spawn_and_sync_v1_zaino_db().await;
+    zaino_db.wait_until_ready().await;
+
+    use crate::chain_index::finalised_state::capability::{
+        CapabilityRequest, DbRead, TransparentHistExt,
+    };
+
+    let backend = zaino_db
+        .backend_for_cap(CapabilityRequest::WriteCore)
+        .unwrap();
+
+    let db_tip = backend.db_height().await.unwrap().unwrap();
+    let incremental = backend.get_tx_out_set_info_accumulator().await.unwrap();
+
+    // 1 = single optimal pass; >1 exercises the sharded multi-pass recombination; 256 = one
+    // first-byte value per shard (maximal sharding).
+    for shards in [1u16, 2, 4, 256] {
+        let built = tokio::task::block_in_place(|| {
+            backend.build_tx_out_set_accumulator_blocking(db_tip, shards)
+        })
+        .unwrap();
+
+        assert_eq!(
+            built, incremental,
+            "bulk builder (shards={shards}) must equal the incrementally-maintained accumulator"
+        );
+    }
+}
+
 /// Computes the canonical [`FinalisedTxOutSetInfoAccumulator`] for a fully-resolved UTXO set,
 /// used as the source of truth by the write/delete accumulator tests.
 fn accumulator_from_unspent_map(

--- a/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
+++ b/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
@@ -360,6 +360,15 @@ fn passthrough_get_block_range() {
     })
 }
 
+// Ignored: this drives the full indexer over `partial_chain_strategy` blocks, whose headers carry
+// arbitrary (invalid) merkle roots. The finalised state now validates blocks on the write path
+// (cheap merkle + parent-continuity checks), so it correctly rejects these blocks once the indexer's
+// finalised-sync reaches them. These proptest chains are not a valid input for the finalised state;
+// MockchainSource-backed tests (chain_index::tests::finalised_state::v1 + migrations) cover the
+// finalised state with valid blocks. Re-enable once the optional-db PR lands, which lets these
+// passthrough proptests run without engaging the finalised state.
+#[ignore = "proptest blocks have invalid merkle roots; finalised state rejects them. \
+            Re-enable when the optional db PR lands. Covered by MockchainSource finalised_state tests."]
 #[test]
 fn make_chain() {
     init_tracing();


### PR DESCRIPTION
Fixes: Speed up finalised-state sync & v1.1→v1.2 migration (sandblast-height stall fix)

This PR takes lessons learned in #1214 and tries to implement them within the current finalised state framework, ensuring full crash resistance and resumability (sync and migration), compatibility with #1200/#1218, ensuring that feature is not held up on sync optimisations, and compatibility with the future "small footprint db". Changes have also been kept more directed, to ease review into release, and to give us more time to discuss the larger architectural changed proposed in #1214 without blocking release.

---

  Problem

  Finalised-state sync — and the v1.1→v1.2 migration — crawls to a stall around sandblast height. The per-block work is dominated by random I/O that faults once the DB exceeds RAM:
  - the txout-set accumulator did an unbounded fan-out of random spent reads per block,
  - every written block was re-read and re-validated,
  - and the random-key index writes (spent, txid_location) faulted a scattered B-tree leaf per insert.

  This PR removes the per-block random-read amplification, takes validation off the write hot path, and converts the random-key index writes into sorted batched writes — while preserving crash-safety and resumability
  throughout.

  Changes (oldest → newest commit)

  3773b8c1 — updated 1.1.0→1.2.0 upgrade
  Adds a transparent_db() accessor so the migration’s spent-index backfill reads each block’s transparent data directly from the raw table, bypassing the validated-read path (resolve_validated_hash_or_height →
  validate_block_blocking). Fixes: the migration was re-validating the whole chain (merkle recompute + checksum) inside the backfill loop — pure redundant CPU on already-on-disk, trusted data.

  6a209039 — fixed 1.1.0→1.2.0 migration, moved db to f_sync
  Opens the LMDB env with MDB_NOSYNC and forces durability at explicit env.sync(true) checkpoints (SYNC_CHECKPOINT_INTERVAL = 1000) in the write path and migration; fixes the migration’s finalisation ordering (record the
  version gate durably before deleting progress keys). Fixes: per-commit fsync was the dominant cost now that the write path does many random-key inserts; this batches write-back while bounding crash rollback to a known
  tail. (This is the foundation the rest of the PR relies on.)

  413d1ed9 — txout-set accumulator bulk update
  Adds a sequential bulk accumulator builder (build_tx_out_set_accumulator_blocking / rebuild_tx_out_set_accumulator) that recomputes the accumulator from the finalised transparent+spent tables via sequential scans
  (XOR-multiset cancellation; in-memory per-tx unspent counting), plus a freshness watermark. Fixes: the per-block accumulator’s apply_prior_block_transitions did an unbounded fan-out of random spent reads — the primary
  stall driver. Verified equivalent to the incremental result across shard counts.

  06648b36 — batch block write (write_blocks_to_height)
  Moves the tip→height ingestion loop into the backend behind a new DbWrite::write_blocks_to_height(height, source); the v1 backend defers accumulator maintenance across the run and rebuilds it once at the tip; v0 loops
  write_block; sync_to_height delegates. DRYs write_block into write_block_with_options. Fixes: removes per-block accumulator random-reads during catch-up sync; the rebuild runs once at the tip (and only when blocks were
  actually written).

  2fb30f60 — 3-stage migration
  Splits the v1.1→v1.2 migration into Stage A (txid_location), Stage B (spent only), Stage C (bulk accumulator rebuild via the new builder). Fixes: removes the migration’s per-block accumulator fan-out. Stage C always
  recomputes from scratch, so a partially-run original (2-stage) migration is recomputed correctly, never corrupted; resumable via per-stage progress watermarks.

  58dd461d — remove validation from write path
  Replaces the post-commit validate_block_blocking re-read with two cheap in-memory checks (parent-hash continuity + merkle root) and advances validated_tip directly; full validation is now startup-only. Also fixes
  initial_block_scan to validate in ascending height order (was hash order → cache thrash + non-monotonic tip). Fixes: the per-block re-read re-faulted spent for every input; reads now hit the validated fast path and
  never re-validate after startup. (validated_tip is intentionally not persisted — an on-disk marker isn’t tamper-evident; startup remains the integrity gate.)

  df58450c — sorted batched index writes
  Sync (write_blocks_to_height) and migration Stage B now buffer work up to a configurable byte budget and write each batch in one transaction with the random-keyed spent/txid_location entries inserted in sorted key
  order. Fixes: the random-key index writes faulted a scattered B-tree leaf per insert once the DB exceeded RAM; sorted insertion turns that into a sequential sweep. New config storage.database.sync_write_batch_bytes
  (default 4 GiB). The address-history experimental feature keeps the per-block path (its prev-output resolution can’t see earlier-in-batch uncommitted blocks).
  
  88723ce — bound bulk-sync write batch by count/time; report in-flight progress
  Caps each bulk-sync write batch on the first of {byte budget, SYNC_WRITE_BATCH_MAX_BLOCKS = 100_000, SYNC_WRITE_BATCH_MAX_INTERVAL = 60s} instead of bytes alone, and logs the in-flight height (throttled to 10 s) plus
  the per-batch commit from inside write_blocks_to_height; removes the old sync_to_height reporter that polled the committed db tip. Fixes: on a fresh sync the early-chain blocks are tiny, so the byte-only budget
  buffered an enormous number of blocks before the first commit — delaying durability, inflating RAM, widening the crash-loss window, and making the reporter sit at height 0 (committed tip) so the sync looked hung. The
  count/time caps make the first commit prompt and bound memory; the new logging reports real progress (in-flight + committed). Crash-safety is unchanged: still one atomic txn + fsync per batch, resume from the committed
  tip.
  
  18ef025 — short-sync accumulator update path

  Replaces the unconditional from-genesis accumulator rebuild at the end of write_blocks_to_height with a watermark-driven dispatch: on a steady-state catch-up the accumulator is advanced by applying only the delta for
  the just-written range (DbV1::update_tx_out_set_accumulator_for_range), reading the stored accumulator + _tx_out_set_accumulator_built_height watermark, incorporating the range's created/spent outputs, and rewriting
  both in one txn + fsync. The full rebuild_tx_out_set_accumulator is kept only for the first build (no watermark) or an unusually large gap (tip − watermark > ACCUMULATOR_INCREMENTAL_MAX_GAP = 1_000, e.g. a sync
  interrupted far behind the on-disk tip).

  Fixes: the bulk rebuild added in 413d1ed re-scans the entire spent + transparent tables (a fixed chain-length cost, ~45 min on mainnet once the DB exceeds RAM). Because it ran at the end of every write_blocks_to_height
  call — and the sync loop calls that on every newly-finalised block — each new block triggered a fresh full-chain scan, so the node never reached the tip and stayed stuck "Syncing" (finalised tip pinned ~one rebuild
  behind the validator). The incremental path is O(range): for a steady-state gap of a few blocks it reads only those blocks plus a bounded number of point lookups, independent of chain length.

  Crash-safety & resumability

  Every batch commits atomically (block data + its sorted indexes, or migration spent entries + progress watermark) and fsyncs, so headers/the watermark never run ahead of the indexes. A crash rolls back to the last
  fsynced batch; sync resumes from the on-disk tip, the migration from its watermark. Re-done work is idempotent (NO_OVERWRITE + verify-match).

  Testing

  - New batched_sync_is_batch_size_independent: syncing the same chain as one huge batch vs one-block-per-batch yields an identical db tip, validated tip, and accumulator.
  - New bulk_tx_out_set_accumulator_builder_matches_incremental and write_path_advances_validated_tip.
  - Full zaino-state chain_index suite green (incl. migration crash-resume, accumulator/spent/validated-tip via the batch path).
  - proptest_blockgen::make_chain is #[ignore]d: it drives the indexer with partial_chain_strategy blocks (invalid merkle roots) that the finalised state now correctly rejects; MockchainSource tests cover the finalised
  state. Re-enable when the optional-db PR lands.

  Config

  - storage.database.sync_write_batch_bytes (default 4 GiB) — bulk-sync/migration write-batch budget; raise on large-RAM hosts (trades RAM + dirty pages against the page cache the sorted sweep needs).

  Known follow-ups (not in this PR)

  - Apply the sorted-batch treatment to migration Stage A (txid_location) — same random-write cliff as Stage B; and consider merging Stage A+B into one pass (Stage B no longer depends on txid_location).
  - Fully batch the address-history feature (resolve prev-outputs from the in-memory batch buffer).
