### PR TITLE
Persistent finalised-state: version-graph migrations + config-driven major selection

### DIFF
--- a/docs/adr/0002-persistent-finalised-state-migrations.md
+++ b/docs/adr/0002-persistent-finalised-state-migrations.md
@@ -1,0 +1,249 @@
+# Persistent finalised-state versioning and migrations
+
+## Status
+
+accepted
+
+## Constraints (spec)
+
+The *persistent finalised state* (the on-disk database backing `FinalisedState`,
+as opposed to the *ephemeral finalised state* that serves from the backing
+validator) evolves under a versioned schema. These constraints are the binding
+contract for that evolution. A migration that violates any of them is a bug,
+regardless of whether it appears to work in the common case.
+
+**C1 — One authoritative version fingerprint.** `DbMetadata::version`, a single
+`DbVersion {major, minor, patch}` persisted inside each database directory, is
+the *sole* source of truth for the version of the data in that directory. There
+is no separate set of "applied migrations".
+
+**C2 — Versions form a forward-only graph; migrations are its edges.** Each
+migration maps one exact `DbVersion` to the next. Reaching a target version is
+finding a path through that graph from the current fingerprint and running its
+edges in order. A missing path is a hard error, never an unsafe fallback.
+Downgrades are not edges (see C7).
+
+**C3 — Every migration is exactly one of three types**, distinguished by the
+version boundary it crosses, and the type fixes both its meaning and its
+lifecycle:
+
+- **patch** — code-only; the on-disk schema is byte-for-byte unchanged. Only the
+  version marker advances. No body.
+- **minor** — a schema/data change **within the same major version**. Always
+  engineer-implemented (inherently bespoke): the rebuild may read from data
+  already on disk and/or refetch from the validator, at the engineer's
+  discretion.
+- **major** — a switch **between major versions** (a new directory/backend,
+  possibly a different storage engine). By default it builds the new major from
+  the backing validator from scratch, which produces the *newest available*
+  version of that major — so the default path lands directly on that newest
+  version and does **not** separately run the new major's intermediate
+  minor/patch migrations. The body is overridable: an engineer may implement a
+  faster strategy (e.g. building the new major from the current primary's data
+  instead of refetching from the validator).
+
+  Rule of thumb: code-only, no schema change → *patch*; a change within a major →
+  *minor*; a change of major → *major*.
+
+**C4 — Resumable.** A migration interrupted at any point (crash, kill, power loss)
+resumes correctly on the next startup from durable progress, and never restarts in
+a way that destroys correct work or double-applies a non-idempotent step.
+
+**C5 — Single completion gate.** The persisted `DbMetadata::version` is the only
+signal that a migration finished. It is made durable (fsync) **before** any
+irreversible cleanup (e.g. deleting an old major). A crash before the gate leaves
+the version unchanged, so the migration is re-selected and resumes; a crash after
+it leaves only dead, reclaimable state.
+
+**C6 — No corruption, no partial promotion.**
+- A **minor** migration mutates the one primary in place, is idempotent on resume,
+  and does not advance `DbMetadata::version` until the rebuild is complete and
+  durable.
+- A **major** migration never mutates the existing primary. The new backend is
+  exposed only by an atomic primary swap, and only after it is fully built and
+  fsynced. A crash at any point leaves the existing primary intact and
+  authoritative; a half-built database is never served.
+
+**C7 — Authoritative selection from disk alone; downgrades are selection.** On
+startup, the live primary is chosen from on-disk state. A directory is
+*Authoritative* (a fully-synced DB — including one that crashed mid-patch or
+mid-minor, whose data is complete at the old version) or *IncompleteBuild* (a
+major build target still being built; its metadata is stamped in-progress before
+any data is written and cleared only at the completion gate, or it is
+missing/partial). An IncompleteBuild directory is never opened as primary.
+Selecting an older major that still exists on disk is *selection* of an
+Authoritative directory, not a reverse migration.
+
+**C8 — Major directories may coexist; retention governs deletion.**
+`DatabaseConfig::old_db_retention` (default **Keep**) decides whether the old
+major's directory survives a successful promotion. **Keep** enables instant
+switch-back (no rebuild) at the cost of disk; **Delete** reclaims disk and makes a
+later switch-back a fresh build. Deletion runs only after the completion gate is
+durable.
+
+## Implementation
+
+The model lives under
+`packages/zaino-state/src/chain_index/finalised_state/`.
+
+**Version registry and planner** (`migrations.rs`). The supported migrations are a
+single authored list passed to the `migrations! { … }` macro, which generates the
+`MigrationStep` enum, its static dispatch (no `dyn`), and the planner's `(from,
+to)` edge list — satisfying C2 from one place. `plan_migrations(current, target)`
+builds the adjacency from those edges and computes a deterministic path, erroring
+when none exists. `MigrationManager::migrate()` computes the plan once and runs
+the steps in order, advancing the working version to each step's `TO_VERSION`.
+
+**The `Migration<T>` trait** carries `CURRENT_VERSION` / `TO_VERSION` (C1's
+fingerprints as graph nodes), `from_version()` / `to_version()`, and
+`migration_type()` (default `Patch`). Its default `migrate()` implements the
+generic behaviour for the non-bespoke types: a metadata-only advance for **patch**,
+and the build-and-promote helper for **major** (keyed off `TO_VERSION.major`).
+Default impls keep patch and major bodies empty (C3).
+
+A **minor** migration must override `migrate()`. A true compile-time check is not
+expressible here, because the migration type is a runtime discriminant
+(`migration_type()`) and the default body cannot know at compile time whether it
+was overridden. The default `migrate()` therefore guards against a `Minor` that
+reached it (i.e. did not override) by failing immediately, before any work, with a
+clear error naming the migration. This is backed by a registry test asserting that
+every registered `Minor` overrides the default.
+
+The **default major** `migrate()` builds the new major from scratch, which yields
+the newest version of that major. Its `TO_VERSION` is therefore
+`latest_version_for_major(new_major)`, and the from-scratch build subsumes — does
+not separately run — the new major's intermediate minor/patch migrations.
+
+**Per-type lifecycle is owned by `MigrationManager`**, so bodies stay minimal:
+- *patch* runs against the primary and advances `DbMetadata`; no ephemeral.
+- *minor* installs a full-mode ephemeral reference
+  (`Router::init_or_take_ephemeral(EphemeralMode::Full)`) so reads are served from
+  the validator while the primary is rebuilt (from on-disk data and/or a validator
+  refetch), runs the body, advances `DbMetadata`, and releases the reference (C6
+  minor).
+- *major* runs the build-and-promote helper (below), which manages its own brief
+  ephemeral freeze.
+
+**Build-and-promote helper** (`migrations.rs`, the default major path), realising
+C4–C6 for majors:
+1. `FinalisedSource::spawn_major(target_major, cfg)` spawns the target backend in
+   its own directory and, as its first durable action, stamps the directory's
+   `DbMetadata` with an in-progress status so a crash classifies it as
+   *IncompleteBuild* (C7).
+2. It syncs the target backend to tip from the `BlockchainSource` while the
+   existing primary keeps serving read+write; the build resumes from the target
+   backend's own append-only tip (C4), and the existing primary is never mutated
+   (C6).
+3. A brief ephemeral freeze does the final catch-up, then the **completion gate**:
+   the target backend's `DbMetadata` is set to the target version — the newest
+   version of the new major (`latest_version_for_major`) — and fsynced (C5). Only
+   now is the directory *Authoritative*.
+4. `Router::replace_primary` atomically swaps the new backend in as primary, and
+   the ephemeral reference is released.
+5. The old primary is shut down and its directory is kept or deleted per
+   `old_db_retention` (C8).
+
+**Startup selection** (`finalised_state.rs`). `detect_majors_on_disk(cfg)`
+enumerates the legacy v0 layout and each versioned major directory
+(`finalised_source::VERSION_DIRS`) and reads each one's `DbMetadata`, classifying
+it *Authoritative* or *IncompleteBuild* (C7). `latest_version_for_major(major)`
+maps the configured major to its latest `DbVersion` (`major 1 => DB_VERSION_V1`).
+`FinalisedState::spawn` then, for the configured target major:
+1. target directory *Authoritative* → open it; the planner resumes any in-flight
+   patch/minor and migrates forward to that major's latest;
+2. target directory absent or *IncompleteBuild* → open the best *Authoritative
+   older* major to keep serving, and run/resume the major migration to the target
+   (the half-built target is never served);
+3. no *Authoritative* directory → build the target major fresh from genesis.
+
+A crashed major migration needs no special path: the older directory is
+Authoritative, the configured target is the new major, so the planner re-selects
+the same major edge and the helper resumes the partial build (C2 + C4).
+
+**Configuration.** `DatabaseConfig::old_db_retention: OldDbRetention { Keep,
+Delete }` (default `Keep`, `packages/zaino-common/src/config/storage.rs`) is
+threaded through `ChainIndexConfig` (`packages/zaino-state/src/config.rs`) and read
+by the major helper (C8).
+
+## Engineer / dev guide
+
+Adding a supported version is "write a small `impl` and add one line to the
+registry". Choose the type by C3's rule of thumb.
+
+**Patch** — schema unchanged; only the version marker advances:
+
+```rust
+struct Migration1_2_0To1_2_1;
+impl<T: BlockchainSource> Migration<T> for Migration1_2_0To1_2_1 {
+    const CURRENT_VERSION: DbVersion = DbVersion::new(1, 2, 0);
+    const TO_VERSION:      DbVersion = DbVersion::new(1, 2, 1);
+    // default migration_type() = Patch, default migrate() = metadata-only
+}
+```
+
+**Major** — switch to a new major; default builds from the validator to that
+major's newest version:
+
+```rust
+struct Migration1_2_1To2_0_0;
+impl<T: BlockchainSource> Migration<T> for Migration1_2_1To2_0_0 {
+    const CURRENT_VERSION: DbVersion = DbVersion::new(1, 2, 1);
+    // TO_VERSION is the NEWEST version of the new major: the default from-scratch
+    // build lands there directly, skipping that major's minor/patch migrations.
+    const TO_VERSION:      DbVersion = DbVersion::new(2, 0, 0);
+    fn migration_type(&self) -> MigrationType { MigrationType::Major }
+    // default migrate() = build-and-promote from the validator, keyed off
+    // TO_VERSION.major. Override migrate() for a bespoke major — e.g. building
+    // the new major from the current primary's data instead of refetching.
+}
+```
+
+**Minor** — schema/data change within the same major; inherently bespoke:
+
+```rust
+struct Migration1_1_0To1_2_0;
+impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
+    const CURRENT_VERSION: DbVersion = DbVersion::new(1, 1, 0);
+    const TO_VERSION:      DbVersion = DbVersion::new(1, 2, 0);
+    fn migration_type(&self) -> MigrationType { MigrationType::Minor }
+    async fn migrate(&self, /* router, cfg, source */) -> Result<(), FinalisedStateError> {
+        // Rebuild the affected table(s) from data already on disk and/or by
+        // refetching from the validator. MUST be resumable and idempotent on
+        // resume (C4), and MUST NOT advance DbMetadata::version until the rebuild
+        // is complete and durable (C6).
+    }
+}
+```
+
+Then register the type so the planner gains its edge:
+
+```rust
+migrations! {
+    Migration1_0_0To1_1_0,
+    Migration1_1_0To1_2_0,
+    Migration1_2_0To1_2_1,
+    // Migration1_2_1To2_0_0,  // when DbV2 lands
+}
+```
+
+**Also update the version constants** in the versions module — the registry edge
+and the latest-version source of truth must agree:
+
+- *patch / minor*: bump the affected major's latest-version constant (e.g.
+  `DB_VERSION_V1`) to the new `TO_VERSION`, so fresh databases and
+  `latest_version_for_major` target it.
+- *major*: add the new major's latest-version constant, add its
+  `latest_version_for_major` arm (so the default major build targets the newest
+  version — see above), and append its directory to `VERSION_DIRS`.
+
+Adding a new **major backend** (e.g. DbV2): implement the backend, add its
+`FinalisedSource` variant and `FinalisedSource::spawn_major` arm, append its
+directory to `VERSION_DIRS`, add its latest-version constant and
+`latest_version_for_major` arm, and add its (major) migration line to the
+registry. Its build-and-promote behaviour is inherited.
+
+**Review checklist** for any change under `finalised_state/` that adds or alters a
+migration: confirm C4 (resumable), C5 (completion gate ordering), and C6 (no
+partial promotion / in-place idempotence) by reading the body, not by assuming
+the common path. Minor migrations especially must not advance the version marker
+before the rebuild is durable.

--- a/docs/adr/0002-persistent-finalised-state-migrations.md
+++ b/docs/adr/0002-persistent-finalised-state-migrations.md
@@ -121,8 +121,10 @@ not separately run — the new major's intermediate minor/patch migrations.
   the validator while the primary is rebuilt (from on-disk data and/or a validator
   refetch), runs the body, advances `DbMetadata`, and releases the reference (C6
   minor).
-- *major* runs the build-and-promote helper (below), which manages its own brief
-  ephemeral freeze.
+- *major* runs the build-and-promote helper (below). It needs **no** ephemeral routing: during a
+  migration the indexer is paused by the background-op guard (`sync_to_height` early-returns on
+  `has_background_ops`), so the old primary is static and read-served throughout, and the new backend
+  is built independently and swapped in atomically.
 
 **Build-and-promote helper** (`migrations.rs`, the default major path), realising
 C4–C6 for majors:
@@ -130,18 +132,17 @@ C4–C6 for majors:
    its own directory and, as its first durable action, stamps the directory's
    `DbMetadata` with an in-progress status so a crash classifies it as
    *IncompleteBuild* (C7).
-2. It syncs the target backend to tip from the `BlockchainSource` while the
-   existing primary keeps serving read+write; the build resumes from the target
-   backend's own append-only tip (C4), and the existing primary is never mutated
-   (C6).
-3. A brief ephemeral freeze does the final catch-up, then the **completion gate**:
-   the target backend's `DbMetadata` is set to the target version — the newest
-   version of the new major (`latest_version_for_major`) — and fsynced (C5). Only
-   now is the directory *Authoritative*.
-4. `Router::replace_primary` atomically swaps the new backend in as primary, and
-   the ephemeral reference is released.
-5. The old primary is shut down and its directory is kept or deleted per
-   `old_db_retention` (C8).
+2. It builds the target backend up to the old primary's tip from the
+   `BlockchainSource`. The old primary is *static* for the duration (the indexer
+   is paused by the background-op guard) and is never mutated, so it keeps serving
+   reads and a crash leaves it intact (C6). The build resumes from the target
+   backend's own append-only tip (C4).
+3. **Completion gate**: the target backend's `DbMetadata` is set to the target
+   version — the newest version of the new major — and fsynced (C5). Only now is
+   the directory *Authoritative*.
+4. `Router::replace_primary` atomically swaps the new backend in as primary; the
+   demoted old primary is shut down.
+5. The old primary's directory is kept or deleted per `old_db_retention` (C8).
 
 **Startup selection** (`finalised_state.rs`). `detect_majors_on_disk(cfg)`
 enumerates the legacy v0 layout and each versioned major directory

--- a/packages/zaino-common/src/config/storage.rs
+++ b/packages/zaino-common/src/config/storage.rs
@@ -106,6 +106,27 @@ impl AccumulatorRebuildMemorySize {
     }
 }
 
+/// Retention policy for a *previous* major's database directory after a major switch/promotion.
+///
+/// Major database directories may coexist on disk (e.g. `mainnet/v1/` and `mainnet/v2/`). After a
+/// successful major migration promotes a new major to primary, this controls what happens to the old
+/// major's directory:
+/// - [`OldDbRetention::Keep`] leaves it on disk so switching back to that major is instant (no
+///   rebuild), at the cost of disk space.
+/// - [`OldDbRetention::Delete`] removes it to reclaim disk; switching back later triggers a fresh
+///   build.
+///
+/// Defaults to [`OldDbRetention::Keep`] (the safe, no-data-loss choice).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum OldDbRetention {
+    /// Keep the old major's directory after promotion (instant switch-back; uses more disk).
+    #[default]
+    Keep,
+    /// Delete the old major's directory after promotion (reclaims disk; switching back rebuilds).
+    Delete,
+}
+
 /// Database configuration.
 ///
 /// Configures the file path and size limits for persistent storage
@@ -157,6 +178,13 @@ pub struct DatabaseConfig {
     /// crash-loss / corruption window. Defaults to 120 seconds (2 minutes).
     #[serde(default = "default_sync_checkpoint_interval")]
     pub sync_checkpoint_interval: u64,
+
+    /// Retention policy for a previous major's database directory after a major switch.
+    ///
+    /// See [`OldDbRetention`]. Defaults to [`OldDbRetention::Keep`]. Read at the chain-index layer
+    /// during major migrations; not yet surfaced in higher-layer (e.g. `zainod`) config.
+    #[serde(default)]
+    pub old_db_retention: OldDbRetention,
 }
 
 /// Default [`DatabaseConfig::sync_checkpoint_interval`]: 120 seconds (2 minutes).
@@ -172,6 +200,7 @@ impl Default for DatabaseConfig {
             sync_write_batch_size: SyncWriteBatchSize::default(),
             accumulator_rebuild_memory_size: AccumulatorRebuildMemorySize::default(),
             sync_checkpoint_interval: default_sync_checkpoint_interval(),
+            old_db_retention: OldDbRetention::default(),
         }
     }
 }
@@ -201,6 +230,12 @@ mod tests {
             AccumulatorRebuildMemorySize(8)
         );
         assert_eq!(database.sync_checkpoint_interval, 120);
+    }
+
+    #[test]
+    fn default_old_db_retention_is_keep() {
+        assert_eq!(OldDbRetention::default(), OldDbRetention::Keep);
+        assert_eq!(DatabaseConfig::default().old_db_retention, OldDbRetention::Keep);
     }
 
     #[test]

--- a/packages/zaino-common/src/config/storage.rs
+++ b/packages/zaino-common/src/config/storage.rs
@@ -235,7 +235,10 @@ mod tests {
     #[test]
     fn default_old_db_retention_is_keep() {
         assert_eq!(OldDbRetention::default(), OldDbRetention::Keep);
-        assert_eq!(DatabaseConfig::default().old_db_retention, OldDbRetention::Keep);
+        assert_eq!(
+            DatabaseConfig::default().old_db_retention,
+            OldDbRetention::Keep
+        );
     }
 
     #[test]

--- a/packages/zaino-common/src/lib.rs
+++ b/packages/zaino-common/src/lib.rs
@@ -18,8 +18,8 @@ pub use net::{resolve_socket_addr, try_resolve_address, AddressResolution};
 pub use config::network::{ActivationHeights, Network, ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS};
 pub use config::service::ServiceConfig;
 pub use config::storage::{
-    AccumulatorRebuildMemorySize, CacheConfig, DatabaseConfig, DatabaseSize, StorageConfig,
-    SyncWriteBatchSize,
+    AccumulatorRebuildMemorySize, CacheConfig, DatabaseConfig, DatabaseSize, OldDbRetention,
+    StorageConfig, SyncWriteBatchSize,
 };
 pub use config::validator::ValidatorConfig;
 

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -458,7 +458,9 @@ impl<T: BlockchainSource> FinalisedState<T> {
 
             let target_major = cfg.db_version;
             let target_version = latest_version_for_major(target_major).ok_or_else(|| {
-                FinalisedStateError::Custom(format!("unsupported database version: DbV{target_major}"))
+                FinalisedStateError::Custom(format!(
+                    "unsupported database version: DbV{target_major}"
+                ))
             })?;
 
             // Open the serving primary per the ADR 0002 selection rules, honouring the configured
@@ -1196,9 +1198,63 @@ impl<T: BlockchainSource> FinalisedState<T> {
 #[cfg(test)]
 mod selection_tests {
     use super::*;
+    use crate::chain_index::source::mockchain_source::MockchainSource;
+    use zaino_common::{network::ActivationHeights, DatabaseConfig, Network, StorageConfig};
 
     fn metadata_with(status: MigrationStatus) -> DbMetadata {
         DbMetadata::new(DB_VERSION_V1, [0u8; 32], status)
+    }
+
+    fn regtest_cfg(path: std::path::PathBuf) -> ChainIndexConfig {
+        ChainIndexConfig {
+            storage: StorageConfig {
+                database: DatabaseConfig {
+                    path,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ephemeral: false,
+            db_version: 1,
+            network: Network::Regtest(ActivationHeights::default()),
+        }
+    }
+
+    /// Writes empty `data.mdb` + `lock.mdb` into `dir` to mimic a present LMDB database.
+    fn write_lmdb_files(dir: &std::path::Path) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join("data.mdb"), b"").unwrap();
+        std::fs::write(dir.join("lock.mdb"), b"").unwrap();
+    }
+
+    #[test]
+    fn detect_major_dirs_finds_present_versioned_majors() {
+        let temporary_directory = tempfile::tempdir().unwrap();
+        let cfg = regtest_cfg(temporary_directory.path().to_path_buf());
+
+        // Nothing on disk yet.
+        assert!(FinalisedState::<MockchainSource>::detect_major_dirs(&cfg).is_empty());
+
+        // A populated v1 directory is detected as major 1.
+        write_lmdb_files(&temporary_directory.path().join("regtest").join("v1"));
+        assert_eq!(
+            FinalisedState::<MockchainSource>::detect_major_dirs(&cfg)
+                .into_iter()
+                .collect::<Vec<_>>(),
+            vec![1],
+        );
+    }
+
+    #[test]
+    fn legacy_v0_layout_is_detected() {
+        let temporary_directory = tempfile::tempdir().unwrap();
+        let cfg = regtest_cfg(temporary_directory.path().to_path_buf());
+
+        assert!(!FinalisedState::<MockchainSource>::legacy_v0_present(&cfg));
+
+        // Regtest's legacy directory is `local/`.
+        write_lmdb_files(&temporary_directory.path().join("local"));
+        assert!(FinalisedState::<MockchainSource>::legacy_v0_present(&cfg));
     }
 
     #[test]

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -636,18 +636,12 @@ impl<T: BlockchainSource> FinalisedState<T> {
 
     /// Opens the backend for a specific major version.
     ///
-    /// Maps a major to its concrete `FinalisedSource` backend. (Step 5 promotes this to
-    /// `FinalisedSource::spawn_major` and adds further majors, e.g. DbV2.)
+    /// Thin wrapper over [`FinalisedSource::spawn_major`], which maps a major to its concrete backend.
     async fn open_major_backend(
         cfg: &ChainIndexConfig,
         major: u32,
     ) -> Result<FinalisedSource<T>, FinalisedStateError> {
-        match major {
-            1 => FinalisedSource::spawn_v1(cfg).await,
-            other => Err(FinalisedStateError::Custom(format!(
-                "unsupported database version: DbV{other}"
-            ))),
-        }
+        FinalisedSource::spawn_major(major, cfg).await
     }
 
     /// Selects and opens the serving primary backend per the ADR 0002 (C7) selection rules, honouring

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -122,9 +122,13 @@
 //!
 //! # On-disk layout and version detection
 //!
-//! Database discovery is intentionally conservative: `try_find_current_db_version` returns the
-//! **oldest** detected version, because the process may have been terminated mid-migration, leaving
-//! multiple version directories on disk.
+//! Startup honours the configured target major (`cfg.db_version`) even when several majors coexist on
+//! disk. `detect_major_dirs` probes which major directories are present, and `select_primary` opens
+//! the serving primary per ADR 0002 (C7): open the requested major if it is authoritative; otherwise
+//! serve from the best older authoritative major while the requested major is (re)built; otherwise
+//! build the requested major fresh. A half-built major target (classified from its metadata via
+//! `is_authoritative`) is never opened as primary, so a major migration interrupted mid-build resumes
+//! from the older database rather than serving partial data.
 //!
 //! The current logic recognises two layouts:
 //!
@@ -365,6 +369,29 @@ pub(crate) struct FinalisedState<T: BlockchainSource> {
     cfg: ChainIndexConfig,
 }
 
+/// The newest supported [`DbVersion`] for a given major, or `None` if the major is unsupported.
+///
+/// Single source of truth for "latest version per major", used by both startup target selection
+/// ([`FinalisedState::spawn`]) and the default major migration (which builds a new major directly to
+/// its newest version).
+fn latest_version_for_major(major: u32) -> Option<DbVersion> {
+    match major {
+        1 => Some(DB_VERSION_V1),
+        _ => None,
+    }
+}
+
+/// Classifies an opened major directory from its persisted metadata (ADR 0002, C7).
+///
+/// A directory is *authoritative* — eligible to be opened as the serving primary — unless it is a
+/// half-built major target, which the build-and-promote helper marks with
+/// [`MigrationStatus::MajorBuildInProgress`]. Every other readable metadata is authoritative,
+/// **including** a primary that crashed mid-patch or mid-minor (whose data is complete at the old
+/// version and is merely being transformed in place); such a database must never be refused.
+fn is_authoritative(metadata: &DbMetadata) -> bool {
+    metadata.migration_status() != MigrationStatus::MajorBuildInProgress
+}
+
 /// Lifecycle, migration control, and core read/write API for the finalised database.
 ///
 /// This `impl` intentionally stays small and policy heavy:
@@ -377,16 +404,20 @@ impl<T: BlockchainSource> FinalisedState<T> {
     /// Spawns a `FinalisedState` instance.
     ///
     /// This method:
-    /// 1. Detects the on-disk database version (if any) using [`FinalisedState::try_find_current_db_version`].
-    /// 2. Selects a target schema version from `cfg.db_version`.
-    /// 3. Opens the existing database at the detected version, or creates a new database at the
-    ///    target version.
-    /// 4. If an existing database is older than the target (`current_version < target_version`),
-    ///    runs migrations using `migrations::MigrationManager`.
+    /// 1. Selects a target major from `cfg.db_version` and its latest version via
+    ///    [`latest_version_for_major`].
+    /// 2. Detects the major directories present on disk ([`FinalisedState::detect_major_dirs`]) and
+    ///    opens the serving primary per the ADR 0002 selection rules
+    ///    ([`FinalisedState::select_primary`]).
+    /// 3. If the opened primary is older than the target (`current_version < target_version`), runs
+    ///    migrations in the background using `migrations::MigrationManager`.
     ///
     /// ## Version selection rules
-    /// - `cfg.db_version == 1` targets the latest v1 DB version (`DB_VERSION_V1`)..
-    /// - Any other value (including the legacy `0`) returns an error.
+    /// - `cfg.db_version` selects the target major; its latest version comes from
+    ///   [`latest_version_for_major`]. An unsupported major (or the legacy `0` layout) returns an
+    ///   error.
+    /// - The configured major is honoured even when multiple majors coexist on disk; a half-built
+    ///   major target is never opened as primary.
     ///
     /// ## Migrations
     /// Migrations are invoked only when a database already exists on disk and the opened database
@@ -416,53 +447,34 @@ impl<T: BlockchainSource> FinalisedState<T> {
                 cfg,
             });
         } else {
-            let version_opt = Self::try_find_current_db_version(&cfg).await;
+            // Legacy v0 is detected only to reject it: v0 is no longer supported.
+            if Self::legacy_v0_present(&cfg) {
+                return Err(FinalisedStateError::Custom(format!(
+                    "legacy v0 database detected at {}; v0 is no longer supported. \
+                     Remove the directory and restart to resync a v1 database from genesis.",
+                    cfg.storage.database.path.display()
+                )));
+            }
 
-            let target_version = match cfg.db_version {
-                1 => DB_VERSION_V1,
-                x => {
-                    return Err(FinalisedStateError::Custom(format!(
-                        "unsupported database version: DbV{x}"
-                    )));
-                }
-            };
+            let target_major = cfg.db_version;
+            let target_version = latest_version_for_major(target_major).ok_or_else(|| {
+                FinalisedStateError::Custom(format!("unsupported database version: DbV{target_major}"))
+            })?;
 
-            let backend = match version_opt {
-                Some(version) => {
-                    info!(version, "Opening FinalisedState from file");
-                    match version {
-                        0 => {
-                            return Err(FinalisedStateError::Custom(format!(
-                                "legacy v0 database detected at {}; v0 is no longer supported. \
-                                 Remove the directory and restart to resync a v1 database from genesis.",
-                                cfg.storage.database.path.display()
-                            )));
-                        }
-                        1 => FinalisedSource::spawn_v1(&cfg).await?,
-                        _ => {
-                            return Err(FinalisedStateError::Custom(format!(
-                                "unsupported database version: DbV{version}"
-                            )));
-                        }
-                    }
-                }
-                None => {
-                    info!(version = %target_version, "Creating new FinalisedState");
-                    match target_version.major() {
-                        1 => FinalisedSource::spawn_v1(&cfg).await?,
-                        _ => {
-                            return Err(FinalisedStateError::Custom(format!(
-                                "unsupported database version: DbV{target_version}"
-                            )));
-                        }
-                    }
-                }
-            };
+            // Open the serving primary per the ADR 0002 selection rules, honouring the configured
+            // major even when several majors coexist on disk.
+            let present_majors = Self::detect_major_dirs(&cfg);
+            let backend = Self::select_primary(&cfg, target_major, &present_majors).await?;
+
             let current_version = backend.get_metadata().await?.version();
 
             let router = Arc::new(Router::new(Arc::new(backend)));
 
-            if version_opt.is_some() && current_version < target_version {
+            // Migrate when the opened primary is behind the target. A freshly created database is
+            // initialised at its major's latest version (so `current_version == target_version` and
+            // this is skipped); an older on-disk major triggers the forward path — minor/patch within
+            // the major, or a major build-and-promote when the configured major is newer.
+            if current_version < target_version {
                 info!(
                     from_version = %current_version,
                     to_version = %target_version,
@@ -579,60 +591,136 @@ impl<T: BlockchainSource> FinalisedState<T> {
         }
     }
 
-    /// Attempts to detect the current on-disk database version from the filesystem layout.
+    /// Returns `true` if a legacy v0 database directory is present on disk.
     ///
-    /// The detection is intentionally conservative: it returns the **oldest** detected version,
-    /// because the process may have been terminated mid-migration, leaving both an older primary
-    /// and a newer shadow directory on disk.
-    ///
-    /// ## Recognised layouts
-    ///
-    /// - **Legacy v0 layout**
-    ///   - Network directories: `live/`, `test/`, `local/`
-    ///   - Presence check: both `data.mdb` and `lock.mdb` exist
-    ///   - Reported version: `Some(0)`. v0 is no longer supported, so `spawn` rejects this with a
-    ///     clear error rather than opening or migrating it; detection exists only to produce that
-    ///     error.
-    ///
-    /// - **Versioned v1+ layout**
-    ///   - Network directories: `mainnet/`, `testnet/`, `regtest/`
-    ///   - Version subdirectories: enumerated by `finalised_source::VERSION_DIRS` (e.g. `"v1"`)
-    ///   - Presence check: both `data.mdb` and `lock.mdb` exist within a version directory
-    ///   - Reported version: `Some(i + 1)` where `i` is the index in `VERSION_DIRS`
-    ///
-    /// Returns:
-    /// - `Some(version)` if a compatible database directory is found,
-    /// - `None` if no database is detected (fresh DB creation case).
-    async fn try_find_current_db_version(cfg: &ChainIndexConfig) -> Option<u32> {
+    /// v0 is no longer supported: detection exists only so `spawn` can reject it with a clear error.
+    /// The legacy layout uses the network directories `live/` (mainnet), `test/` (testnet),
+    /// `local/` (regtest) holding LMDB `data.mdb` + `lock.mdb`.
+    fn legacy_v0_present(cfg: &ChainIndexConfig) -> bool {
         let legacy_dir = match cfg.network.to_zebra_network().kind() {
             NetworkKind::Mainnet => "live",
             NetworkKind::Testnet => "test",
             NetworkKind::Regtest => "local",
         };
         let legacy_path = cfg.storage.database.path.join(legacy_dir);
-        if legacy_path.join("data.mdb").exists() && legacy_path.join("lock.mdb").exists() {
-            return Some(0);
-        }
+        legacy_path.join("data.mdb").exists() && legacy_path.join("lock.mdb").exists()
+    }
 
+    /// Detects which major database directories physically exist on disk.
+    ///
+    /// Returns the set of present majors. The versioned layout stores each major under a per-network
+    /// directory (`mainnet/`, `testnet/`, `regtest/`) in a subdirectory enumerated by
+    /// `finalised_source::VERSION_DIRS` — `VERSION_DIRS[i]` is major `i + 1`. Presence is "both
+    /// `data.mdb` and `lock.mdb` exist". This is a cheap filesystem probe; classification
+    /// (authoritative vs incomplete build) is done by reading each candidate's metadata after opening
+    /// it (see [`FinalisedState::select_primary`]).
+    fn detect_major_dirs(cfg: &ChainIndexConfig) -> std::collections::BTreeSet<u32> {
         let net_dir = match cfg.network.to_zebra_network().kind() {
             NetworkKind::Mainnet => "mainnet",
             NetworkKind::Testnet => "testnet",
             NetworkKind::Regtest => "regtest",
         };
         let net_path = cfg.storage.database.path.join(net_dir);
-        if net_path.exists() && net_path.is_dir() {
+
+        let mut majors = std::collections::BTreeSet::new();
+        if net_path.is_dir() {
             for (i, version_dir) in VERSION_DIRS.iter().enumerate() {
                 let db_path = net_path.join(version_dir);
-                let data_file = db_path.join("data.mdb");
-                let lock_file = db_path.join("lock.mdb");
-                if data_file.exists() && lock_file.exists() {
-                    let version = (i + 1) as u32;
-                    return Some(version);
+                if db_path.join("data.mdb").exists() && db_path.join("lock.mdb").exists() {
+                    majors.insert((i + 1) as u32);
+                }
+            }
+        }
+        majors
+    }
+
+    /// Opens the backend for a specific major version.
+    ///
+    /// Maps a major to its concrete `FinalisedSource` backend. (Step 5 promotes this to
+    /// `FinalisedSource::spawn_major` and adds further majors, e.g. DbV2.)
+    async fn open_major_backend(
+        cfg: &ChainIndexConfig,
+        major: u32,
+    ) -> Result<FinalisedSource<T>, FinalisedStateError> {
+        match major {
+            1 => FinalisedSource::spawn_v1(cfg).await,
+            other => Err(FinalisedStateError::Custom(format!(
+                "unsupported database version: DbV{other}"
+            ))),
+        }
+    }
+
+    /// Selects and opens the serving primary backend per the ADR 0002 (C7) selection rules, honouring
+    /// the configured `target_major` even when several majors coexist on disk.
+    ///
+    /// 1. **Requested major present and authoritative** → open and serve it; the planner resumes any
+    ///    in-flight patch/minor and migrates it forward to that major's latest version.
+    /// 2. **Requested major absent or an incomplete build** → open the best *authoritative older*
+    ///    major to keep serving; the background migration then builds the requested major and promotes
+    ///    it. A half-built target is never served as primary — this is the "stopped a major migration
+    ///    then restarted" case.
+    /// 3. **No authoritative database** → build the requested major fresh from genesis.
+    async fn select_primary(
+        cfg: &ChainIndexConfig,
+        target_major: u32,
+        present_majors: &std::collections::BTreeSet<u32>,
+    ) -> Result<FinalisedSource<T>, FinalisedStateError> {
+        // Rule 1: requested major present and authoritative.
+        if present_majors.contains(&target_major) {
+            let backend = Self::open_major_backend(cfg, target_major).await?;
+            match backend.get_metadata().await {
+                Ok(metadata) if is_authoritative(&metadata) => {
+                    info!(
+                        major = target_major,
+                        version = %metadata.version(),
+                        "Opening requested major as primary"
+                    );
+                    return Ok(backend);
+                }
+                Ok(_incomplete) => {
+                    // A half-built major target: do not serve from it (ADR C7). Shut it down and
+                    // fall through to rebuilding it from an older authoritative major, or fresh.
+                    info!(
+                        major = target_major,
+                        "Requested major is an incomplete build; will rebuild and promote"
+                    );
+                    backend.shutdown().await?;
+                }
+                Err(error) => {
+                    // Unreadable metadata: treat as an incomplete build and rebuild.
+                    info!(
+                        major = target_major,
+                        %error, "Requested major metadata is unreadable; will rebuild and promote"
+                    );
+                    backend.shutdown().await?;
                 }
             }
         }
 
-        None
+        // Rule 2: an older authoritative major exists -> open it to keep serving while the requested
+        // major is built and promoted by the background migration.
+        for &older_major in present_majors.iter().rev().filter(|&&m| m < target_major) {
+            let backend = Self::open_major_backend(cfg, older_major).await?;
+            match backend.get_metadata().await {
+                Ok(metadata) if is_authoritative(&metadata) => {
+                    info!(
+                        serving_major = older_major,
+                        target_major, "Opening older major as primary; will build requested major"
+                    );
+                    return Ok(backend);
+                }
+                _ => {
+                    backend.shutdown().await?;
+                }
+            }
+        }
+
+        // Rule 3: no authoritative database -> build the requested major fresh from genesis.
+        info!(
+            major = target_major,
+            "No existing database for requested major; creating it fresh"
+        );
+        Self::open_major_backend(cfg, target_major).await
     }
 
     /// Returns the database backend that should serve the requested capability.
@@ -958,26 +1046,14 @@ impl<T: BlockchainSource> FinalisedState<T> {
             )));
         }
 
-        let version_opt = Self::try_find_current_db_version(&cfg).await;
-
-        let backend = match version_opt {
-            Some(version) => {
-                info!(version, "Opening FinalisedState from file");
-                match version {
-                    1 => FinalisedSource::spawn_v1(&cfg).await?,
-                    _ => {
-                        return Err(FinalisedStateError::Custom(format!(
-                            "unsupported database version: DbV{version}"
-                        )));
-                    }
-                }
-            }
-            None => {
-                return Err(FinalisedStateError::Custom(
-                    "expected existing v1.0.0 migration-test database, found no database"
-                        .to_string(),
-                ));
-            }
+        let present_majors = Self::detect_major_dirs(&cfg);
+        let backend = if present_majors.contains(&1) {
+            info!("Opening FinalisedState from file");
+            FinalisedSource::spawn_v1(&cfg).await?
+        } else {
+            return Err(FinalisedStateError::Custom(
+                "expected existing v1.0.0 migration-test database, found no database".to_string(),
+            ));
         };
         let current_version = backend.get_metadata().await?.version();
 
@@ -1120,5 +1196,40 @@ impl<T: BlockchainSource> FinalisedState<T> {
         drop(db);
 
         Self::spawn_with_target_version(cfg, source, target_version).await
+    }
+}
+
+#[cfg(test)]
+mod selection_tests {
+    use super::*;
+
+    fn metadata_with(status: MigrationStatus) -> DbMetadata {
+        DbMetadata::new(DB_VERSION_V1, [0u8; 32], status)
+    }
+
+    #[test]
+    fn latest_version_for_major_maps_known_majors_only() {
+        assert_eq!(latest_version_for_major(1), Some(DB_VERSION_V1));
+        assert_eq!(latest_version_for_major(2), None);
+        assert_eq!(latest_version_for_major(0), None);
+    }
+
+    #[test]
+    fn major_build_in_progress_is_the_only_non_authoritative_state() {
+        // A half-built major target must never be served as primary (ADR 0002, C7).
+        assert!(!is_authoritative(&metadata_with(
+            MigrationStatus::MajorBuildInProgress
+        )));
+
+        // Every other readable metadata is authoritative — including a primary that crashed
+        // mid-patch / mid-minor, which must always remain openable.
+        assert!(is_authoritative(&metadata_with(MigrationStatus::Empty)));
+        assert!(is_authoritative(&metadata_with(
+            MigrationStatus::PartialBuidInProgress
+        )));
+        assert!(is_authoritative(&metadata_with(
+            MigrationStatus::FinalBuildInProgress
+        )));
+        assert!(is_authoritative(&metadata_with(MigrationStatus::Complete)));
     }
 }

--- a/packages/zaino-state/src/chain_index/finalised_state/capability.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/capability.rs
@@ -574,6 +574,15 @@ pub(crate) enum MigrationStatus {
 
     /// Migration work is complete and the database is ready for promotion/steady-state operation.
     Complete,
+
+    /// A new major's database directory is being built from scratch and has not yet been promoted.
+    ///
+    /// Stamped by the major build-and-promote helper before any data is written, and cleared (the
+    /// metadata set to the target version with status `Empty`) only at the completion gate. A
+    /// directory in this state is classified as an incomplete build at startup and is never opened as
+    /// the serving primary (ADR 0002, C7). Patch/minor migrations never set it, so a primary that
+    /// crashed mid-patch or mid-minor stays authoritative.
+    MajorBuildInProgress,
 }
 
 /// Human-readable migration status for logs and diagnostics.
@@ -585,6 +594,7 @@ impl fmt::Display for MigrationStatus {
             MigrationStatus::PartialBuildComplete => "Partial build complete",
             MigrationStatus::FinalBuildInProgress => "Final build in progress",
             MigrationStatus::Complete => "Complete",
+            MigrationStatus::MajorBuildInProgress => "Major build in progress",
         };
         write!(f, "{status_str}")
     }
@@ -612,6 +622,7 @@ impl ZainoVersionedSerde for MigrationStatus {
             MigrationStatus::PartialBuildComplete => 2,
             MigrationStatus::FinalBuildInProgress => 3,
             MigrationStatus::Complete => 4,
+            MigrationStatus::MajorBuildInProgress => 5,
         };
         write_u8(w, tag)
     }
@@ -623,6 +634,7 @@ impl ZainoVersionedSerde for MigrationStatus {
             2 => Ok(MigrationStatus::PartialBuildComplete),
             3 => Ok(MigrationStatus::FinalBuildInProgress),
             4 => Ok(MigrationStatus::Complete),
+            5 => Ok(MigrationStatus::MajorBuildInProgress),
             other => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("invalid MigrationStatus tag: {other}"),

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source.rs
@@ -266,11 +266,8 @@ impl<T: BlockchainSource> FinalisedSource<T> {
             #[cfg(test)]
             2 => {
                 let mut standin_cfg = cfg.clone();
-                standin_cfg.storage.database.path = cfg
-                    .storage
-                    .database
-                    .path
-                    .join("__test_major2_standin__");
+                standin_cfg.storage.database.path =
+                    cfg.storage.database.path.join("__test_major2_standin__");
                 Self::spawn_v1(&standin_cfg).await
             }
 

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source.rs
@@ -245,6 +245,41 @@ impl<T: BlockchainSource> FinalisedSource<T> {
         Ok(Self::V1(Box::new(DbV1::spawn(cfg).await?)))
     }
 
+    /// Spawns the backend for a specific major version, in that major's own directory.
+    ///
+    /// Maps a major to its concrete backend. Used at startup (selecting which major to open) and by
+    /// the major build-and-promote migration (building the target major alongside the serving
+    /// primary). A real DbV2 adds its arm here (and to `VERSION_DIRS` / `latest_version_for_major`).
+    pub(crate) async fn spawn_major(
+        major: u32,
+        cfg: &ChainIndexConfig,
+    ) -> Result<Self, FinalisedStateError> {
+        match major {
+            1 => Self::spawn_v1(cfg).await,
+
+            // Test-only stand-in for a second major: a real `DbV1` backend rooted in a side
+            // directory, used to exercise `build_and_promote_major` (build → completion gate →
+            // promote → retention → resume) end to end without a real DbV2. It deliberately lives
+            // off the canonical `<net>/v2/` path, so `detect_major_dirs` does not pick it up — it
+            // only supports driving the migration helper directly. The full restart/selection path
+            // and reopen-as-major-2 need a real DbV2 (DbV1 enforces `major == 1`).
+            #[cfg(test)]
+            2 => {
+                let mut standin_cfg = cfg.clone();
+                standin_cfg.storage.database.path = cfg
+                    .storage
+                    .database
+                    .path
+                    .join("__test_major2_standin__");
+                Self::spawn_v1(&standin_cfg).await
+            }
+
+            other => Err(FinalisedStateError::Custom(format!(
+                "unsupported database version: DbV{other}"
+            ))),
+        }
+    }
+
     /// Spawns a "ephemeral" finalised state.
     pub(crate) fn ephemeral(
         source: T,

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -148,7 +148,7 @@
 //! - No unsafe code and no temporary named LMDB database are used.
 
 use super::{
-    capability::{DbRead, DbVersion, DbWrite, MigrationStatus},
+    capability::{DbCore, DbRead, DbVersion, DbWrite, MigrationStatus},
     router::Router,
 };
 
@@ -157,7 +157,7 @@ use crate::{
         finalised_state::{
             capability::DbMetadata,
             entry::{StoredEntryFixed, StoredEntryVar},
-            finalised_source::v1::SYNC_CHECKPOINT_INTERVAL,
+            finalised_source::{v1::SYNC_CHECKPOINT_INTERVAL, FinalisedSource, VERSION_DIRS},
             router::EphemeralMode,
         },
         source::BlockchainSource,
@@ -171,8 +171,11 @@ use crate::{
 use lmdb::{Transaction, WriteFlags};
 
 use async_trait::async_trait;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::info;
+use zaino_common::OldDbRetention;
+use zebra_chain::parameters::NetworkKind;
 
 /// Broad categorisation of migration severity.
 ///
@@ -301,23 +304,100 @@ async fn migrate_metadata_only<T: BlockchainSource>(
 
 /// Generic **major** migration: builds the target major from the backing validator and promotes it.
 ///
-/// This is the default behaviour of a major migration (overridable for a bespoke major). The old
-/// primary keeps serving read+write while the new backend is built in its own directory; a brief
-/// ephemeral freeze covers the final catch-up and the atomic primary swap; the old directory is then
-/// kept or deleted per the retention policy. `target` is the newest version of the new major.
+/// This is the default behaviour of a major migration (overridable for a bespoke major). `target` is
+/// the newest version of the new major (a from-scratch build lands directly there).
 ///
-/// Implemented in a later step (it depends on `FinalisedSource::spawn_major`, the retention config,
-/// and `Router::replace_primary`). No major migration is registered yet, so this path is currently
-/// unreachable.
+/// The serving primary (the old major) is **static** for the duration: during a migration the indexer
+/// is paused by the background-op guard (`sync_to_height` early-returns on `has_background_ops`), and
+/// this code never mutates the old primary — it keeps serving reads from its complete data. So,
+/// unlike a minor migration, no ephemeral routing is needed; a crash leaves the old primary intact
+/// and authoritative (ADR 0002, C6).
+///
+/// Steps:
+/// 1. Spawn the target major in its own directory and mark it `MajorBuildInProgress` *before* writing
+///    any data, so a crash classifies the directory as an incomplete build and it is never served as
+///    primary (C7). The recorded version stays the backend's natural version; only the status marks
+///    it incomplete.
+/// 2. Build the new backend up to the old primary's tip. `write_blocks_to_height` resumes from the
+///    new backend's own append-only tip, so an interrupted build resumes (C4).
+/// 3. Completion gate: record the target version durably (fsync). This is the only signal the
+///    migration finished and must be durable before the swap and any cleanup (C5).
+/// 4. Atomically promote the new backend via `replace_primary`, shut down the demoted old primary,
+///    and keep or delete the old major's directory per the retention policy (C8).
 async fn build_and_promote_major<T: BlockchainSource>(
-    _router: Arc<Router<T>>,
-    _cfg: ChainIndexConfig,
-    _source: T,
+    router: Arc<Router<T>>,
+    cfg: ChainIndexConfig,
+    source: T,
     target: DbVersion,
 ) -> Result<(), FinalisedStateError> {
-    Err(FinalisedStateError::Custom(format!(
-        "major build-and-promote to {target} is not yet implemented"
-    )))
+    info!(
+        target_major = target.major,
+        %target, "Starting major migration: building and promoting new major"
+    );
+
+    let old_primary = router.primary_backend();
+    let old_major = old_primary.get_metadata().await?.version().major;
+    let old_tip = old_primary.db_height().await?;
+
+    // 1. Spawn the target major in its own directory and stamp the in-progress marker first.
+    let new_backend = FinalisedSource::spawn_major(target.major, &cfg).await?;
+    new_backend.wait_until_ready().await;
+    {
+        let mut metadata = new_backend.get_metadata().await?;
+        metadata.migration_status = MigrationStatus::MajorBuildInProgress;
+        new_backend.update_metadata(metadata).await?;
+    }
+    new_backend.env()?.sync(true)?;
+
+    // 2. Build up to the old primary's tip (resumable from the new backend's own tip).
+    if let Some(tip) = old_tip {
+        new_backend.write_blocks_to_height(tip, &source).await?;
+    }
+
+    // 3. Completion gate: record the target version, durably, before any swap or cleanup.
+    {
+        let mut metadata = new_backend.get_metadata().await?;
+        metadata.version = target;
+        metadata.migration_status = MigrationStatus::Empty;
+        new_backend.update_metadata(metadata).await?;
+    }
+    new_backend.env()?.sync(true)?;
+
+    // 4. Promote the new backend atomically, shut down the demoted old primary, apply retention.
+    let demoted = router.replace_primary(Arc::new(new_backend));
+    demoted.shutdown().await?;
+
+    if cfg.storage.database.old_db_retention == OldDbRetention::Delete {
+        if let Some(old_dir) = major_dir_path(&cfg, old_major) {
+            info!(major = old_major, path = %old_dir.display(), "Deleting demoted major directory");
+            match std::fs::remove_dir_all(&old_dir) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(FinalisedStateError::Custom(format!(
+                        "failed to delete demoted major directory {}: {error}",
+                        old_dir.display()
+                    )));
+                }
+            }
+        }
+    }
+
+    info!(%target, "Major migration complete");
+    Ok(())
+}
+
+/// The on-disk directory for a given major version: `<base>/<network>/<version-dir>`.
+///
+/// Returns `None` if the major has no `VERSION_DIRS` entry (so callers skip rather than guess a path).
+fn major_dir_path(cfg: &ChainIndexConfig, major: u32) -> Option<PathBuf> {
+    let version_dir = VERSION_DIRS.get((major as usize).checked_sub(1)?)?;
+    let net_dir = match cfg.network.to_zebra_network().kind() {
+        NetworkKind::Mainnet => "mainnet",
+        NetworkKind::Testnet => "testnet",
+        NetworkKind::Regtest => "regtest",
+    };
+    Some(cfg.storage.database.path.join(net_dir).join(version_dir))
 }
 
 /// Orchestrates a sequence of migration steps until `target_version` is reached.
@@ -1203,5 +1283,130 @@ mod tests {
     fn no_path_from_unregistered_source_errors() {
         // No edge departs from 0.0.0 (legacy v0 is rejected, not migrated).
         assert!(plan_migrations::<Source>(v(0, 0, 0), v(1, 1, 0)).is_err());
+    }
+
+    // ***** build_and_promote_major (major migration orchestration) *****
+
+    /// A regtest config rooted at `path`, with the given retention policy.
+    fn regtest_config(path: PathBuf, retention: OldDbRetention) -> ChainIndexConfig {
+        use zaino_common::{network::ActivationHeights, DatabaseConfig, Network, StorageConfig};
+        let mut cfg = ChainIndexConfig {
+            storage: StorageConfig {
+                database: DatabaseConfig {
+                    path,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ephemeral: false,
+            db_version: 1,
+            network: Network::Regtest(ActivationHeights::default()),
+        };
+        cfg.storage.database.old_db_retention = retention;
+        cfg
+    }
+
+    /// Spawns a fresh v1 database and syncs it to `active_height`, returning the running state (whose
+    /// router is the "old primary" for a major migration) and the backing source.
+    async fn synced_v1_primary(
+        cfg: ChainIndexConfig,
+        active_height: Height,
+    ) -> (
+        crate::chain_index::finalised_state::FinalisedState<Source>,
+        Source,
+    ) {
+        use crate::chain_index::tests::vectors::{build_active_mockchain_source, load_test_vectors};
+        let blocks = load_test_vectors().unwrap().blocks;
+        let source = build_active_mockchain_source(active_height.0, blocks);
+
+        let db = crate::chain_index::finalised_state::FinalisedState::spawn(cfg, source.clone())
+            .await
+            .unwrap();
+        db.sync_to_height(active_height, &source).await.unwrap();
+        db.wait_until_synced().await;
+        (db, source)
+    }
+
+    // multi_thread required: `build_and_promote_major` -> `write_blocks_to_height` uses
+    // `block_in_place`, which panics on a current-thread runtime.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn major_migration_builds_promotes_and_keeps_old_dir() {
+        crate::chain_index::tests::init_tracing();
+
+        let temporary_directory = tempfile::tempdir().unwrap();
+        let cfg = regtest_config(temporary_directory.path().to_path_buf(), OldDbRetention::Keep);
+        let active_height = Height(20);
+
+        let (db, source) = synced_v1_primary(cfg.clone(), active_height).await;
+        let old_tip = db.db_height().await.unwrap();
+        assert_eq!(old_tip, Some(active_height));
+
+        let old_primary_dir = cfg.storage.database.path.join("regtest").join("v1");
+        assert!(old_primary_dir.exists());
+
+        let router = Arc::clone(&db.db);
+        build_and_promote_major(Arc::clone(&router), cfg.clone(), source, DbVersion::new(2, 0, 0))
+            .await
+            .unwrap();
+
+        // Promoted: the primary reports the target version at the old primary's preserved tip.
+        assert_eq!(router.get_metadata().await.unwrap().version(), DbVersion::new(2, 0, 0));
+        assert_eq!(router.db_height().await.unwrap(), old_tip);
+        // Retention Keep: the demoted major's directory is retained for instant switch-back.
+        assert!(old_primary_dir.exists());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn major_migration_deletes_old_dir_when_retention_is_delete() {
+        crate::chain_index::tests::init_tracing();
+
+        let temporary_directory = tempfile::tempdir().unwrap();
+        let cfg = regtest_config(temporary_directory.path().to_path_buf(), OldDbRetention::Delete);
+        let active_height = Height(20);
+
+        let (db, source) = synced_v1_primary(cfg.clone(), active_height).await;
+        let old_primary_dir = cfg.storage.database.path.join("regtest").join("v1");
+        assert!(old_primary_dir.exists());
+
+        let router = Arc::clone(&db.db);
+        build_and_promote_major(Arc::clone(&router), cfg.clone(), source, DbVersion::new(2, 0, 0))
+            .await
+            .unwrap();
+
+        // Retention Delete: the demoted major's directory is removed.
+        assert!(!old_primary_dir.exists());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn major_migration_resumes_a_partially_built_target() {
+        crate::chain_index::tests::init_tracing();
+
+        let temporary_directory = tempfile::tempdir().unwrap();
+        let cfg = regtest_config(temporary_directory.path().to_path_buf(), OldDbRetention::Keep);
+        let active_height = Height(20);
+
+        let (db, source) = synced_v1_primary(cfg.clone(), active_height).await;
+
+        // Simulate a major build interrupted partway: the target backend exists, is stamped
+        // in-progress, and holds only a prefix of the chain.
+        {
+            let partial = FinalisedSource::<Source>::spawn_major(2, &cfg).await.unwrap();
+            partial.wait_until_ready().await;
+            let mut metadata = partial.get_metadata().await.unwrap();
+            metadata.migration_status = MigrationStatus::MajorBuildInProgress;
+            partial.update_metadata(metadata).await.unwrap();
+            partial.write_blocks_to_height(Height(10), &source).await.unwrap();
+            partial.env().unwrap().sync(true).unwrap();
+            partial.shutdown().await.unwrap();
+        }
+
+        // Resuming builds the remaining blocks (from the partial tip) and promotes to the full tip.
+        let router = Arc::clone(&db.db);
+        build_and_promote_major(Arc::clone(&router), cfg.clone(), source, DbVersion::new(2, 0, 0))
+            .await
+            .unwrap();
+
+        assert_eq!(router.get_metadata().await.unwrap().version(), DbVersion::new(2, 0, 0));
+        assert_eq!(router.db_height().await.unwrap(), Some(active_height));
     }
 }

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -17,11 +17,15 @@
 //!
 //! - [`MigrationManager<T>`]:
 //!   - holds the router, config, current and target versions, and a `BlockchainSource`,
-//!   - repeatedly selects and runs the next migration via `get_migration()`.
+//!   - plans a path over the version graph via [`plan_migrations`] and runs each step in order.
 //!
-//! - [`MigrationStep`]:
-//!   - enum-based dispatch wrapper used by `MigrationManager` to select between multiple concrete
-//!     `Migration<T>` implementations (Rust cannot return different `impl Trait` types from a `match`).
+//! - [`MigrationStep`] and the [`migrations!`] macro:
+//!   - the macro generates the `MigrationStep` dispatch enum (static, no `dyn`) and the
+//!     `MigrationStep::all` registry from a single authored list; [`plan_migrations`] walks that
+//!     registry as a graph (nodes = `DbVersion`, edges = steps) to find the path to the target.
+//!
+//! The authoritative spec for this module is ADR 0002
+//! (`docs/adr/0002-persistent-finalised-state-migrations.md`).
 //!
 //! - [`capability::MigrationStatus`]:
 //!   - stored in `DbMetadata` and used to resume work safely after shutdown.
@@ -77,17 +81,18 @@
 //!
 //! # Development: adding a new migration step
 //!
-//! 1. Introduce a new `struct MigrationX_Y_ZToA_B_C;` and implement `Migration<T>`.
-//! 2. Add a new `MigrationStep` variant and register it in `MigrationManager::get_migration()` by
-//!    matching on the *current* version.
-//! 3. Ensure the migration is:
-//!    - deterministic,
-//!    - resumable (use `DbMetadata::migration_status` and/or shadow tip),
-//!    - crash-safe (never leaves a partially promoted DB).
-//! 4. Add tests/fixtures for:
-//!    - starting from the old version,
-//!    - resuming mid-build if applicable,
-//!    - validating the promoted DB serves required capabilities.
+//! See ADR 0002's "Engineer / dev guide" for the full recipe. In short:
+//!
+//! 1. Introduce a new `#[derive(Clone, Copy)] struct MigrationX_Y_ZToA_B_C;` and implement
+//!    `Migration<T>` (set `CURRENT_VERSION` / `TO_VERSION`, and `migration_type()` for non-patch).
+//! 2. Add its name to the `migrations! { .. }` list — that registers it for the planner; there is no
+//!    strict `(major, minor, patch)` match to edit.
+//! 3. Update the version constants in the versions module so the registry edge and
+//!    `latest_version_for_major` agree.
+//! 4. Ensure the migration is deterministic, resumable (`DbMetadata::migration_status` and/or the
+//!    target backend's own tip), and crash-safe (never leaves a partially promoted DB).
+//! 5. Add tests/fixtures: starting from the old version, resuming mid-build if applicable, and
+//!    validating the resulting DB serves the required capabilities.
 //!
 //! # Implemented migrations
 //!
@@ -177,8 +182,8 @@ use tracing::info;
 /// - **Major**: capability or schema changes that require rebuilding indices from the backing validator,
 ///   typically using the router’s primary/shadow model.
 ///
-/// Note: this enum is not currently used to dispatch behaviour in this file; concrete steps are
-/// selected by [`MigrationManager::get_migration`].
+/// Note: concrete steps are selected by [`plan_migrations`] from the [`migrations!`] registry; this
+/// enum drives the per-type lifecycle in [`MigrationManager::migrate`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MigrationType {
     /// Patch-level changes: no schema change; metadata updates only.
@@ -214,7 +219,7 @@ pub trait Migration<T: BlockchainSource> {
     const TO_VERSION: DbVersion;
 
     /// Returns the version this step migrates *from*.
-    fn current_version(&self) -> DbVersion {
+    fn from_version(&self) -> DbVersion {
         Self::CURRENT_VERSION
     }
 
@@ -309,28 +314,27 @@ pub(super) struct MigrationManager<T: BlockchainSource> {
 }
 
 impl<T: BlockchainSource> MigrationManager<T> {
-    /// Iteratively performs each migration step from current version to target version.
+    /// Plans a path from `current_version` to `target_version` over the migration version graph,
+    /// then performs each step in order.
     ///
-    /// The manager applies steps in order, where each step maps one specific `DbVersion` to the next.
-    /// The loop terminates once `current_version >= target_version`.
+    /// The plan is computed once via [`plan_migrations`]; each step maps one specific `DbVersion`
+    /// to the next, and `current_version` is advanced to each step's `to_version` as it completes.
     ///
     /// # Errors
-    /// Returns an error if a migration step is missing for the current version, or if any migration
-    /// step fails.
+    /// Returns an error if no path exists from the current version to the target, or if any
+    /// migration step fails.
     pub(super) async fn migrate(&mut self) -> Result<(), FinalisedStateError> {
-        while self.current_version < self.target_version {
-            let migration = self.get_migration()?;
-            let migration_type = migration.migration_type::<T>();
+        let plan = plan_migrations::<T>(self.current_version, self.target_version)?;
 
-            match migration_type {
+        for step in plan {
+            match step.migration_type::<T>() {
                 MigrationType::Patch => {
-                    migration
-                        .migrate(
-                            Arc::clone(&self.router),
-                            self.cfg.clone(),
-                            self.source.clone(),
-                        )
-                        .await?;
+                    step.migrate(
+                        Arc::clone(&self.router),
+                        self.cfg.clone(),
+                        self.source.clone(),
+                    )
+                    .await?;
                 }
 
                 MigrationType::Minor | MigrationType::Major => {
@@ -347,95 +351,163 @@ impl<T: BlockchainSource> MigrationManager<T> {
                         )
                         .await?;
 
-                    migration
-                        .migrate(
-                            Arc::clone(&self.router),
-                            self.cfg.clone(),
-                            self.source.clone(),
-                        )
-                        .await?;
+                    step.migrate(
+                        Arc::clone(&self.router),
+                        self.cfg.clone(),
+                        self.source.clone(),
+                    )
+                    .await?;
                 }
             }
 
-            self.current_version = migration.to_version::<T>();
+            self.current_version = step.to_version::<T>();
         }
 
         Ok(())
     }
-
-    /// Returns the next migration step for the current on-disk version.
-    ///
-    /// This must be updated whenever a new supported DB version is introduced. The match is strict:
-    /// if a step is missing, migration is aborted rather than attempting an unsafe fallback.
-    fn get_migration(&self) -> Result<MigrationStep, FinalisedStateError> {
-        match (
-            self.current_version.major,
-            self.current_version.minor,
-            self.current_version.patch,
-        ) {
-            (1, 0, 0) => Ok(MigrationStep::Migration1_0_0To1_1_0(Migration1_0_0To1_1_0)),
-            (1, 1, 0) => Ok(MigrationStep::Migration1_1_0To1_2_0(Migration1_1_0To1_2_0)),
-            (1, 2, 0) => Ok(MigrationStep::Migration1_2_0To1_2_1(Migration1_2_0To1_2_1)),
-            (_, _, _) => Err(FinalisedStateError::Custom(format!(
-                "Missing migration from version {}",
-                self.current_version
-            ))),
-        }
-    }
 }
 
-/// Concrete migration step selector.
+/// Generates the [`MigrationStep`] dispatch enum and the planner's registry from a single authored
+/// list of migration types.
 ///
-/// Rust cannot return `impl Migration<T>` from a `match` that selects between multiple concrete
-/// migration types. `MigrationStep` is the enum-based dispatch wrapper used by [`MigrationManager`]
-/// to select a step and call `migrate(...)`, and to read the step’s `TO_VERSION`.
-enum MigrationStep {
-    Migration1_0_0To1_1_0(Migration1_0_0To1_1_0),
-    Migration1_1_0To1_2_0(Migration1_1_0To1_2_0),
-    Migration1_2_0To1_2_1(Migration1_2_0To1_2_1),
+/// Each listed type is a unit struct implementing [`Migration<T>`]. The macro generates:
+/// - the `MigrationStep` enum (one variant per type),
+/// - static dispatch for `from_version` / `to_version` / `migration_type` / `migrate` (no `dyn`),
+/// - `MigrationStep::all`, the registry [`plan_migrations`] walks to build the version graph.
+///
+/// Adding a migration is therefore: implement `Migration<T>` for a new unit struct, then add its
+/// name to the `migrations! { .. }` list below. A `fn` cannot generate enum variants or match arms,
+/// so a macro is the minimal tool for this (per the repo's DRY guideline).
+macro_rules! migrations {
+    ($($step:ident),* $(,)?) => {
+        /// Concrete migration step selector (generated by [`migrations!`]).
+        ///
+        /// Rust cannot return `impl Migration<T>` from a `match` that selects between multiple
+        /// concrete migration types, so this enum provides the static dispatch over them.
+        #[derive(Clone, Copy)]
+        enum MigrationStep {
+            $($step($step),)*
+        }
+
+        impl MigrationStep {
+            /// Every registered migration step, in registry order. The planner builds the version
+            /// graph (nodes = `DbVersion`, edges = these steps) from this list.
+            fn all() -> Vec<MigrationStep> {
+                vec![$(MigrationStep::$step($step),)*]
+            }
+
+            /// The exact on-disk version this step migrates *from*.
+            fn from_version<T: BlockchainSource>(&self) -> DbVersion {
+                match self {
+                    $(MigrationStep::$step(_) => <$step as Migration<T>>::CURRENT_VERSION,)*
+                }
+            }
+
+            /// The exact on-disk version this step migrates *to*.
+            fn to_version<T: BlockchainSource>(&self) -> DbVersion {
+                match self {
+                    $(MigrationStep::$step(_) => <$step as Migration<T>>::TO_VERSION,)*
+                }
+            }
+
+            /// The routing/lifecycle category for this step.
+            fn migration_type<T: BlockchainSource>(&self) -> MigrationType {
+                match self {
+                    $(MigrationStep::$step(step) => <$step as Migration<T>>::migration_type(step),)*
+                }
+            }
+
+            /// Runs this step.
+            async fn migrate<T: BlockchainSource>(
+                &self,
+                router: Arc<Router<T>>,
+                cfg: ChainIndexConfig,
+                source: T,
+            ) -> Result<(), FinalisedStateError> {
+                match self {
+                    $(MigrationStep::$step(step) => step.migrate(router, cfg, source).await,)*
+                }
+            }
+        }
+    };
 }
 
-impl MigrationStep {
-    fn to_version<T: BlockchainSource>(&self) -> DbVersion {
-        match self {
-            MigrationStep::Migration1_0_0To1_1_0(_step) => {
-                <Migration1_0_0To1_1_0 as Migration<T>>::TO_VERSION
-            }
-            MigrationStep::Migration1_1_0To1_2_0(_step) => {
-                <Migration1_1_0To1_2_0 as Migration<T>>::TO_VERSION
-            }
-            MigrationStep::Migration1_2_0To1_2_1(_step) => {
-                <Migration1_2_0To1_2_1 as Migration<T>>::TO_VERSION
+migrations! {
+    Migration1_0_0To1_1_0,
+    Migration1_1_0To1_2_0,
+    Migration1_2_0To1_2_1,
+}
+
+/// Computes the ordered sequence of migration steps from `current` to `target` over the version
+/// graph formed by the registered migrations (nodes = `DbVersion`, edges = `MigrationStep`s).
+///
+/// The path is the shortest one found by breadth-first search; ties are broken by registry order,
+/// so the result is deterministic. Returns an empty plan when `current == target`.
+///
+/// # Errors
+/// Returns [`FinalisedStateError::Custom`] if no path exists from `current` to `target`.
+fn plan_migrations<T: BlockchainSource>(
+    current: DbVersion,
+    target: DbVersion,
+) -> Result<Vec<MigrationStep>, FinalisedStateError> {
+    use std::collections::{HashMap, HashSet, VecDeque};
+
+    if current == target {
+        return Ok(Vec::new());
+    }
+
+    let steps = MigrationStep::all();
+
+    // Adjacency by source version, preserving registry order so ties break deterministically.
+    let mut adjacency: HashMap<DbVersion, Vec<usize>> = HashMap::new();
+    for (index, step) in steps.iter().enumerate() {
+        adjacency
+            .entry(step.from_version::<T>())
+            .or_default()
+            .push(index);
+    }
+
+    // BFS from `current`, recording the predecessor edge for each newly reached version.
+    let mut predecessor: HashMap<DbVersion, (DbVersion, usize)> = HashMap::new();
+    let mut visited: HashSet<DbVersion> = HashSet::from([current]);
+    let mut queue: VecDeque<DbVersion> = VecDeque::from([current]);
+
+    while let Some(version) = queue.pop_front() {
+        if version == target {
+            break;
+        }
+        if let Some(indices) = adjacency.get(&version) {
+            for &index in indices {
+                let next = steps[index].to_version::<T>();
+                if visited.insert(next) {
+                    predecessor.insert(next, (version, index));
+                    queue.push_back(next);
+                }
             }
         }
     }
 
-    fn migration_type<T: BlockchainSource>(&self) -> MigrationType {
-        match self {
-            MigrationStep::Migration1_0_0To1_1_0(step) => {
-                <Migration1_0_0To1_1_0 as Migration<T>>::migration_type(step)
-            }
-            MigrationStep::Migration1_1_0To1_2_0(step) => {
-                <Migration1_1_0To1_2_0 as Migration<T>>::migration_type(step)
-            }
-            MigrationStep::Migration1_2_0To1_2_1(step) => {
-                <Migration1_2_0To1_2_1 as Migration<T>>::migration_type(step)
-            }
-        }
+    if !visited.contains(&target) {
+        return Err(FinalisedStateError::Custom(format!(
+            "no migration path from {current} to {target}"
+        )));
     }
 
-    async fn migrate<T: BlockchainSource>(
-        &self,
-        router: Arc<Router<T>>,
-        cfg: ChainIndexConfig,
-        source: T,
-    ) -> Result<(), FinalisedStateError> {
-        match self {
-            MigrationStep::Migration1_0_0To1_1_0(step) => step.migrate(router, cfg, source).await,
-            MigrationStep::Migration1_1_0To1_2_0(step) => step.migrate(router, cfg, source).await,
-            MigrationStep::Migration1_2_0To1_2_1(step) => step.migrate(router, cfg, source).await,
-        }
+    // Walk predecessors back from `target` to `current`, then reverse into forward order.
+    let mut plan = Vec::new();
+    let mut cursor = target;
+    while cursor != current {
+        let (previous, index) = *predecessor.get(&cursor).ok_or_else(|| {
+            FinalisedStateError::Custom(
+                "internal error: incomplete migration path reconstruction".to_string(),
+            )
+        })?;
+        plan.push(steps[index]);
+        cursor = previous;
     }
+    plan.reverse();
+
+    Ok(plan)
 }
 
 // ***** Migrations *****
@@ -453,6 +525,7 @@ impl MigrationStep {
 /// - Idempotent: if run more than once, it will re-write the same metadata.
 /// - No shadow database and no table rebuild.
 /// - Clears any stale in-progress migration status.
+#[derive(Clone, Copy)]
 struct Migration1_0_0To1_1_0;
 
 #[async_trait]
@@ -479,6 +552,7 @@ impl<T: BlockchainSource> Migration<T> for Migration1_0_0To1_1_0 {
 /// - Crash-safe: each block's spent entries, txout-set accumulator, and progress update are
 ///   committed in the same LMDB transaction.
 /// - No shadow database.
+#[derive(Clone, Copy)]
 struct Migration1_1_0To1_2_0;
 
 /// Flushes a buffered batch of `spent` index entries in sorted key order, then commits them
@@ -989,6 +1063,7 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
 /// Because there is no data change, it uses the trait's default `migration_type` ([`MigrationType::Patch`])
 /// and default `migrate` implementation, which only advances `DbMetadata::version` (and re-stamps the
 /// unchanged schema checksum). It is idempotent, builds no shadow database, and rebuilds no indices.
+#[derive(Clone, Copy)]
 struct Migration1_2_0To1_2_1;
 
 #[async_trait]
@@ -1004,4 +1079,74 @@ impl<T: BlockchainSource> Migration<T> for Migration1_2_0To1_2_1 {
         minor: 2,
         patch: 1,
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chain_index::source::mockchain_source::MockchainSource;
+
+    // Type witness: `plan_migrations` only reads the version constants, which are identical for
+    // every `BlockchainSource`, so any concrete source type works to instantiate it.
+    type Source = MockchainSource;
+
+    fn v(major: u32, minor: u32, patch: u32) -> DbVersion {
+        DbVersion::new(major, minor, patch)
+    }
+
+    /// Flattens a plan into its `(from, to)` edges for assertion.
+    fn edges(plan: &[MigrationStep]) -> Vec<(DbVersion, DbVersion)> {
+        plan.iter()
+            .map(|step| (step.from_version::<Source>(), step.to_version::<Source>()))
+            .collect()
+    }
+
+    #[test]
+    fn registry_edges_match_authored_list() {
+        assert_eq!(
+            edges(&MigrationStep::all()),
+            vec![
+                (v(1, 0, 0), v(1, 1, 0)),
+                (v(1, 1, 0), v(1, 2, 0)),
+                (v(1, 2, 0), v(1, 2, 1)),
+            ],
+        );
+    }
+
+    #[test]
+    fn plans_full_linear_path() {
+        let plan = plan_migrations::<Source>(v(1, 0, 0), v(1, 2, 1)).expect("path exists");
+        assert_eq!(
+            edges(&plan),
+            vec![
+                (v(1, 0, 0), v(1, 1, 0)),
+                (v(1, 1, 0), v(1, 2, 0)),
+                (v(1, 2, 0), v(1, 2, 1)),
+            ],
+        );
+    }
+
+    #[test]
+    fn plans_partial_path() {
+        let plan = plan_migrations::<Source>(v(1, 1, 0), v(1, 2, 0)).expect("path exists");
+        assert_eq!(edges(&plan), vec![(v(1, 1, 0), v(1, 2, 0))]);
+    }
+
+    #[test]
+    fn plan_for_equal_versions_is_empty() {
+        let plan = plan_migrations::<Source>(v(1, 2, 1), v(1, 2, 1)).expect("trivially reachable");
+        assert!(plan.is_empty());
+    }
+
+    #[test]
+    fn no_path_to_unregistered_target_errors() {
+        // No edge reaches a 2.x major yet, so the target is unreachable.
+        assert!(plan_migrations::<Source>(v(1, 0, 0), v(2, 0, 0)).is_err());
+    }
+
+    #[test]
+    fn no_path_from_unregistered_source_errors() {
+        // No edge departs from 0.0.0 (legacy v0 is rejected, not migrated).
+        assert!(plan_migrations::<Source>(v(0, 0, 0), v(1, 1, 0)).is_err());
+    }
 }

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -1315,7 +1315,9 @@ mod tests {
         crate::chain_index::finalised_state::FinalisedState<Source>,
         Source,
     ) {
-        use crate::chain_index::tests::vectors::{build_active_mockchain_source, load_test_vectors};
+        use crate::chain_index::tests::vectors::{
+            build_active_mockchain_source, load_test_vectors,
+        };
         let blocks = load_test_vectors().unwrap().blocks;
         let source = build_active_mockchain_source(active_height.0, blocks);
 
@@ -1334,7 +1336,10 @@ mod tests {
         crate::chain_index::tests::init_tracing();
 
         let temporary_directory = tempfile::tempdir().unwrap();
-        let cfg = regtest_config(temporary_directory.path().to_path_buf(), OldDbRetention::Keep);
+        let cfg = regtest_config(
+            temporary_directory.path().to_path_buf(),
+            OldDbRetention::Keep,
+        );
         let active_height = Height(20);
 
         let (db, source) = synced_v1_primary(cfg.clone(), active_height).await;
@@ -1345,12 +1350,20 @@ mod tests {
         assert!(old_primary_dir.exists());
 
         let router = Arc::clone(&db.db);
-        build_and_promote_major(Arc::clone(&router), cfg.clone(), source, DbVersion::new(2, 0, 0))
-            .await
-            .unwrap();
+        build_and_promote_major(
+            Arc::clone(&router),
+            cfg.clone(),
+            source,
+            DbVersion::new(2, 0, 0),
+        )
+        .await
+        .unwrap();
 
         // Promoted: the primary reports the target version at the old primary's preserved tip.
-        assert_eq!(router.get_metadata().await.unwrap().version(), DbVersion::new(2, 0, 0));
+        assert_eq!(
+            router.get_metadata().await.unwrap().version(),
+            DbVersion::new(2, 0, 0)
+        );
         assert_eq!(router.db_height().await.unwrap(), old_tip);
         // Retention Keep: the demoted major's directory is retained for instant switch-back.
         assert!(old_primary_dir.exists());
@@ -1361,7 +1374,10 @@ mod tests {
         crate::chain_index::tests::init_tracing();
 
         let temporary_directory = tempfile::tempdir().unwrap();
-        let cfg = regtest_config(temporary_directory.path().to_path_buf(), OldDbRetention::Delete);
+        let cfg = regtest_config(
+            temporary_directory.path().to_path_buf(),
+            OldDbRetention::Delete,
+        );
         let active_height = Height(20);
 
         let (db, source) = synced_v1_primary(cfg.clone(), active_height).await;
@@ -1369,9 +1385,14 @@ mod tests {
         assert!(old_primary_dir.exists());
 
         let router = Arc::clone(&db.db);
-        build_and_promote_major(Arc::clone(&router), cfg.clone(), source, DbVersion::new(2, 0, 0))
-            .await
-            .unwrap();
+        build_and_promote_major(
+            Arc::clone(&router),
+            cfg.clone(),
+            source,
+            DbVersion::new(2, 0, 0),
+        )
+        .await
+        .unwrap();
 
         // Retention Delete: the demoted major's directory is removed.
         assert!(!old_primary_dir.exists());
@@ -1382,7 +1403,10 @@ mod tests {
         crate::chain_index::tests::init_tracing();
 
         let temporary_directory = tempfile::tempdir().unwrap();
-        let cfg = regtest_config(temporary_directory.path().to_path_buf(), OldDbRetention::Keep);
+        let cfg = regtest_config(
+            temporary_directory.path().to_path_buf(),
+            OldDbRetention::Keep,
+        );
         let active_height = Height(20);
 
         let (db, source) = synced_v1_primary(cfg.clone(), active_height).await;
@@ -1390,23 +1414,92 @@ mod tests {
         // Simulate a major build interrupted partway: the target backend exists, is stamped
         // in-progress, and holds only a prefix of the chain.
         {
-            let partial = FinalisedSource::<Source>::spawn_major(2, &cfg).await.unwrap();
+            let partial = FinalisedSource::<Source>::spawn_major(2, &cfg)
+                .await
+                .unwrap();
             partial.wait_until_ready().await;
             let mut metadata = partial.get_metadata().await.unwrap();
             metadata.migration_status = MigrationStatus::MajorBuildInProgress;
             partial.update_metadata(metadata).await.unwrap();
-            partial.write_blocks_to_height(Height(10), &source).await.unwrap();
+            partial
+                .write_blocks_to_height(Height(10), &source)
+                .await
+                .unwrap();
             partial.env().unwrap().sync(true).unwrap();
             partial.shutdown().await.unwrap();
         }
 
         // Resuming builds the remaining blocks (from the partial tip) and promotes to the full tip.
         let router = Arc::clone(&db.db);
-        build_and_promote_major(Arc::clone(&router), cfg.clone(), source, DbVersion::new(2, 0, 0))
-            .await
-            .unwrap();
+        build_and_promote_major(
+            Arc::clone(&router),
+            cfg.clone(),
+            source,
+            DbVersion::new(2, 0, 0),
+        )
+        .await
+        .unwrap();
 
-        assert_eq!(router.get_metadata().await.unwrap().version(), DbVersion::new(2, 0, 0));
+        assert_eq!(
+            router.get_metadata().await.unwrap().version(),
+            DbVersion::new(2, 0, 0)
+        );
         assert_eq!(router.db_height().await.unwrap(), Some(active_height));
+    }
+
+    // ***** minor fail-fast guard (Step 3) *****
+
+    /// A minor migration that forgets to override `migrate()` must fail immediately rather than
+    /// silently running the patch metadata-only path.
+    #[tokio::test]
+    async fn minor_migration_without_override_fails_fast() {
+        #[derive(Clone, Copy)]
+        struct UnimplementedMinor;
+
+        #[async_trait::async_trait]
+        impl<T: BlockchainSource> Migration<T> for UnimplementedMinor {
+            const CURRENT_VERSION: DbVersion = DbVersion {
+                major: 1,
+                minor: 0,
+                patch: 0,
+            };
+            const TO_VERSION: DbVersion = DbVersion {
+                major: 1,
+                minor: 1,
+                patch: 0,
+            };
+            fn migration_type(&self) -> MigrationType {
+                MigrationType::Minor
+            }
+            // Deliberately does not override `migrate()`.
+        }
+
+        // An ephemeral state is enough: the guard errors before touching the router/cfg/source.
+        let temporary_directory = tempfile::tempdir().unwrap();
+        let mut cfg = regtest_config(
+            temporary_directory.path().to_path_buf(),
+            OldDbRetention::Keep,
+        );
+        cfg.ephemeral = true;
+        let source = crate::chain_index::tests::vectors::build_active_mockchain_source(
+            0,
+            crate::chain_index::tests::vectors::load_test_vectors()
+                .unwrap()
+                .blocks,
+        );
+        let db =
+            crate::chain_index::finalised_state::FinalisedState::spawn(cfg.clone(), source.clone())
+                .await
+                .unwrap();
+        let router = Arc::clone(&db.db);
+
+        let error = UnimplementedMinor
+            .migrate(router, cfg, source)
+            .await
+            .expect_err("a minor migration without a `migrate` override must error");
+        assert!(
+            error.to_string().contains("must override"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -219,6 +219,8 @@ pub trait Migration<T: BlockchainSource> {
     const TO_VERSION: DbVersion;
 
     /// Returns the version this step migrates *from*.
+    // `from_version` is a getter for the source version (per ADR 0002), not a constructor.
+    #[allow(clippy::wrong_self_convention)]
     fn from_version(&self) -> DbVersion {
         Self::CURRENT_VERSION
     }
@@ -228,61 +230,94 @@ pub trait Migration<T: BlockchainSource> {
         Self::TO_VERSION
     }
 
-    /// Returns the routing/lifecycle category for this migration.
+    /// Returns the routing/lifecycle category for this migration, which selects both the manager's
+    /// plumbing (see [`MigrationManager::migrate`]) and the default [`Migration::migrate`] body:
     ///
-    /// Patch migrations run directly against the current routed primary state and use the default
-    /// metadata-only migration implementation.
-    ///
-    /// Minor and major migrations are run while the migration manager holds a full-mode ephemeral
-    /// reference. During that time normal service capabilities route to ephemeral and migration code
-    /// must use direct maintenance access to the persistent backend or replacement backend.
+    /// - **Patch** — runs directly against the primary; the default `migrate` advances `DbMetadata`
+    ///   only.
+    /// - **Minor** — runs while the manager holds a full-mode ephemeral reference (reads served from
+    ///   the validator while the primary is rebuilt in place); the migration **must** override
+    ///   `migrate`.
+    /// - **Major** — the default `migrate` builds the new major from the validator and promotes it
+    ///   (see [`build_and_promote_major`]); the old primary keeps serving until the swap, so the
+    ///   manager installs no full-duration ephemeral.
     fn migration_type(&self) -> MigrationType {
         MigrationType::Patch
     }
 
     /// Performs the migration step.
     ///
-    /// Implementations may:
-    /// - spawn a shadow backend,
-    /// - build or rebuild indices,
-    /// - update metadata and migration status,
-    /// - and promote the shadow backend to primary via the router.
+    /// The default dispatches on [`Migration::migration_type`]:
+    /// - **Patch** → a metadata-only advance of the recorded version ([`migrate_metadata_only`]).
+    /// - **Major** → the generic build-and-promote helper ([`build_and_promote_major`]), targeting
+    ///   `TO_VERSION` (the newest version of the new major).
+    /// - **Minor** → fails fast: a minor migration carries bespoke in-place rebuild logic and **must**
+    ///   override this method. A compile-time check is not expressible against the runtime
+    ///   `migration_type` discriminant, so this is a fail-fast guard (covered by a registry test).
     ///
     /// # Errors
     /// Returns `FinalisedStateError` if the migration cannot proceed safely or deterministically.
-    ///
-    /// **Default**: Metadata-only migration.
-    ///
-    /// Use this for migrations where no LMDB data layout changes are required.
     async fn migrate(
         &self,
         router: Arc<Router<T>>,
-        _cfg: ChainIndexConfig,
-        _source: T,
+        cfg: ChainIndexConfig,
+        source: T,
     ) -> Result<(), FinalisedStateError> {
-        info!(
-            "Starting metadata-only migration from {} to {}.",
-            Self::CURRENT_VERSION,
-            Self::TO_VERSION,
-        );
-
-        let mut metadata: DbMetadata = router.get_metadata().await?;
-
-        metadata.version = Self::TO_VERSION;
-        metadata.schema_hash =
-            crate::chain_index::finalised_state::finalised_source::v1::DB_SCHEMA_V1_HASH;
-        metadata.migration_status = MigrationStatus::Empty;
-
-        router.update_metadata(metadata).await?;
-
-        info!(
-            "Metadata-only migration from {} to {} complete.",
-            Self::CURRENT_VERSION,
-            Self::TO_VERSION,
-        );
-
-        Ok(())
+        match self.migration_type() {
+            MigrationType::Patch => {
+                migrate_metadata_only::<T>(router, Self::CURRENT_VERSION, Self::TO_VERSION).await
+            }
+            MigrationType::Major => {
+                build_and_promote_major::<T>(router, cfg, source, Self::TO_VERSION).await
+            }
+            MigrationType::Minor => Err(FinalisedStateError::Custom(format!(
+                "minor migration {} -> {} must override migrate()",
+                Self::CURRENT_VERSION,
+                Self::TO_VERSION,
+            ))),
+        }
     }
+}
+
+/// Metadata-only migration: advances the recorded `DbMetadata::version` (and re-stamps the schema
+/// checksum), touching no table data. This is the default behaviour of a **patch** migration.
+async fn migrate_metadata_only<T: BlockchainSource>(
+    router: Arc<Router<T>>,
+    from: DbVersion,
+    to: DbVersion,
+) -> Result<(), FinalisedStateError> {
+    info!("Starting metadata-only migration from {from} to {to}.");
+
+    let mut metadata: DbMetadata = router.get_metadata().await?;
+    metadata.version = to;
+    metadata.schema_hash =
+        crate::chain_index::finalised_state::finalised_source::v1::DB_SCHEMA_V1_HASH;
+    metadata.migration_status = MigrationStatus::Empty;
+    router.update_metadata(metadata).await?;
+
+    info!("Metadata-only migration from {from} to {to} complete.");
+    Ok(())
+}
+
+/// Generic **major** migration: builds the target major from the backing validator and promotes it.
+///
+/// This is the default behaviour of a major migration (overridable for a bespoke major). The old
+/// primary keeps serving read+write while the new backend is built in its own directory; a brief
+/// ephemeral freeze covers the final catch-up and the atomic primary swap; the old directory is then
+/// kept or deleted per the retention policy. `target` is the newest version of the new major.
+///
+/// Implemented in a later step (it depends on `FinalisedSource::spawn_major`, the retention config,
+/// and `Router::replace_primary`). No major migration is registered yet, so this path is currently
+/// unreachable.
+async fn build_and_promote_major<T: BlockchainSource>(
+    _router: Arc<Router<T>>,
+    _cfg: ChainIndexConfig,
+    _source: T,
+    target: DbVersion,
+) -> Result<(), FinalisedStateError> {
+    Err(FinalisedStateError::Custom(format!(
+        "major build-and-promote to {target} is not yet implemented"
+    )))
 }
 
 /// Orchestrates a sequence of migration steps until `target_version` is reached.
@@ -328,6 +363,7 @@ impl<T: BlockchainSource> MigrationManager<T> {
 
         for step in plan {
             match step.migration_type::<T>() {
+                // Patch: metadata-only, runs directly against the primary.
                 MigrationType::Patch => {
                     step.migrate(
                         Arc::clone(&self.router),
@@ -337,7 +373,10 @@ impl<T: BlockchainSource> MigrationManager<T> {
                     .await?;
                 }
 
-                MigrationType::Minor | MigrationType::Major => {
+                // Minor: in-place rebuild of the one primary. Hold a full-mode ephemeral reference
+                // for the duration so reads are served from the validator while the primary is
+                // rewritten.
+                MigrationType::Minor => {
                     let primary = self.router.primary_backend();
                     let db_height = primary.db_height().await?;
 
@@ -351,6 +390,18 @@ impl<T: BlockchainSource> MigrationManager<T> {
                         )
                         .await?;
 
+                    step.migrate(
+                        Arc::clone(&self.router),
+                        self.cfg.clone(),
+                        self.source.clone(),
+                    )
+                    .await?;
+                }
+
+                // Major: the old primary keeps serving while a new major is built in its own
+                // directory; the build-and-promote helper installs its own brief ephemeral freeze
+                // for the swap, so the manager holds no full-duration ephemeral here.
+                MigrationType::Major => {
                     step.migrate(
                         Arc::clone(&self.router),
                         self.cfg.clone(),
@@ -397,6 +448,9 @@ macro_rules! migrations {
             }
 
             /// The exact on-disk version this step migrates *from*.
+            // Getters for the source/target versions (per ADR 0002), not constructors; the
+            // `from_*`/`to_*` self-convention lints don't apply.
+            #[allow(clippy::wrong_self_convention)]
             fn from_version<T: BlockchainSource>(&self) -> DbVersion {
                 match self {
                     $(MigrationStep::$step(_) => <$step as Migration<T>>::CURRENT_VERSION,)*
@@ -404,6 +458,7 @@ macro_rules! migrations {
             }
 
             /// The exact on-disk version this step migrates *to*.
+            #[allow(clippy::wrong_self_convention)]
             fn to_version<T: BlockchainSource>(&self) -> DbVersion {
                 match self {
                     $(MigrationStep::$step(_) => <$step as Migration<T>>::TO_VERSION,)*


### PR DESCRIPTION
- Closes https://github.com/zingolabs/zaino/issues/859

### What this does
Replaces the finalised state's rigid (major, minor, patch) migration ladder with a version-graph planner, and rebuilds startup so it honours a configured DB major even when several exist on disk. The headline win: adding a migration is now one impl + one line in a registry list — no dispatch match to edit — and startup can never strand a database that crashed mid-migration.

**This is the last plumbing DbV2 needs: once this lands, DbV2 is "a backend + one registry line".**

### Note since the issue was written
The issue describes major migrations via a "shadow DB". That mechanism was already removed and replaced by the ephemeral passthrough (reads served from the validator during migration). We built on the current primitives instead. A nice consequence: the indexer is paused during migration, so the old DB is static — the promotion swap is atomic and needs no write freeze.

### Key decisions
- Version graph, not a migration-ID DAG — Zaino has a single authoritative DbVersion per DB, so a graph covers every case without a persisted applied-set (issue's Option A).
- A migrations! { … } macro generates the dispatch enum + planner edges from one list, keeping the trait's default impls and static dispatch (no dyn) — this is what kills the boilerplate.
- Three self-plumbing types: patch/major carry zero migration code by default; only minor (an in-place rebuild) needs a body. Rule of thumb: code-only → patch, change within a major → minor, change of major → major.
- Retention config OldDbRetention { Keep, Delete } (default Keep) controls whether an old major's files survive a switch.

**All of this is pinned as a spec in docs/adr/0002-persistent-finalised-state-migrations.md — read that first.**

### The safety guarantee
Startup classifies each on-disk major as Authoritative or IncompleteBuild. A half-built new major (marked mid-build) is never served; everything else — including a DB that crashed mid-patch or mid-minor — is always reopened. So this change cannot brick your only database. There's a test asserting exactly that.

### Adding a migration (the payoff)
```
  // major: switch majors — default builds from the validator. No body needed.
  struct Migration1_2_1To2_0_0;
  impl<T: BlockchainSource> Migration<T> for Migration1_2_1To2_0_0 {
      const CURRENT_VERSION: DbVersion = DbVersion { major: 1, minor: 2, patch: 1 };
      const TO_VERSION:      DbVersion = DbVersion { major: 2, minor: 0, patch: 0 };
      fn migration_type(&self) -> MigrationType { MigrationType::Major }
  }
```
  …then add Migration1_2_1To2_0_0 to migrations! { … }. That's it. (Patch is even shorter; only minor needs a migrate() body. Full recipes in the ADR.)
  
### Testing
Cargo nextest run — 190 tests green, clippy clean. Covers the planner, classification, selection probes, retention Keep/Delete, major build/promote/resume, and the minor fail-fast guard, alongside the unchanged existing migration suite.

Major switching is implemented and tested via a #[cfg(test)] stand-in. Two tests (full restart-selection, reopen-as-major-2) wait for real DbV2, because the stand-in reuses DbV1 which enforces major == 1 — noted in spawn_major. The retention config is wired to the chain-index layer only, to be surfaced in zainod when DbV2 ships.