### PR TITLE
Bump versions for 0.6.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5939,7 +5939,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-common"
-version = "0.2.0"
+version = "0.3.0-rc.1"
 dependencies = [
  "rustls",
  "serde",
@@ -5952,7 +5952,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-fetch"
-version = "0.2.1"
+version = "0.3.0-rc.1"
 dependencies = [
  "base64",
  "derive_more",
@@ -5992,7 +5992,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-serve"
-version = "0.3.1"
+version = "0.4.0-rc.1"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -6013,7 +6013,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-state"
-version = "0.3.1"
+version = "0.4.0-rc.1"
 dependencies = [
  "arc-swap",
  "bitflags 2.13.0",
@@ -6090,7 +6090,7 @@ dependencies = [
 
 [[package]]
 name = "zainod"
-version = "0.4.3-ironwood.1"
+version = "0.6.0-rc.1"
 dependencies = [
  "clap",
  "config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5979,7 +5979,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-proto"
-version = "0.1.3"
+version = "0.2.0-rc.1"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,15 +124,15 @@ tempfile = "3.2"
 # no longer need `default-features = false` to drop it: their default feature
 # set is already empty. Enable zcashd end-to-end with `--features zcashd_support`.
 zainod = { path = "packages/zainod" }
-zaino-common = { path = "packages/zaino-common", version = "0.2.0" }
+zaino-common = { path = "packages/zaino-common", version = "0.3.0-rc.1" }
 # default-features = false so the default-on `zcashd_support` feature can be
 # dropped end-to-end via `--no-default-features`; each consumer re-enables it
 # by forwarding `zcashd_support` in its own `default`. See
 # docs/adr/0001-zcashd-support-feature-gate.md.
-zaino-fetch = { path = "packages/zaino-fetch", version = "0.2.1", default-features = false }
+zaino-fetch = { path = "packages/zaino-fetch", version = "0.3.0-rc.1", default-features = false }
 zaino-proto = { path = "packages/zaino-proto", version = "0.1.3" }
-zaino-state = { path = "packages/zaino-state", version = "0.3.1", default-features = false }
-zaino-serve = { path = "packages/zaino-serve", version = "0.3.1", default-features = false }
+zaino-state = { path = "packages/zaino-state", version = "0.4.0-rc.1", default-features = false }
+zaino-serve = { path = "packages/zaino-serve", version = "0.4.0-rc.1", default-features = false }
 zaino-testutils = { path = "live-tests/zaino-testutils" }
 
 # Zingo-infra (validator launcher driving the live tests; not a prod dep).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ zaino-common = { path = "packages/zaino-common", version = "0.3.0-rc.1" }
 # by forwarding `zcashd_support` in its own `default`. See
 # docs/adr/0001-zcashd-support-feature-gate.md.
 zaino-fetch = { path = "packages/zaino-fetch", version = "0.3.0-rc.1", default-features = false }
-zaino-proto = { path = "packages/zaino-proto", version = "0.1.3" }
+zaino-proto = { path = "packages/zaino-proto", version = "0.2.0-rc.1" }
 zaino-state = { path = "packages/zaino-state", version = "0.4.0-rc.1", default-features = false }
 zaino-serve = { path = "packages/zaino-serve", version = "0.4.0-rc.1", default-features = false }
 zaino-testutils = { path = "live-tests/zaino-testutils" }

--- a/packages/zaino-common/Cargo.toml
+++ b/packages/zaino-common/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.0"
+version = "0.3.0-rc.1"
 
 [dependencies]
 # Zebra

--- a/packages/zaino-fetch/Cargo.toml
+++ b/packages/zaino-fetch/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.1"
+version = "0.3.0-rc.1"
 
 [features]
 default = []

--- a/packages/zaino-proto/Cargo.toml
+++ b/packages/zaino-proto/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.3"
+version = "0.2.0-rc.1"
 
 [features]
 default = ["heavy"]

--- a/packages/zaino-serve/Cargo.toml
+++ b/packages/zaino-serve/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.1"
+version = "0.4.0-rc.1"
 
 [features]
 default = []

--- a/packages/zaino-state/Cargo.toml
+++ b/packages/zaino-state/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.1"
+version = "0.4.0-rc.1"
 
 [features]
 default = []

--- a/packages/zainod/Cargo.toml
+++ b/packages/zainod/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.3-ironwood.1"
+version = "0.6.0-rc.1"
 
 [[bin]]
 name = "zainod"


### PR DESCRIPTION
Version bumps for the 0.6.0 release candidate, cut from `release_alpha` (latest dev plus the seven open PRs: #1355, #1371, #1375, #1377, #1381, #1384, #1385; #1361 landed in dev before the cut). Merging this PR fires the rc auto-tag, and the 0.6.0-rc.1 tag push triggers the Docker Hub release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)