### PR TITLE
build(live-tests): bump zcash_local_net to the bump_to_NU6.3 head (Wallet abstraction)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6184,7 +6184,7 @@ dependencies = [
 [[package]]
 name = "zcash_local_net"
 version = "0.7.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?rev=78511f7304ba27895967be860016ede923acec08#78511f7304ba27895967be860016ede923acec08"
+source = "git+https://github.com/zingolabs/infrastructure.git?rev=f6a2af51e4eb65cfa5d1443f8ea00f6b9f55bf05#f6a2af51e4eb65cfa5d1443f8ea00f6b9f55bf05"
 dependencies = [
  "hex",
  "reqwest 0.12.28",
@@ -6735,12 +6735,12 @@ dependencies = [
 [[package]]
 name = "zingo-consensus"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?rev=78511f7304ba27895967be860016ede923acec08#78511f7304ba27895967be860016ede923acec08"
+source = "git+https://github.com/zingolabs/infrastructure.git?rev=f6a2af51e4eb65cfa5d1443f8ea00f6b9f55bf05#f6a2af51e4eb65cfa5d1443f8ea00f6b9f55bf05"
 
 [[package]]
 name = "zingo_test_vectors"
 version = "0.0.1"
-source = "git+https://github.com/zingolabs/infrastructure.git?rev=78511f7304ba27895967be860016ede923acec08#78511f7304ba27895967be860016ede923acec08"
+source = "git+https://github.com/zingolabs/infrastructure.git?rev=f6a2af51e4eb65cfa5d1443f8ea00f6b9f55bf05#f6a2af51e4eb65cfa5d1443f8ea00f6b9f55bf05"
 
 [[package]]
 name = "zip32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,12 +138,15 @@ zaino-testutils = { path = "live-tests/zaino-testutils" }
 # Zingo-infra (validator launcher driving the live tests; not a prod dep).
 # Pinned to an exact commit past zcash_local_net_v0.7.0: the v0.7.0 launcher's
 # zebrad config writer silently drops NU6.3 activation heights
-# (https://github.com/zingolabs/zaino/issues/1368). This rev additionally
-# makes the Validator the sole compile-time source of activation-height
-# truth (infrastructure ADR 0003, PR #278): wallet clients derive their
-# heights via `WalletNetwork::from_validator`, and `ZainodConfig` carries a
-# payload-free network kind. Restore a release tag once one is cut upstream.
-zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", rev = "78511f7304ba27895967be860016ede923acec08" }
+# (https://github.com/zingolabs/zaino/issues/1368). The pin also carries the
+# Validator-as-sole-heights-truth enforcement (infrastructure ADR 0003,
+# PR #278; wallet clients derive their heights via
+# `WalletNetwork::from_validator`, and `ZainodConfig` carries a payload-free
+# network kind), the Wallet abstraction (the `client` module renamed to
+# `wallet`, infrastructure PR #280), deterministic listener-port allocation,
+# and the Indexer-convergence barrier. Restore a release tag once one is cut
+# upstream.
+zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", rev = "f6a2af51e4eb65cfa5d1443f8ea00f6b9f55bf05" }
 
 wire_serialized_transaction_test_data = "1.0.0"
 config = { version = "0.15", default-features = false, features = ["toml"] }

--- a/live-tests/e2e/Cargo.toml
+++ b/live-tests/e2e/Cargo.toml
@@ -20,6 +20,9 @@ zcashd_support = [
     "zaino-state/zcashd_support",
     "zaino-fetch/zcashd_support",
     "zainod/zcashd_support",
+    # devtool_zcashd.rs constructs the Zcashd validator directly, so forward
+    # zcash_local_net's opt-in legacy-stack gate here as well.
+    "zcash_local_net/legacy-stack",
 ]
 
 # Single non-default gate for every devtool-incompatible / heavy test (the

--- a/live-tests/e2e/src/devtool.rs
+++ b/live-tests/e2e/src/devtool.rs
@@ -4,7 +4,7 @@
 //!
 //! [`DevtoolClients`] mirrors [`crate::Clients`]' method names one-for-one so
 //! tests can swap backends mechanically. The clients are managed by
-//! zcash_local_net's [`zcash_local_net::client`] module: each wallet
+//! zcash_local_net's [`zcash_local_net::wallet`] module: each wallet
 //! operation is a run-to-completion `zcash-devtool` subprocess invocation
 //! (the binary must be built with `--features regtest_support` and be
 //! locatable via `TEST_BINARIES_DIR`/`PATH`).
@@ -21,9 +21,9 @@
 //!   constants derived from zingolib note selection (e.g. 235_000 after
 //!   shielding 250_000) must be re-verified on first devtool runs.
 
-use zcash_local_net::client::{
+use zcash_local_net::wallet::{
     zcash_devtool::{ZcashDevtool, ZcashDevtoolConfig},
-    AddressReceiver, Client as _, GetInfo, WalletBalance,
+    AddressReceiver, GetInfo, Wallet as _, WalletBalance,
 };
 use zcash_primitives::transaction::TxId;
 
@@ -51,7 +51,7 @@ pub async fn build_clients<V: zcash_local_net::validator::Validator>(
     zaino_grpc_listen_port: u16,
     validator: &V,
 ) -> DevtoolClients {
-    let network = zcash_local_net::client::WalletNetwork::from_validator(validator).await;
+    let network = zcash_local_net::wallet::WalletNetwork::from_validator(validator).await;
 
     let mut faucet_config = ZcashDevtoolConfig::faucet(network);
     faucet_config.indexer_port = zaino_grpc_listen_port;

--- a/live-tests/e2e/tests/devtool_zcashd.rs
+++ b/live-tests/e2e/tests/devtool_zcashd.rs
@@ -3,10 +3,11 @@
 //! The zebrad devtool suite (`tests/devtool.rs`) is complete. This isolates the
 //! one remaining alignment for the zcashd matrix (the `json_server` oracle tests
 //! and the zcashd send/query column): launch zcashd at the same activation
-//! heights zebrad uses — `ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS`, which the devtool
-//! wallet's compiled-in `supported_regtest_activation_heights` requires (the 46
-//! zebrad tests prove the wallet accepts them) — rather than zcashd's default
-//! heights (all = 1), which would mismatch the wallet's consensus branch IDs.
+//! heights zebrad uses — `ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS` — rather than
+//! zcashd's default heights (all = 1), so the two matrix columns exercise one
+//! fixture shape. The wallet itself imposes no heights requirement: it derives
+//! its schedule from the running validator (infrastructure ADR 0003), so this
+//! alignment is about matrix parity, not wallet compatibility.
 //!
 //! zcashd mines ORCHARD coinbase to `REG_O_ADDR_FROM_ABANDONART` (the abandon-art
 //! orchard address the devtool faucet owns), so the faucet is funded with no
@@ -32,12 +33,13 @@ use zebra_chain::subtree::NoteCommitmentSubtreeIndex;
 use zebra_rpc::client::GetAddressBalanceRequest;
 use zebra_rpc::methods::GetAddressTxIdsRequest;
 
-/// Launch zcashd (orchard-mining) at the devtool-compatible activation heights
+/// Launch zcashd (orchard-mining) at the zebrad-matrix activation heights
 /// (`ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS`, which the PoC below proves zcashd
-/// accepts and the devtool wallet requires) and build the devtool
-/// faucet/recipient wallets against the resulting Zaino, without mining or
-/// syncing. The zcashd analogue of devtool.rs's `launch_and_build_clients`,
-/// concrete on zcashd (which has no StateService backend).
+/// accepts; the wallet derives its schedule from the validator) and build the
+/// devtool faucet/recipient wallets against the resulting Zaino, without
+/// mining or syncing. The zcashd analogue of devtool.rs's
+/// `launch_and_build_clients`, concrete on zcashd (which has no StateService
+/// backend).
 async fn launch_zcashd_and_build_clients() -> (TestManager<Zcashd, FetchService>, DevtoolClients) {
     let test_manager = TestManager::<Zcashd, FetchService>::launch_mining_to(
         zaino_testutils::SHIELDED_FUNDING_POOL, // ORCHARD
@@ -104,11 +106,11 @@ async fn faucet_receives_zcashd_orchard_reward() {
     test_manager.close().await;
 }
 
-/// Launch zcashd dual fetch services at the devtool-compatible activation
-/// heights (`ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS`, which the PoC above proves
-/// zcashd accepts and the devtool wallet requires) and build the devtool
-/// faucet/recipient wallets against the resulting Zaino — the devtool analogue
-/// of json_server's `create_zcashd_test_manager_and_fetch_services`.
+/// Launch zcashd dual fetch services at the zebrad-matrix activation heights
+/// (`ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS`, which the PoC above proves zcashd
+/// accepts; the wallet derives its schedule from the validator) and build the
+/// devtool faucet/recipient wallets against the resulting Zaino — the devtool
+/// analogue of json_server's `create_zcashd_test_manager_and_fetch_services`.
 async fn create_zcashd_devtool_services() -> (ZcashdDualFetchServices, DevtoolClients) {
     let services = zaino_testutils::launch_zcashd_dual_fetch_services_at(
         zaino_testutils::ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS,
@@ -120,6 +122,7 @@ async fn create_zcashd_devtool_services() -> (ZcashdDualFetchServices, DevtoolCl
             .zaino_grpc_listen_address
             .expect("zaino enabled")
             .port(),
+        &services.test_manager.local_net,
     )
     .await;
     (services, clients)

--- a/live-tests/zaino-testutils/Cargo.toml
+++ b/live-tests/zaino-testutils/Cargo.toml
@@ -22,6 +22,9 @@ zcashd_support = [
     "zaino-state/zcashd_support",
     "zaino-serve/zcashd_support",
     "zainod/zcashd_support",
+    # zcash_local_net gates its Zcashd validator behind this opt-in
+    # legacy-stack feature (its docs/adr/0001-excise-legacy-stack.md).
+    "zcash_local_net/legacy-stack",
 ]
 
 # **Experimental and alpha features**

--- a/live-tests/zaino-testutils/src/lib.rs
+++ b/live-tests/zaino-testutils/src/lib.rs
@@ -73,8 +73,10 @@ macro_rules! validator_tests {
 /// the truth source — and is never zainod's own schedule: zainod's config
 /// carries only a network kind, and both backends adopt the runtime schedule
 /// from the running validator's `getblockchaininfo.upgrades` (zaino#1076).
-/// It matches zcash_local_net's `supported_regtest_activation_heights`, which
-/// the devtool wallet client currently requires (zaino#1368).
+/// Wallet clients impose no constraint on this choice: they derive their
+/// schedule from the running validator too
+/// (`zcash_local_net::wallet::WalletNetwork::from_validator`, infrastructure
+/// ADR 0003).
 pub const ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS: ActivationHeights = ActivationHeights {
     before_overwinter: Some(1),
     overwinter: Some(1),
@@ -91,10 +93,10 @@ pub const ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS: ActivationHeights = ActivationHeigh
 };
 
 /// Orchard-era-only fixture: every upgrade through NU6.2 active from height 2 and
-/// NU6.3 never activating, so coinbases stay Orchard for the whole chain. For
-/// client-free launches only — the zcash-devtool wallet hardcodes the canonical
-/// regtest set (NU6.3 at 2), so wallet-built transactions on this fixture would fail
-/// consensus branch-id validation.
+/// NU6.3 never activating, so coinbases stay Orchard for the whole chain. Wallet
+/// launches on this fixture are fine: the wallet derives its schedule from the
+/// running validator (infrastructure ADR 0003), so its transactions carry the
+/// fixture's own consensus branch IDs.
 pub const ORCHARD_ONLY_ACTIVATION_HEIGHTS: ActivationHeights = ActivationHeights {
     before_overwinter: Some(1),
     overwinter: Some(1),
@@ -1327,9 +1329,10 @@ pub async fn launch_zcashd_dual_fetch_services() -> ZcashdDualFetchServices {
 }
 
 /// [`launch_zcashd_dual_fetch_services`] with the zcashd chain and both fetch
-/// services pinned to `activation_heights`, for wallet clients (e.g. the devtool
-/// wallet) whose compiled-in regtest heights differ from zcashd's defaults and
-/// must be matched by the validator.
+/// services pinned to `activation_heights`, for tests whose fixture needs a
+/// schedule other than zcashd's defaults. Wallet clients need no matching on
+/// their side: they derive their schedule from the running validator
+/// (infrastructure ADR 0003).
 #[cfg(feature = "zcashd_support")]
 #[allow(deprecated)]
 pub async fn launch_zcashd_dual_fetch_services_at(

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -1100,12 +1100,20 @@ impl<T: BlockchainSource> Migration<T> for Migration1_2_1To1_3_0 {
             )
             .await?;
 
-        // Guard: Ironwood data is only expected from NU6.3 activation. A rebuild-from-existing-data
-        // migration cannot reconstruct ironwood roots/sizes for post-NU6.3 blocks.
-        let zebra_network = cfg.network.clone();
-        let nu6_3_activation_height = crate::chain_index::ShieldedPool::Ironwood
+        // Network-upgrade activation heights (mirrors `write_blocks_to_height`). Blocks at or above
+        // NU6.3 have their ironwood root/size and ironwood tx list rebuilt from the validator (the
+        // legacy on-disk data predates ironwood); blocks below it are rebuilt in place from the
+        // legacy commitment row, with no ironwood.
+        let network = cfg.network.clone();
+        let sapling_activation_height = ShieldedPool::Sapling
             .activation_upgrade()
-            .activation_height(&zebra_network);
+            .activation_height(&network);
+        let nu5_activation_height = ShieldedPool::Orchard
+            .activation_upgrade()
+            .activation_height(&network);
+        let nu6_3_activation_height = ShieldedPool::Ironwood
+            .activation_upgrade()
+            .activation_height(&network);
 
         // Mark migration in progress (observability only; resumption uses the progress key).
         {
@@ -1200,7 +1208,7 @@ impl<T: BlockchainSource> Migration<T> for Migration1_2_1To1_3_0 {
                     })?;
                     let block = build_indexed_block_from_source(
                         &source,
-                        network,
+                        network.clone(),
                         sapling_activation_height,
                         nu5_activation_height,
                         nu6_3_activation_height,

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/migrations/v1_2_to_v1_3.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/migrations/v1_2_to_v1_3.rs
@@ -11,7 +11,7 @@
 use std::path::PathBuf;
 use tempfile::TempDir;
 use zaino_common::network::ActivationHeights;
-use zaino_common::{DatabaseConfig, Network, StorageConfig};
+use zaino_common::{DatabaseConfig, StorageConfig};
 
 use crate::chain_index::finalised_state::capability::{DbVersion, MigrationStatus};
 use crate::chain_index::finalised_state::finalised_source::v1::DB_VERSION_V1;
@@ -59,7 +59,7 @@ async fn v1_2_1_cache_migrates_to_current_then_validates() {
         },
         ephemeral: false,
         db_version: 1,
-        network: Network::Regtest(ActivationHeights::default()),
+        network: ActivationHeights::default().to_regtest_network(),
     };
 
     let source = build_active_mockchain_source(active_height.0, blocks.clone());


### PR DESCRIPTION
Stacked on #1375 (`heights_from_validator`); review only the top two commits.

This advances the infrastructure pin from `78511f73` (the ADR 0003 delivery #1375 already consumed) to `f6a2af51`, the current head of `bump_to_NU6.3` (infrastructure PR #278). The lockfile moves all three infrastructure-repo packages together: `zcash_local_net`, `zingo-consensus`, and `zingo_test_vectors`.

**What the new rev brings, and what zaino does about it:**

- The **Wallet abstraction** (infrastructure PR #280): the `client` module is renamed to `wallet` and the `Client` trait to `Wallet`. Zaino's exposure is a single file — `e2e/src/devtool.rs` updates its imports and paths. No behavioral change.
- **Deterministic listener-port allocation** and the **Indexer-convergence barrier** (`LocalNet::generate_blocks_converged` / `await_indexer_convergence`). Not adopted here; retiring zaino-testutils' own tip-polling in favor of the barrier is a natural follow-up.

**Also included (first commit):** the merge of dev into `heights_from_validator` (933c52c4) left the branch uncompilable — it resolved the v1.2.1 → v1.3.0 migration's activation-height hunk to its pre-#1379 shape while keeping #1379's loop body, and left #1379's regression test on a removed `Network::Regtest(..)` constructor. The first commit repairs both, adapted to this branch's network model (`ChainIndexConfig::network` is the zebra network itself).

**Verification:** `cargo check --all-targets` and `cargo fmt --check` are clean across the workspace; all six finalised-state migration tests pass, including #1379's regression test on the repaired code. The live e2e suites need binaries and are left to their usual runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
