### PR TITLE
Update zebra-* dependencies to ZcashFoundation/zebra@9a27f886a5bfb143f65d1712e912cef252426800

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[env]
+# Workaround for GCC 15+: zebra's librocksdb-sys vendored C++ relies on transitive <cstdint>.
+CXXFLAGS = { value = "-include cstdint", force = false, relative = false }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4702,8 +4702,7 @@ dependencies = [
 [[package]]
 name = "tower-batch-control"
 version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6cf52578f98b4da47335c26c4f883f7993b1a9b9d2f5420eb8dbfd5dd19a28"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
 dependencies = [
  "futures",
  "futures-core",
@@ -4719,8 +4718,7 @@ dependencies = [
 [[package]]
 name = "tower-fallback"
 version = "0.2.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434e19ee996ee5c6aa42f11463a355138452592e5c5b5b73b6f0f19534556af"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -5890,8 +5888,7 @@ dependencies = [
 [[package]]
 name = "zebra-chain"
 version = "10.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a32562497425712e17b78c42d73bb69560053205653bb6b6e3e1aed6217ec"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
 dependencies = [
  "bech32",
  "bitflags 2.13.0",
@@ -5959,8 +5956,7 @@ dependencies = [
 [[package]]
 name = "zebra-consensus"
 version = "9.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c5b49c3cfef4df307ed6f6e8b1bd8cf0baa475c6841620bc17f9e9f53f8e77"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6002,8 +5998,7 @@ dependencies = [
 [[package]]
 name = "zebra-network"
 version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d957623f215fcc049ef1178efba186440ac17c05ceeb68edf8f2999ce7f6eca8"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
 dependencies = [
  "bitflags 2.13.0",
  "byteorder",
@@ -6040,8 +6035,7 @@ dependencies = [
 [[package]]
 name = "zebra-node-services"
 version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799017e2ade4fd2169bd4e14ddcbe180b62332e0b8d2ec9745d3256d8482684d"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -6056,8 +6050,7 @@ dependencies = [
 [[package]]
 name = "zebra-rpc"
 version = "10.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eedf51b44db5c6c8b21aad40e88746a858185b812680e210a7eb44189489cf9"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
 dependencies = [
  "base64",
  "chrono",
@@ -6116,8 +6109,7 @@ dependencies = [
 [[package]]
 name = "zebra-script"
 version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "851f8533916035873c1543945bc425d7b7f3b1daa68a1ba2ba700a0714e75a8d"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
 dependencies = [
  "libzcash_script",
  "rand 0.8.6",
@@ -6130,8 +6122,7 @@ dependencies = [
 [[package]]
 name = "zebra-state"
 version = "9.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f75fbe6845c042d64608664f3c66550c6cd9ed09efbd71a3849c617c14da137"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
 dependencies = [
  "bincode",
  "chrono",
@@ -6168,8 +6159,7 @@ dependencies = [
 [[package]]
 name = "zebra-test"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2b1e773cbe0e9377e6c73f7a45be4e33db3bd92738545e877131a054c60aec"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
 dependencies = [
  "color-eyre",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,11 @@ cargo-lock = "10.1.0"
 derive_more = "2.0.1"
 lazy_static = "1.5.0"
 
+[profile.test]
+opt-level = 3
+debug = true
+
+[patch.crates-io]
 #zcash_client_backend = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
 #zcash_address = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
 #zcash_keys = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
@@ -155,6 +160,6 @@ lazy_static = "1.5.0"
 #zcash_protocol = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
 #zcash_transparent = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
 
-[profile.test]
-opt-level = 3
-debug = true
+zebra-chain = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "9a27f886a5bfb143f65d1712e912cef252426800" }
+zebra-rpc = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "9a27f886a5bfb143f65d1712e912cef252426800" }
+zebra-state = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "9a27f886a5bfb143f65d1712e912cef252426800" }

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/ephemeral.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/ephemeral.rs
@@ -33,9 +33,6 @@ use crate::{BlockContext, BlockMetadata, BlockWithMetadata, ChainWork, NamedAtom
 
 use zaino_proto::proto::utils::{compact_block_with_pool_types, PoolTypeFilter};
 
-#[cfg(feature = "transparent_address_history_experimental")]
-use crate::{chain_index::types::AddrEventBytes, AddrScript};
-
 const EPHEMERAL_FINALISED_STATE_STATUS_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Source-backed finalised-state backend used when persistent finalised-state storage is not

--- a/packages/zaino-state/src/chain_index/source/validator_connector.rs
+++ b/packages/zaino-state/src/chain_index/source/validator_connector.rs
@@ -1059,7 +1059,11 @@ impl BlockchainSource for ValidatorConnector {
             }) => {
                 match read_state_service
                     .clone()
-                    .call(zebra_state::ReadRequest::NonFinalizedBlocksListener)
+                    // Empty `known_chain_tips` requests every block currently in the
+                    // non-finalized state (the prior unit-variant behaviour).
+                    .call(zebra_state::ReadRequest::NonFinalizedBlocksListener {
+                        known_chain_tips: Default::default(),
+                    })
                     .await
                 {
                     Ok(ReadResponse::NonFinalizedBlocksListener(listener)) => {


### PR DESCRIPTION
This updates to the in-flight ZcashFoundation/zebra@9a27f886a5bfb143f65d1712e912cef252426800 that is intended to be included in the next round of zebrad releases. It provides functionality to allow use of Zebra's internal logic for finding the fork point relative to Zebra's current "best chain" tip given a block locator, which Zallet depends upon. Zebra is able to find the fork point much more efficiently than an external client is able to because they have an indexed in-memory tree of all of the current chain branches that isn't otherwise exposed (except as chain tips) to consumers.