### PR TITLE
Add transaction and shielded-action sync throughput metrics

### DIFF
--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -654,6 +654,8 @@ impl ZainoDB {
                 };
                 parent_chainwork = chain_block.context.chainwork;
 
+                record_block_throughput(&chain_block);
+
                 self.write_block(chain_block).await?;
             }
 
@@ -971,5 +973,38 @@ impl ZainoDB {
         drop(db);
 
         Self::spawn_with_target_version(cfg, source, target_version).await
+    }
+}
+
+/// Increments the per-block throughput counters — transactions, Sapling outputs,
+/// and Orchard actions — for one indexed block. This is a no-op unless the
+/// `prometheus` feature is enabled, keeping the hot sync loop free of `#[cfg]`.
+///
+/// The counts come from data already materialized in `block` by the preceding
+/// `IndexedBlock::try_from` step, so this adds no I/O or parsing — only a walk
+/// over in-memory vectors and a few integer adds.
+///
+/// These are monotonic counters so `rate(...)` over them yields sync speed measured
+/// in transactions/sec and shielded-actions/sec, which tracks indexing work far more
+/// faithfully than blocks/sec: early-chain blocks are near-empty, while post-NU5
+/// blocks can carry thousands of note commitments per block. Sapling outputs and
+/// Orchard actions are reported separately (sum them in PromQL for total shielded
+/// throughput) rather than conflated under one ambiguous "actions" name.
+#[inline]
+fn record_block_throughput(_block: &IndexedBlock) {
+    #[cfg(feature = "prometheus")]
+    {
+        let transactions = u64::try_from(_block.transactions().len()).unwrap_or(u64::MAX);
+        let mut sapling_outputs: u64 = 0;
+        let mut orchard_actions: u64 = 0;
+        for tx in _block.transactions() {
+            sapling_outputs = sapling_outputs
+                .saturating_add(u64::try_from(tx.sapling().outputs().len()).unwrap_or(u64::MAX));
+            orchard_actions = orchard_actions
+                .saturating_add(u64::try_from(tx.orchard().actions().len()).unwrap_or(u64::MAX));
+        }
+        metrics::counter!("zaino.sync.transactions_total").increment(transactions);
+        metrics::counter!("zaino.sync.sapling_outputs_total").increment(sapling_outputs);
+        metrics::counter!("zaino.sync.orchard_actions_total").increment(orchard_actions);
     }
 }

--- a/packages/zainod/src/metrics.rs
+++ b/packages/zainod/src/metrics.rs
@@ -44,4 +44,20 @@ fn describe_metrics() {
         "zaino.chain.tip_height",
         "Latest chain tip height reported by the validator"
     );
+
+    // Throughput counters. `rate()` over these gives sync speed in
+    // transactions/sec and shielded-actions/sec, which tracks indexing work more
+    // faithfully than blocks/sec since per-block content varies wildly by height.
+    metrics::describe_counter!(
+        "zaino.sync.transactions_total",
+        "Total transactions indexed during sync"
+    );
+    metrics::describe_counter!(
+        "zaino.sync.sapling_outputs_total",
+        "Total Sapling outputs indexed during sync"
+    );
+    metrics::describe_counter!(
+        "zaino.sync.orchard_actions_total",
+        "Total Orchard actions indexed during sync"
+    );
 }


### PR DESCRIPTION
## Summary

Sync speed has so far only been observable in **blocks/sec**, which understates indexing work: early-chain blocks are near-empty while post-NU5 blocks can carry thousands of note commitments each. This adds workload-based throughput counters so sync speed can be read in transactions/sec and shielded-actions/sec.

Builds on the `/metrics` endpoint from #1216.

## Metrics added

Three monotonic counters, emitted from the `sync_to_height` loop behind the existing `prometheus` feature (no-op when the feature is off):

| Metric (scraped name) | Meaning |
|---|---|
| `zaino_sync_transactions_total` | Total transactions indexed during sync |
| `zaino_sync_sapling_outputs_total` | Total Sapling outputs indexed during sync |
| `zaino_sync_orchard_actions_total` | Total Orchard actions indexed during sync |

Example PromQL:

```promql
rate(zaino_sync_transactions_total[5m])                                            # tx/sec
rate(zaino_sync_sapling_outputs_total[5m]) + rate(zaino_sync_orchard_actions_total[5m])  # shielded actions/sec
```

## Notes

- **No observer-effect cost on the hot path.** Counts are read from data already materialized in the `IndexedBlock` by the preceding `IndexedBlock::try_from` step — just a walk over in-memory vectors and a few integer adds. No I/O, no parsing, no allocation.
- Sapling outputs and Orchard actions are kept as **separate** counters (sum in PromQL for total shielded throughput) rather than conflated under one ambiguous "actions" name.
- Descriptions registered alongside the existing gauges in `zainod`'s `describe_metrics`.
- Verified `cargo check` clean both with `--features prometheus` and in the default (feature-off) build.

A follow-up Grafana dashboard update will add tx/sec and actions/sec panels.