### PR TITLE
Support upcoming NU6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this library adheres to Rust's notion of
 
 ## Unreleased
 
+### Added
+- NU6.3 (Ironwood) network upgrade is now supported so Zaino can be consumed by
+  zallet: activation-height configuration (`zaino-common`) recognises NU6.3, and
+  Zebra RPC response parsing (`zaino-fetch`) handles the `Nu6_3` upgrade and the
+  new `ironwood` value pool. The zebra pin is bumped to the NU6.3 branch and the
+  librustzcash crates are pinned to librustzcash `main` (the NU6.3 line),
+  tracking zallet PR #537.
+
 ### Changed
 - **Breaking** — config: `storage.database.sync_write_batch_bytes` (bytes) is
   renamed to `sync_write_batch_size` and given in **GiB** (default raised from

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ dependencies = [
  "zaino-testutils",
  "zainod",
  "zcash_local_net",
- "zcash_primitives",
+ "zcash_primitives 0.29.0-pre.0",
  "zebra-chain 10.1.0",
  "zebra-rpc 10.0.1",
  "zebra-state 9.0.1",
@@ -1304,8 +1304,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=eb828caadb4b2be4a39823f95e50b42731a515f5#eb828caadb4b2be4a39823f95e50b42731a515f5"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1352,8 +1351,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=eb828caadb4b2be4a39823f95e50b42731a515f5#eb828caadb4b2be4a39823f95e50b42731a515f5"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2984,6 +2982,42 @@ name = "orchard"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
+dependencies = [
+ "aes",
+ "bitvec",
+ "blake2b_simd",
+ "corez",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "halo2_gadgets",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "hex",
+ "incrementalmerkletree",
+ "lazy_static",
+ "memuse",
+ "nonempty 0.11.0",
+ "pasta_curves",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "reddsa",
+ "serde",
+ "sinsemilla",
+ "subtle",
+ "tracing",
+ "visibility",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "orchard"
+version = "0.15.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e277dd4b46f5d06deae3ffb8af1a951e8622368f028c2a4d6fe59339566403"
 dependencies = [
  "aes",
  "bitvec",
@@ -5085,7 +5119,7 @@ dependencies = [
 [[package]]
 name = "tower-batch-control"
 version = "1.0.1"
-source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=fd3e9e32120afbe698522db1f62400b08e8a7444#fd3e9e32120afbe698522db1f62400b08e8a7444"
 dependencies = [
  "futures",
  "futures-core",
@@ -5113,7 +5147,7 @@ dependencies = [
 [[package]]
 name = "tower-fallback"
 version = "0.2.41"
-source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=fd3e9e32120afbe698522db1f62400b08e8a7444#fd3e9e32120afbe698522db1f62400b08e8a7444"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -6146,11 +6180,11 @@ dependencies = [
  "zaino-common",
  "zaino-fetch",
  "zaino-proto",
- "zcash_address",
- "zcash_keys",
- "zcash_primitives",
- "zcash_protocol",
- "zcash_transparent",
+ "zcash_address 0.13.0-pre.0",
+ "zcash_keys 0.15.0-pre.0",
+ "zcash_primitives 0.29.0-pre.0",
+ "zcash_protocol 0.10.0-pre.0",
+ "zcash_transparent 0.9.0-pre.0",
  "zebra-chain 10.1.0",
  "zebra-rpc 10.0.1",
  "zebra-state 9.0.1",
@@ -6173,7 +6207,7 @@ dependencies = [
  "zaino-state",
  "zainod",
  "zcash_local_net",
- "zcash_protocol",
+ "zcash_protocol 0.10.0-pre.0",
  "zebra-chain 10.1.0",
  "zebra-rpc 10.0.1",
  "zebra-state 9.0.1",
@@ -6199,8 +6233,8 @@ dependencies = [
  "zaino-fetch",
  "zaino-serve",
  "zaino-state",
- "zcash_address",
- "zcash_protocol",
+ "zcash_address 0.13.0-pre.0",
+ "zcash_protocol 0.10.0-pre.0",
  "zebra-chain 10.1.0",
  "zebra-state 9.0.1",
 ]
@@ -6216,14 +6250,26 @@ dependencies = [
  "corez",
  "f4jumble",
  "zcash_encoding",
- "zcash_protocol",
+ "zcash_protocol 0.9.0",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.13.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=eb828caadb4b2be4a39823f95e50b42731a515f5#eb828caadb4b2be4a39823f95e50b42731a515f5"
+dependencies = [
+ "bech32",
+ "bs58",
+ "corez",
+ "f4jumble",
+ "zcash_encoding",
+ "zcash_protocol 0.10.0-pre.0",
 ]
 
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
+source = "git+https://github.com/zcash/librustzcash.git?rev=eb828caadb4b2be4a39823f95e50b42731a515f5#eb828caadb4b2be4a39823f95e50b42731a515f5"
 dependencies = [
  "corez",
  "hex",
@@ -6235,6 +6281,16 @@ name = "zcash_history"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fde17bf53792f9c756b313730da14880257d7661b5bfc69d0571c3a7c11a76d"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "primitive-types 0.12.2",
+]
+
+[[package]]
+name = "zcash_history"
+version = "0.5.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=eb828caadb4b2be4a39823f95e50b42731a515f5#eb828caadb4b2be4a39823f95e50b42731a515f5"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -6256,16 +6312,43 @@ dependencies = [
  "group",
  "memuse",
  "nonempty 0.11.0",
- "orchard",
+ "orchard 0.14.0",
  "rand_core 0.6.4",
  "sapling-crypto",
  "secrecy",
  "subtle",
  "tracing",
- "zcash_address",
+ "zcash_address 0.12.0",
  "zcash_encoding",
- "zcash_protocol",
- "zcash_transparent",
+ "zcash_protocol 0.9.0",
+ "zcash_transparent 0.8.0",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_keys"
+version = "0.15.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=eb828caadb4b2be4a39823f95e50b42731a515f5#eb828caadb4b2be4a39823f95e50b42731a515f5"
+dependencies = [
+ "bech32",
+ "blake2b_simd",
+ "bls12_381",
+ "bs58",
+ "corez",
+ "document-features",
+ "group",
+ "memuse",
+ "nonempty 0.11.0",
+ "orchard 0.15.0-pre.1",
+ "rand_core 0.6.4",
+ "sapling-crypto",
+ "secrecy",
+ "subtle",
+ "tracing",
+ "zcash_address 0.13.0-pre.0",
+ "zcash_encoding",
+ "zcash_protocol 0.10.0-pre.0",
+ "zcash_transparent 0.9.0-pre.0",
  "zip32",
 ]
 
@@ -6283,7 +6366,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "zcash_protocol",
+ "zcash_protocol 0.9.0",
  "zebra-chain 9.0.0",
  "zebra-node-services 7.0.0",
  "zebra-rpc 9.0.0",
@@ -6322,7 +6405,7 @@ dependencies = [
  "jubjub",
  "memuse",
  "nonempty 0.11.0",
- "orchard",
+ "orchard 0.14.0",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
@@ -6330,9 +6413,39 @@ dependencies = [
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol",
+ "zcash_protocol 0.9.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.8.0",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.29.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=eb828caadb4b2be4a39823f95e50b42731a515f5#eb828caadb4b2be4a39823f95e50b42731a515f5"
+dependencies = [
+ "blake2b_simd",
+ "block-buffer 0.11.0-rc.3",
+ "corez",
+ "crypto-common 0.2.0-rc.1",
+ "document-features",
+ "equihash",
+ "ff",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty 0.11.0",
+ "orchard 0.15.0-pre.1",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "secp256k1",
+ "sha2 0.10.9",
+ "zcash_encoding",
+ "zcash_note_encryption",
+ "zcash_protocol 0.10.0-pre.0",
+ "zcash_script",
+ "zcash_transparent 0.9.0-pre.0",
 ]
 
 [[package]]
@@ -6355,7 +6468,29 @@ dependencies = [
  "tracing",
  "wagyu-zcash-parameters",
  "xdg",
- "zcash_primitives",
+ "zcash_primitives 0.28.0",
+]
+
+[[package]]
+name = "zcash_proofs"
+version = "0.29.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=eb828caadb4b2be4a39823f95e50b42731a515f5#eb828caadb4b2be4a39823f95e50b42731a515f5"
+dependencies = [
+ "bellman",
+ "blake2b_simd",
+ "bls12_381",
+ "document-features",
+ "group",
+ "home",
+ "jubjub",
+ "known-folders",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "tracing",
+ "wagyu-zcash-parameters",
+ "xdg",
+ "zcash_primitives 0.29.0-pre.0",
 ]
 
 [[package]]
@@ -6363,6 +6498,18 @@ name = "zcash_protocol"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
+dependencies = [
+ "corez",
+ "document-features",
+ "hex",
+ "memuse",
+ "zcash_encoding",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.10.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=eb828caadb4b2be4a39823f95e50b42731a515f5#eb828caadb4b2be4a39823f95e50b42731a515f5"
 dependencies = [
  "corez",
  "document-features",
@@ -6414,9 +6561,33 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address",
+ "zcash_address 0.12.0",
  "zcash_encoding",
- "zcash_protocol",
+ "zcash_protocol 0.9.0",
+ "zcash_script",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_transparent"
+version = "0.9.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=eb828caadb4b2be4a39823f95e50b42731a515f5#eb828caadb4b2be4a39823f95e50b42731a515f5"
+dependencies = [
+ "bip32",
+ "bs58",
+ "corez",
+ "document-features",
+ "getset",
+ "hex",
+ "nonempty 0.11.0",
+ "ripemd 0.1.3",
+ "secp256k1",
+ "sha2 0.10.9",
+ "subtle",
+ "zcash_address 0.13.0-pre.0",
+ "zcash_encoding",
+ "zcash_protocol 0.10.0-pre.0",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -6452,7 +6623,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "num-integer",
- "orchard",
+ "orchard 0.14.0",
  "primitive-types 0.12.2",
  "rand_core 0.6.4",
  "rayon",
@@ -6476,20 +6647,20 @@ dependencies = [
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
- "zcash_address",
+ "zcash_address 0.12.0",
  "zcash_encoding",
- "zcash_history",
+ "zcash_history 0.4.0",
  "zcash_note_encryption",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.28.0",
+ "zcash_protocol 0.9.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.8.0",
 ]
 
 [[package]]
 name = "zebra-chain"
 version = "10.1.0"
-source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=fd3e9e32120afbe698522db1f62400b08e8a7444#fd3e9e32120afbe698522db1f62400b08e8a7444"
 dependencies = [
  "bech32",
  "bitflags 2.13.0",
@@ -6515,7 +6686,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "num-integer",
- "orchard",
+ "orchard 0.15.0-pre.1",
  "primitive-types 0.12.2",
  "proptest",
  "proptest-derive",
@@ -6543,14 +6714,14 @@ dependencies = [
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
- "zcash_address",
+ "zcash_address 0.13.0-pre.0",
  "zcash_encoding",
- "zcash_history",
+ "zcash_history 0.5.0-pre.0",
  "zcash_note_encryption",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.29.0-pre.0",
+ "zcash_protocol 0.10.0-pre.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.9.0-pre.0",
  "zebra-test",
 ]
 
@@ -6574,7 +6745,7 @@ dependencies = [
  "metrics",
  "mset",
  "once_cell",
- "orchard",
+ "orchard 0.14.0",
  "rand 0.8.6",
  "rayon",
  "sapling-crypto",
@@ -6586,11 +6757,11 @@ dependencies = [
  "tower-fallback 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
  "tracing-futures",
- "zcash_primitives",
- "zcash_proofs",
- "zcash_protocol",
+ "zcash_primitives 0.28.0",
+ "zcash_proofs 0.28.0",
+ "zcash_protocol 0.9.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.8.0",
  "zebra-chain 9.0.0",
  "zebra-node-services 7.0.0",
  "zebra-script 8.0.0",
@@ -6600,7 +6771,7 @@ dependencies = [
 [[package]]
 name = "zebra-consensus"
 version = "9.0.1"
-source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=fd3e9e32120afbe698522db1f62400b08e8a7444#fd3e9e32120afbe698522db1f62400b08e8a7444"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6616,7 +6787,7 @@ dependencies = [
  "metrics",
  "mset",
  "once_cell",
- "orchard",
+ "orchard 0.15.0-pre.1",
  "rand 0.8.6",
  "rayon",
  "sapling-crypto",
@@ -6624,15 +6795,15 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tower 0.4.13",
- "tower-batch-control 1.0.1 (git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800)",
- "tower-fallback 0.2.41 (git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800)",
+ "tower-batch-control 1.0.1 (git+https://github.com/ZcashFoundation/zebra.git?rev=fd3e9e32120afbe698522db1f62400b08e8a7444)",
+ "tower-fallback 0.2.41 (git+https://github.com/ZcashFoundation/zebra.git?rev=fd3e9e32120afbe698522db1f62400b08e8a7444)",
  "tracing",
  "tracing-futures",
- "zcash_primitives",
- "zcash_proofs",
- "zcash_protocol",
+ "zcash_primitives 0.29.0-pre.0",
+ "zcash_proofs 0.29.0-pre.0",
+ "zcash_protocol 0.10.0-pre.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.9.0-pre.0",
  "zebra-chain 10.1.0",
  "zebra-node-services 8.0.0",
  "zebra-script 9.0.0",
@@ -6680,7 +6851,7 @@ dependencies = [
 [[package]]
 name = "zebra-network"
 version = "9.0.0"
-source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=fd3e9e32120afbe698522db1f62400b08e8a7444#fd3e9e32120afbe698522db1f62400b08e8a7444"
 dependencies = [
  "bitflags 2.13.0",
  "byteorder",
@@ -6733,7 +6904,7 @@ dependencies = [
 [[package]]
 name = "zebra-node-services"
 version = "8.0.0"
-source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=fd3e9e32120afbe698522db1f62400b08e8a7444#fd3e9e32120afbe698522db1f62400b08e8a7444"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -6768,7 +6939,7 @@ dependencies = [
  "metrics",
  "nix",
  "openrpsee",
- "orchard",
+ "orchard 0.14.0",
  "phf",
  "prost",
  "rand 0.8.6",
@@ -6790,13 +6961,13 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "which",
- "zcash_address",
- "zcash_keys",
- "zcash_primitives",
- "zcash_proofs",
- "zcash_protocol",
+ "zcash_address 0.12.0",
+ "zcash_keys 0.14.0",
+ "zcash_primitives 0.28.0",
+ "zcash_proofs 0.28.0",
+ "zcash_protocol 0.9.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.8.0",
  "zebra-chain 9.0.0",
  "zebra-consensus 8.0.0",
  "zebra-network 8.0.0",
@@ -6808,7 +6979,7 @@ dependencies = [
 [[package]]
 name = "zebra-rpc"
 version = "10.0.1"
-source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=fd3e9e32120afbe698522db1f62400b08e8a7444#fd3e9e32120afbe698522db1f62400b08e8a7444"
 dependencies = [
  "base64",
  "chrono",
@@ -6827,7 +6998,7 @@ dependencies = [
  "metrics",
  "nix",
  "openrpsee",
- "orchard",
+ "orchard 0.15.0-pre.1",
  "phf",
  "prost",
  "rand 0.8.6",
@@ -6849,13 +7020,13 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "which",
- "zcash_address",
- "zcash_keys",
- "zcash_primitives",
- "zcash_proofs",
- "zcash_protocol",
+ "zcash_address 0.13.0-pre.0",
+ "zcash_keys 0.15.0-pre.0",
+ "zcash_primitives 0.29.0-pre.0",
+ "zcash_proofs 0.29.0-pre.0",
+ "zcash_protocol 0.10.0-pre.0",
  "zcash_script",
- "zcash_transparent",
+ "zcash_transparent 0.9.0-pre.0",
  "zebra-chain 10.1.0",
  "zebra-consensus 9.0.1",
  "zebra-network 9.0.0",
@@ -6873,7 +7044,7 @@ dependencies = [
  "libzcash_script",
  "rand 0.8.6",
  "thiserror 2.0.18",
- "zcash_primitives",
+ "zcash_primitives 0.28.0",
  "zcash_script",
  "zebra-chain 9.0.0",
 ]
@@ -6881,12 +7052,12 @@ dependencies = [
 [[package]]
 name = "zebra-script"
 version = "9.0.0"
-source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=fd3e9e32120afbe698522db1f62400b08e8a7444#fd3e9e32120afbe698522db1f62400b08e8a7444"
 dependencies = [
  "libzcash_script",
  "rand 0.8.6",
  "thiserror 2.0.18",
- "zcash_primitives",
+ "zcash_primitives 0.29.0-pre.0",
  "zcash_script",
  "zebra-chain 10.1.0",
 ]
@@ -6932,7 +7103,7 @@ dependencies = [
 [[package]]
 name = "zebra-state"
 version = "9.0.1"
-source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=fd3e9e32120afbe698522db1f62400b08e8a7444#fd3e9e32120afbe698522db1f62400b08e8a7444"
 dependencies = [
  "bincode",
  "chrono",
@@ -6969,7 +7140,7 @@ dependencies = [
 [[package]]
 name = "zebra-test"
 version = "3.0.0"
-source = "git+https://github.com/ZcashFoundation/zebra.git?rev=9a27f886a5bfb143f65d1712e912cef252426800#9a27f886a5bfb143f65d1712e912cef252426800"
+source = "git+https://github.com/ZcashFoundation/zebra.git?rev=fd3e9e32120afbe698522db1f62400b08e8a7444#fd3e9e32120afbe698522db1f62400b08e8a7444"
 dependencies = [
  "color-eyre",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,18 @@ license = "Apache-2.0"
 zingo_common_components = "0.3.1"
 
 # Librustzcash
-incrementalmerkletree = "0.8"
-zcash_address = "0.12"
-zcash_keys = "0.14"
-zcash_protocol = "0.9"
-zcash_primitives = "0.28"
-zcash_transparent = "0.8"
+# TEMPORARY: the librustzcash crates track the NU6.3 (Ironwood) line. The
+# version requirements below match zallet PR #537 (feat/nu63-comp), and the
+# sources are pinned to librustzcash `main` via [patch.crates-io] at the bottom
+# of this file. These MUST stay in lockstep with zallet's dependency set; update
+# them only to follow zallet changes. Drop the `-pre.0` suffixes and the patch
+# once the final NU6.3 releases are published.
+incrementalmerkletree = "0.8.2"
+zcash_address = "0.13.0-pre.0"
+zcash_keys = "0.15.0-pre.0"
+zcash_protocol = "0.10.0-pre.0"
+zcash_primitives = "0.29.0-pre.0"
+zcash_transparent = "0.9.0-pre.0"
 zcash_client_backend = "0.23"
 
 # Zebra
@@ -174,12 +180,24 @@ opt-level = 3
 debug = true
 
 [patch.crates-io]
-#zcash_client_backend = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
-#zcash_address = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
-#zcash_keys = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
-#zcash_primitives = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
-#zcash_protocol = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
-#zcash_transparent = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
+# TEMPORARY: pin the librustzcash crates to `main` (the canonical, internally
+# consistent latest, which carries the NU6.3 / Ironwood work). Tracking zallet
+# PR #537 (feat/nu63-comp): both build against the NU6.3 librustzcash line so
+# zaino and zallet share one librustzcash, and the NU6.3 zebra branch below
+# resolves against the same sources. Pinned to a specific `main` rev (not the
+# bare branch) so resolution is reproducible; bump the rev to follow librustzcash
+# main. Drop this patch for plain crates.io versions once the NU6.3 releases are
+# final. Tracking: zaino#<TODO-revert-librustzcash-main>.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "eb828caadb4b2be4a39823f95e50b42731a515f5" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "eb828caadb4b2be4a39823f95e50b42731a515f5" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "eb828caadb4b2be4a39823f95e50b42731a515f5" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "eb828caadb4b2be4a39823f95e50b42731a515f5" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "eb828caadb4b2be4a39823f95e50b42731a515f5" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "eb828caadb4b2be4a39823f95e50b42731a515f5" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "eb828caadb4b2be4a39823f95e50b42731a515f5" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "eb828caadb4b2be4a39823f95e50b42731a515f5" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "eb828caadb4b2be4a39823f95e50b42731a515f5" }
+zcash_transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "eb828caadb4b2be4a39823f95e50b42731a515f5" }
 
 # TEMPORARY: zebra is pinned to an unreleased ZcashFoundation/zebra rev whose
 # ReadRequest::NonFinalizedBlocksListener is a struct variant carrying

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,16 +199,19 @@ zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "eb828
 zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "eb828caadb4b2be4a39823f95e50b42731a515f5" }
 zcash_transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "eb828caadb4b2be4a39823f95e50b42731a515f5" }
 
-# TEMPORARY: zebra is pinned to an unreleased ZcashFoundation/zebra rev whose
-# ReadRequest::NonFinalizedBlocksListener is a struct variant carrying
-# `known_chain_tips` (its Cargo version is 9.0.1, but it is NOT the published
-# crates.io 9.0.1 — that one is still a unit variant). Revert to a plain
-# version requirement once the change is released. This is the single root
-# workspace (the live-test crates were folded in; see docs/adr/0002), so the
-# patch lives here once and every member — production and live-test alike —
-# inherits it through the single lock; Cargo honours `[patch.crates-io]` only
-# from the workspace root. See docs/updating_zebra_crates.md.
+# TEMPORARY: zebra is pinned to the unreleased NU6.3 (Ironwood) branch of
+# ZcashFoundation/zebra, which adds the `NetworkUpgrade::Nu6_3` variant, the
+# `ConfiguredActivationHeights::nu6_3` field, and the sixth `ironwood` value
+# pool balance. All three zebra-* crates use the same rev. This is the exact
+# zebra rev that zallet PR #537 (feat/nu63-comp) uses, and it builds against the
+# librustzcash `main` pinned above, so zaino and zallet share one zebra and one
+# librustzcash. Revert to a plain version requirement once NU6.3 is released.
+# This is the single root workspace (the live-test crates were folded in; see
+# docs/adr/0002), so the patch lives here once and every member — production and
+# live-test alike — inherits it through the single lock; Cargo honours
+# `[patch.crates-io]` only from the workspace root. See
+# docs/updating_zebra_crates.md. Update only to follow zallet changes.
 # Tracking: zaino#<TODO-revert-zebra-fork>.
-zebra-chain = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "9a27f886a5bfb143f65d1712e912cef252426800" }
-zebra-rpc = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "9a27f886a5bfb143f65d1712e912cef252426800" }
-zebra-state = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "9a27f886a5bfb143f65d1712e912cef252426800" }
+zebra-chain = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "fd3e9e32120afbe698522db1f62400b08e8a7444" }
+zebra-rpc = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "fd3e9e32120afbe698522db1f62400b08e8a7444" }
+zebra-state = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "fd3e9e32120afbe698522db1f62400b08e8a7444" }

--- a/live-tests/clientless/tests/chain_cache.rs
+++ b/live-tests/clientless/tests/chain_cache.rs
@@ -114,6 +114,8 @@ mod chain_query_interface {
                                 nu6: local_net_activation_heights.nu6(),
                                 nu6_1: local_net_activation_heights.nu6_1(),
                                 nu6_2: local_net_activation_heights.nu6_2(),
+                                // zingo_common_components 0.3.1 has no nu6_3 slot.
+                                nu6_3: None,
                                 nu7: local_net_activation_heights.nu7(),
                             },
                         ))

--- a/live-tests/zaino-testutils/src/lib.rs
+++ b/live-tests/zaino-testutils/src/lib.rs
@@ -323,6 +323,9 @@ pub fn local_network_from_activation_heights(
         nu6_2: activation_heights
             .nu6_2
             .map(zcash_protocol::consensus::BlockHeight::from),
+        nu6_3: activation_heights
+            .nu6_3
+            .map(zcash_protocol::consensus::BlockHeight::from),
     }
 }
 
@@ -1041,6 +1044,8 @@ pub async fn launch_state_and_fetch_services_mining_to<V: ValidatorExt>(
                 nu6: activation_heights.nu6(),
                 nu6_1: activation_heights.nu6_1(),
                 nu6_2: activation_heights.nu6_2(),
+                // zingo_common_components 0.3.1 has no nu6_3 slot.
+                nu6_3: None,
                 nu7: activation_heights.nu7(),
             }
         }),

--- a/packages/zaino-common/src/config/network.rs
+++ b/packages/zaino-common/src/config/network.rs
@@ -16,6 +16,7 @@ pub const ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS: ActivationHeights = ActivationHeigh
     nu6: Some(2),
     nu6_1: Some(2),
     nu6_2: Some(2),
+    nu6_3: Some(2),
     nu7: None,
 };
 
@@ -108,6 +109,9 @@ pub struct ActivationHeights {
     /// Activation height for `NU6.2` network upgrade.
     #[serde(rename = "NU6.2")]
     pub nu6_2: Option<u32>,
+    /// Activation height for `NU6.3` (Ironwood) network upgrade.
+    #[serde(rename = "NU6.3")]
+    pub nu6_3: Option<u32>,
     /// Activation height for `NU7` network upgrade.
     #[serde(rename = "NU7")]
     pub nu7: Option<u32>,
@@ -126,6 +130,7 @@ impl Default for ActivationHeights {
             nu6: Some(2),
             nu6_1: Some(2),
             nu6_2: Some(2),
+            nu6_3: Some(2),
             nu7: None,
         }
     }
@@ -143,6 +148,10 @@ impl From<ActivationHeights> for zingo_common_components::protocol::ActivationHe
             .set_nu6(val.nu6)
             .set_nu6_1(val.nu6_1)
             .set_nu6_2(val.nu6_2)
+            // NOTE: zingo_common_components 0.3.1 has no nu6_3 slot, so the
+            // NU6.3 activation height is not carried through this intermediate.
+            // The NU6.3 height is preserved on the zebra `ConfiguredActivationHeights`
+            // path, which is what NU6.3 support actually needs.
             .set_nu7(val.nu7)
             .build()
     }
@@ -161,6 +170,7 @@ impl From<ConfiguredActivationHeights> for ActivationHeights {
             nu6,
             nu6_1,
             nu6_2,
+            nu6_3,
             nu7,
         }: ConfiguredActivationHeights,
     ) -> Self {
@@ -175,6 +185,7 @@ impl From<ConfiguredActivationHeights> for ActivationHeights {
             nu6,
             nu6_1,
             nu6_2,
+            nu6_3,
             nu7,
         }
     }
@@ -192,6 +203,7 @@ impl From<ActivationHeights> for ConfiguredActivationHeights {
             nu6,
             nu6_1,
             nu6_2,
+            nu6_3,
             nu7,
         }: ActivationHeights,
     ) -> Self {
@@ -206,6 +218,7 @@ impl From<ActivationHeights> for ConfiguredActivationHeights {
             nu6,
             nu6_1,
             nu6_2,
+            nu6_3,
             nu7,
         }
     }
@@ -224,6 +237,9 @@ impl From<zingo_common_components::protocol::ActivationHeights> for ActivationHe
             nu6: activation_heights.nu6(),
             nu6_1: activation_heights.nu6_1(),
             nu6_2: activation_heights.nu6_2(),
+            // zingo_common_components 0.3.1 has no nu6_3 slot; the NU6.3 height
+            // is not carried on this intermediate (see the forward conversion).
+            nu6_3: None,
             nu7: activation_heights.nu7(),
         }
     }
@@ -248,6 +264,7 @@ impl Network {
             nu6: Some(1),
             nu6_1: None,
             nu6_2: None,
+            nu6_3: None,
             nu7: None,
         }
     }
@@ -292,6 +309,7 @@ impl From<zebra_chain::parameters::Network> for Network {
                         nu6: None,
                         nu6_1: None,
                         nu6_2: None,
+                        nu6_3: None,
                         nu7: None,
                     };
                     for (height, upgrade) in parameters.activation_heights().iter() {
@@ -326,6 +344,9 @@ impl From<zebra_chain::parameters::Network> for Network {
                             }
                             zebra_chain::parameters::NetworkUpgrade::Nu6_2 => {
                                 activation_heights.nu6_2 = Some(height.0)
+                            }
+                            zebra_chain::parameters::NetworkUpgrade::Nu6_3 => {
+                                activation_heights.nu6_3 = Some(height.0)
                             }
                             zebra_chain::parameters::NetworkUpgrade::Nu7 => {
                                 activation_heights.nu7 = Some(height.0)
@@ -376,12 +397,16 @@ mod tests {
             nu6: Some(1),
             nu6_1: Some(1),
             nu6_2: Some(2),
+            nu6_3: Some(3),
             nu7: Some(1000),
         };
 
         let zebra_heights: zebra_chain::parameters::testnet::ConfiguredActivationHeights =
             heights.into();
         assert_eq!(zebra_heights.nu6_2, Some(2));
+        // The NU6.3 height round-trips on the zebra path (unlike the lossy
+        // zingo intermediate below, whose 0.3.1 type has no nu6_3 slot).
+        assert_eq!(zebra_heights.nu6_3, Some(3));
 
         let zingo_heights: zingo_common_components::protocol::ActivationHeights = heights.into();
         let heights = ActivationHeights::from(zingo_heights);

--- a/packages/zaino-fetch/src/jsonrpsee/response.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response.rs
@@ -361,7 +361,7 @@ pub struct GetBlockchainInfoResponse {
 
     /// Value pool balances
     #[serde(rename = "valuePools")]
-    value_pools: [ChainBalance; 5],
+    value_pools: [ChainBalance; 6],
 
     /// Branch IDs of the current and upcoming consensus rules
     pub consensus: zebra_rpc::methods::TipConsensusBranch,
@@ -539,7 +539,8 @@ mod get_tx_out_set_info_tests {
                 { "id": "sprout", "chainValue": 0.0, "chainValueZat": 0 },
                 { "id": "sapling", "chainValue": 0.0, "chainValueZat": 0 },
                 { "id": "orchard", "chainValue": 0.0, "chainValueZat": 0 },
-                { "id": "deferred", "chainValue": 0.0, "chainValueZat": 0 }
+                { "id": "deferred", "chainValue": 0.0, "chainValueZat": 0 },
+                { "id": "ironwood", "chainValue": 0.0, "chainValueZat": 0 }
             ],
             "consensus": {
                 "chaintip": "5437f330",
@@ -663,6 +664,10 @@ impl<'de> Deserialize<'de> for ChainBalance {
             // TODO: Investigate source of undocument 'lockbox' value
             // that likely is intended to be 'deferred'
             "lockbox" | "deferred" => Ok(ChainBalance(GetBlockchainInfoBalance::deferred(
+                amount, None,
+            ))),
+            // Ironwood (NU6.3) chain value pool; zero before NU6.3 activates.
+            "ironwood" => Ok(ChainBalance(GetBlockchainInfoBalance::ironwood(
                 amount, None,
             ))),
             "" => Ok(ChainBalance(GetBlockchainInfoBalance::chain_supply(
@@ -1144,7 +1149,7 @@ pub struct BlockObject {
     /// Value pool balances
     ///
     #[serde(rename = "valuePools")]
-    value_pools: Option<[ChainBalance; 5]>,
+    value_pools: Option<[ChainBalance; 6]>,
 
     /// Information about the note commitment trees.
     pub trees: GetBlockTrees,
@@ -1205,8 +1210,15 @@ impl TryFrom<GetBlockResponse> for zebra_rpc::methods::GetBlock {
                         block.difficulty,
                         block.chain_supply.map(|supply| supply.0),
                         block.value_pools.map(
-                            |[transparent, sprout, sapling, orchard, deferred]| {
-                                [transparent.0, sprout.0, sapling.0, orchard.0, deferred.0]
+                            |[transparent, sprout, sapling, orchard, deferred, ironwood]| {
+                                [
+                                    transparent.0,
+                                    sprout.0,
+                                    sapling.0,
+                                    orchard.0,
+                                    deferred.0,
+                                    ironwood.0,
+                                ]
                             },
                         ),
                         block.trees.into(),

--- a/packages/zaino-state/src/chain_index/tests/vectors.rs
+++ b/packages/zaino-state/src/chain_index/tests/vectors.rs
@@ -111,6 +111,7 @@ pub(crate) fn indexed_block_chain(
                     // see https://zips.z.cash/#nu6-1-candidate-zips for info on NU6.1
                     nu6_1: None,
                     nu6_2: None,
+                    nu6_3: None,
                     nu7: None,
                 }
                 .into(),


### PR DESCRIPTION
Based previously on https://github.com/zingolabs/zaino/pull/1340.

Don't review nor merge.

The first two commits should follow the following branches, until proper releases have been made:
- [librustzcash - dw/merge-ironwood-branch](https://github.com/zcash/librustzcash/tree/dw/merge-ironwood-branch) which includes [2509](https://github.com/zcash/librustzcash/pull/2509), but ensures that it is always up-to-date with the main branch.
- [zebra - nu63-ironwood](https://github.com/ZcashFoundation/zebra/tree/nu63-ironwood).

As the branches get updated, fixup commits can be done respectively in [e0be576](https://github.com/zingolabs/zaino/pull/1350/commits/e0be576b8478caee8feab023b59ef56be2611fdf) for librustzcash and [44dc9a8](https://github.com/zingolabs/zaino/pull/1350/commits/44dc9a8c7ca57996954dfe59a7e0a022022672c5) for zebra.