### PR TITLE
fix: wait for the validator's first block instead of crash-looping at startup

### DIFF
--- a/packages/zaino-state/src/chain_index/source/validator_connector.rs
+++ b/packages/zaino-state/src/chain_index/source/validator_connector.rs
@@ -122,6 +122,19 @@ impl ValidatorConnector {
             .await
             .map_err(BlockchainSourceError::unrecoverable)?;
 
+        // A freshly started validator answers RPC before it has fetched and
+        // committed its first block: zebra serves getblockchaininfo and an
+        // empty getrawmempool while getbestblockhash returns "No blocks in
+        // state" until genesis arrives, which can take minutes of peer
+        // discovery. Everything downstream assumes a servable tip
+        // (Mempool::spawn returns Critical on get_best_block_hash and the
+        // ChainIndex sync loop escalates to CriticalError), so wait here
+        // instead of failing spawn and exit-looping the whole process.
+        while let Err(e) = fetcher.get_best_blockhash().await {
+            info!(%e, "Waiting for validator to serve its first block");
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        }
+
         Ok((ValidatorConnector::Fetch(fetcher), info))
     }
 
@@ -188,10 +201,19 @@ impl ValidatorConnector {
                 .and_then(|service| service.call(ReadRequest::Tip))
                 .await
                 .map_err(BlockchainSourceError::unrecoverable)?;
-            let (syncer_height, syncer_tip_hash) = expected_read_response!(syncer_response, Tip)
-                .ok_or_else(|| {
-                    BlockchainSourceError::Unrecoverable("no blocks in chain".to_string())
-                })?;
+            // A freshly started validator answers RPC before it has committed
+            // its first block (getblockchaininfo reports a genesis-hash
+            // placeholder on an empty state), and the syncer has no tip until
+            // genesis arrives, which can take minutes of peer discovery.
+            // Everything below assumes a servable tip, so wait here instead
+            // of failing spawn and exit-looping the whole process.
+            let Some((syncer_height, syncer_tip_hash)) =
+                expected_read_response!(syncer_response, Tip)
+            else {
+                info!("Waiting for validator to serve its first block");
+                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                continue;
+            };
 
             if server_height == syncer_height && server_tip_hash == syncer_tip_hash {
                 info!(


### PR DESCRIPTION
Fixes: #1388

## Problem

A freshly started validator answers JSON-RPC before it has committed any
blocks: zebra serves `getblockchaininfo` (reporting a genesis-hash
placeholder) and an empty `getrawmempool`, while `getbestblockhash` returns
"No blocks in state" until genesis arrives via peer discovery, which can take
minutes on slow networks or CI. Starting zainod in that window fails spawn on
both connector paths:

- `spawn_fetch` returns the connector without checking for a servable tip, so
  `NodeBackedChainIndex::new` fails downstream (`Mempool::spawn` returns
  `Critical` when `get_best_block_hash` errors).
- `spawn_state`'s sync-wait loop gets `None` from
  `expected_read_response!(_, Tip)` and fails with "no blocks in chain".

Under an orchestrator that gates zaino on "validator RPC answers" (the natural
healthcheck) zainod exit-loops until the validator commits genesis.

## Change

One commit, both waits in
`packages/zaino-state/src/chain_index/source/validator_connector.rs`:

1. **`spawn_fetch`**: poll `get_best_blockhash` before returning the
   connector, logging "Waiting for validator to serve its first block" every
   3s.
2. **`spawn_state`**: treat a `None` syncer tip in the existing sync-wait
   loop as wait-and-retry (log, 3s sleep, continue) instead of failing with
   "no blocks in chain".

**Does this wait forever?** Yes, by design, and only while the validator
reports an empty state. At this point in spawn the validator is reachable,
version-checked, and answering RPC, which is the same liveness standard
operators use to sequence zainod after the validator. A validator that never
commits a block is indistinguishable from one about to, and aborting would
just move the retry loop out to the process supervisor, with a Critical exit
in the logs instead of a clear message. The wait logs progress every 3
seconds so it is visible and diagnosable. Happy to switch to a bounded wait
or a configurable interval if preferred.

## Testing

- `cargo fmt --all -- --check` is clean and `cargo nextest run` (workspace
  default-members) passes locally (356 tests).
- `cargo clippy --all-targets --all-features -- -D warnings` fails identically
  on clean `dev` with rust 1.96 (pre-existing: `wrong_self_convention` in
  zaino-state test code, `manual_is_multiple_of` in zaino-fetch test code, and
  an E0425 in an all-features path of `write_core.rs`); this diff introduces
  no new clippy findings.
- Behavioral check: ran zainod against a zebra whose RPC was up on a fully
  empty state (only configured peer unroutable, so no blocks ever arrived).
  Before this change zainod fails startup and restart-loops; with it, both
  connection types log the wait message every 3s and proceed normally once
  genesis lands.
- The live/network test suites were not run locally; happy to iterate on CI.

## Related

#962 (fixes #593) hardened the chain-index sync loop against incomplete
readiness; this addresses the adjacent race in the two connector spawn paths
before the chain index exists.
