### PR TITLE
 fix(chain-index): wait for the validator's chain instead of failing at start-up

### DIFF
--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -868,6 +868,22 @@ pub(crate) struct SyncTimings {
     pub(crate) initial_backoff: Duration,
     pub(crate) max_backoff: Duration,
     pub(crate) max_consecutive_failures: u32,
+    /// Failure budget applied *before the loop has ever completed an
+    /// iteration*, i.e. while waiting for the validator to become usable at
+    /// start-up.
+    ///
+    /// A validator that has not yet committed its genesis block reports no best
+    /// block height, which reaches the loop as the same
+    /// `SyncError::ErrorFromSource` a broken validator produces. The two are
+    /// indistinguishable here, so the steady-state budget — designed for a
+    /// validator that *was* working and then failed — used to give zaino only
+    /// ~40 s to wait for a node that was still starting up, after which the
+    /// worker returned and could never recover (issue #1006).
+    ///
+    /// Start-up therefore gets its own, much larger budget. It stays bounded so
+    /// a misconfigured validator address still fails loudly instead of hanging
+    /// the daemon forever.
+    pub(crate) startup_max_consecutive_failures: u32,
 }
 
 impl Default for SyncTimings {
@@ -877,6 +893,9 @@ impl Default for SyncTimings {
             initial_backoff: Duration::from_millis(250),
             max_backoff: Duration::from_secs(8),
             max_consecutive_failures: 10,
+            // ~10 minutes: 7.75 s of ramp (250 ms doubling to the 8 s cap)
+            // followed by 74 × 8 s.
+            startup_max_consecutive_failures: 80,
         }
     }
 }
@@ -890,6 +909,10 @@ impl SyncTimings {
             initial_backoff: Duration::from_millis(25),
             max_backoff: Duration::from_millis(800),
             max_consecutive_failures: 10,
+            // Only ~2× the steady-state budget, not the production 8×: start-up
+            // tests must observe the loop *outliving* the steady-state window
+            // without waiting a full production-scale grace period.
+            startup_max_consecutive_failures: 20,
         }
     }
 
@@ -899,9 +922,19 @@ impl SyncTimings {
     /// Sums backoff delays for failures `1..max_consecutive_failures` — the
     /// final failure sets CriticalError without sleeping.
     pub(crate) fn max_backoff_window(&self) -> Duration {
+        self.backoff_window_for(self.max_consecutive_failures)
+    }
+
+    /// [`Self::max_backoff_window`] for the start-up budget — the window before
+    /// the loop's *first* successful iteration.
+    pub(crate) fn max_startup_backoff_window(&self) -> Duration {
+        self.backoff_window_for(self.startup_max_consecutive_failures)
+    }
+
+    fn backoff_window_for(&self, failures: u32) -> Duration {
         let mut total = Duration::ZERO;
         let mut current = self.initial_backoff;
-        for _ in 0..self.max_consecutive_failures.saturating_sub(1) {
+        for _ in 0..failures.saturating_sub(1) {
             total += current;
             current = (current * 2).min(self.max_backoff);
         }
@@ -1029,6 +1062,10 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
             let mut change_rx = source.subscribe_to_blocks_received();
             let mut consecutive_failures: u32 = 0;
             let mut current_backoff = timings.initial_backoff;
+            // False until the first iteration completes. While false the loop is
+            // still waiting for the validator to become usable, which gets the
+            // larger `startup_max_consecutive_failures` budget (issue #1006).
+            let mut has_completed_an_iteration = false;
             #[cfg(feature = "prometheus")]
             let mut has_reached_tip = false;
 
@@ -1128,6 +1165,7 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                     Ok(()) => {
                         consecutive_failures = 0;
                         current_backoff = timings.initial_backoff;
+                        has_completed_an_iteration = true;
                         status.store(StatusType::Ready);
                         #[cfg(feature = "prometheus")]
                         {
@@ -1165,7 +1203,20 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                             metrics::histogram!(SYNC_ITERATION_DURATION_SECONDS)
                                 .record(iteration_start.elapsed().as_secs_f64());
                         }
-                        if consecutive_failures >= timings.max_consecutive_failures {
+                        // Before the first successful iteration the validator
+                        // may simply not be up yet (a node that has not
+                        // committed genesis reports no best block height, which
+                        // arrives here as an ordinary source error). Waiting
+                        // that out is the whole point of the start-up budget;
+                        // once an iteration has succeeded, a validator that
+                        // fails really has broken and the steady-state budget
+                        // applies. See issue #1006.
+                        let failure_budget = if has_completed_an_iteration {
+                            timings.max_consecutive_failures
+                        } else {
+                            timings.startup_max_consecutive_failures
+                        };
+                        if consecutive_failures >= failure_budget {
                             #[cfg(feature = "prometheus")]
                             metrics::counter!(SYNC_ERRORS_TOTAL, "severity" => "critical")
                                 .increment(1);
@@ -1179,7 +1230,8 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                         }
                         tracing::warn!(
                             consecutive_failures,
-                            max = timings.max_consecutive_failures,
+                            max = failure_budget,
+                            awaiting_first_sync = !has_completed_an_iteration,
                             backoff = ?current_backoff,
                             ?e,
                             "sync loop iteration failed, retrying"

--- a/packages/zaino-state/src/chain_index/mempool.rs
+++ b/packages/zaino-state/src/chain_index/mempool.rs
@@ -62,33 +62,27 @@ impl<T: BlockchainSource> Mempool<T> {
         fetcher: T,
         capacity_and_shard_amount: Option<(usize, usize)>,
     ) -> Result<Self, MempoolError> {
-        // Wait for mempool in validator to come online.
-        loop {
+        // Wait for the validator to become usable. Two *distinct* conditions are
+        // awaited here, not one: its mempool coming online, and its chain having
+        // a committed block.
+        //
+        // A validator that is up but has not yet committed its genesis block
+        // answers mempool queries while reporting no best block hash. Treating
+        // that as fatal made zaino's start-up race the validator's, so zaino had
+        // to be started behind an external delay that could only ever narrow the
+        // window (issue #1006). Waiting for the chain the same way the mempool is
+        // already waited for removes the race instead of shrinking it.
+        const VALIDATOR_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
+        let best_block_hash: BlockHash = loop {
             match fetcher.get_mempool_txids().await {
-                Ok(_) => {
-                    break;
-                }
-                Err(_) => {
-                    info!("Waiting for Validator mempool to come online");
-                    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-                }
+                Err(_) => info!("Waiting for Validator mempool to come online"),
+                Ok(_) => match fetcher.get_best_block_hash().await {
+                    Ok(Some(hash)) => break hash.into(),
+                    Ok(None) => info!("Waiting for Validator to commit its genesis block"),
+                    Err(_) => info!("Waiting for Validator chain to come online"),
+                },
             }
-        }
-
-        let best_block_hash: BlockHash = match fetcher.get_best_block_hash().await {
-            Ok(block_hash_opt) => match block_hash_opt {
-                Some(hash) => hash.into(),
-                None => {
-                    return Err(MempoolError::Critical(
-                        "Error in mempool: Error connecting with validator".to_string(),
-                    ))
-                }
-            },
-            Err(_e) => {
-                return Err(MempoolError::Critical(
-                    "Error in mempool: Error connecting with validator".to_string(),
-                ))
-            }
+            tokio::time::sleep(VALIDATOR_POLL_INTERVAL).await;
         };
 
         let (chain_tip_sender, _chain_tip_reciever) = tokio::sync::watch::channel(best_block_hash);

--- a/packages/zaino-state/src/chain_index/tests.rs
+++ b/packages/zaino-state/src/chain_index/tests.rs
@@ -93,6 +93,50 @@ async fn load_test_vectors_and_sync_chain_index_with_timings(
     load_with_settings(mode, sync_timings, Duration::from_millis(25)).await
 }
 
+/// Build a chain index over a caller-supplied source, returning as soon as
+/// construction completes and *without* waiting for the sync worker to bring the
+/// non-finalised state up.
+///
+/// Taking the source as a parameter lets a test configure it — in particular
+/// `set_failing(true)` — before construction begins, which the waiting helpers
+/// below cannot express: they build the source internally and then block until
+/// the index is synced. That is what the #1006 start-up scenario needs.
+async fn build_index_with_source(
+    source: MockchainSource,
+    mode: MockchainMode,
+    sync_timings: SyncTimings,
+) -> (
+    NodeBackedChainIndex<MockchainSource>,
+    NodeBackedChainIndexSubscriber<MockchainSource>,
+) {
+    init_tracing();
+
+    let temp_dir: TempDir = tempfile::tempdir().unwrap();
+    let db_path: PathBuf = temp_dir.path().to_path_buf();
+    let seed = v1_finalised_seed_dir(mode).await;
+    copy_dir_recursive(seed, &db_path).unwrap();
+
+    let config = ChainIndexConfig {
+        storage: StorageConfig {
+            database: DatabaseConfig {
+                path: db_path,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ephemeral: false,
+        db_version: 1,
+        network: ActivationHeights::default().to_regtest_network(),
+    };
+
+    let indexer = NodeBackedChainIndex::new_with_sync_timings(source, config, sync_timings)
+        .await
+        .unwrap();
+    let index_reader = indexer.subscriber();
+
+    (indexer, index_reader)
+}
+
 async fn load_with_settings(
     mode: MockchainMode,
     sync_timings: SyncTimings,

--- a/packages/zaino-state/src/chain_index/tests/sync_loop.rs
+++ b/packages/zaino-state/src/chain_index/tests/sync_loop.rs
@@ -81,6 +81,169 @@ async fn escalates_to_critical_after_persistent_failure() {
     );
 }
 
+/// The start-up failure budget must exceed the steady-state one, or #1006's fix
+/// is a no-op — the loop would give up on a validator that is still booting just
+/// as quickly as on one that has genuinely broken.
+///
+/// Synchronous: the body is pure arithmetic over the timing constants.
+#[test]
+fn startup_budget_outlasts_steady_state_budget() {
+    for (label, timings) in [
+        ("production", SyncTimings::default()),
+        ("fast", SyncTimings::fast()),
+    ] {
+        assert!(
+            timings.max_startup_backoff_window() > timings.max_backoff_window(),
+            "{label} start-up window ({:?}) must outlast the steady-state window ({:?})",
+            timings.max_startup_backoff_window(),
+            timings.max_backoff_window(),
+        );
+    }
+}
+
+/// Regression test for #1006: a validator that is not yet usable when zaino
+/// starts must be waited out, not treated as a broken one.
+///
+/// A node that has not committed genesis reports no best block height, which
+/// reaches the sync loop as the same `ErrorFromSource` a broken node produces.
+/// The loop cannot tell them apart, so before the fix the steady-state budget
+/// (~40 s in production) applied to start-up: the worker gave up and `return`ed,
+/// and a validator that came up afterwards could never revive it. An external
+/// pre-start delay narrowed that window but could not close it.
+///
+/// The loop now spends `startup_max_consecutive_failures` before its first
+/// successful iteration, so it outlives the steady-state window and picks the
+/// chain up once the validator arrives.
+///
+/// `multi_thread` required: the assertions depend on the spawned sync worker
+/// running concurrently with this future's sleeps.
+#[tokio::test(flavor = "multi_thread")]
+async fn waits_out_validator_that_is_unavailable_at_startup() {
+    let timings = SyncTimings::fast();
+    let blocks = super::load_test_vectors().unwrap().blocks;
+    let mockchain = super::build_active_mockchain_source(150, blocks);
+
+    // Unavailable before construction begins, so the very first request the
+    // index makes observes an unusable validator rather than racing the flag.
+    mockchain.set_failing(true);
+
+    let construction = tokio::spawn({
+        let source = mockchain.clone();
+        async move { super::build_index_with_source(source, MockchainMode::Active, timings).await }
+    });
+
+    // Before the fix, construction failed here in well under a second with
+    // `MempoolError::Critical("Error connecting with validator")`. Outlast the
+    // steady-state budget to show it is now waiting rather than giving up.
+    sleep(timings.max_backoff_window()).await;
+    assert!(
+        !construction.is_finished(),
+        "chain-index construction gave up on a validator that was merely not \
+         ready yet; it must wait for the chain to come online (#1006)"
+    );
+
+    // The validator commits its genesis block and starts serving.
+    mockchain.set_failing(false);
+    let expected_tip = mockchain.active_height();
+
+    let (_indexer, index_reader) = construction.await.expect("construction task panicked");
+
+    super::poll::poll_until(
+        "indexer to sync once the validator became available",
+        Duration::from_secs(30),
+        timings.initial_backoff,
+        || async {
+            let tip = index_reader
+                .snapshot_nonfinalized_state()
+                .await
+                .ok()?
+                .get_nfs_snapshot()?
+                .best_tip
+                .height
+                .0;
+            (tip == expected_tip).then_some(())
+        },
+    )
+    .await;
+
+    assert_eq!(
+        index_reader.status(),
+        StatusType::Ready,
+        "sync loop should report Ready once it has caught up with the validator"
+    );
+}
+
+/// Reproduction for #1006 — the failure is terminal, not transient.
+///
+/// When the backoff ladder is exhausted the sync loop does not merely report
+/// [`StatusType::CriticalError`]: it `return`s, so the worker task itself is
+/// gone. A validator that becomes reachable afterwards can never revive it.
+///
+/// This is what makes "zaino assumes the genesis block is confirmed" a race
+/// rather than a slow start. A validator that has not yet committed genesis
+/// makes `get_best_block_height` yield nothing, every iteration counts as a
+/// failure, and ~40 s later (production timings) the worker exits for good.
+/// At startup that is fatal: `NodeBackedIndexerService::launch` polls the
+/// status and aborts the daemon on `CriticalError`. An external pre-start
+/// delay narrows the window but cannot close it.
+///
+/// `multi_thread` required: the assertions depend on the spawned sync worker
+/// running concurrently with this future's sleeps.
+#[tokio::test(flavor = "multi_thread")]
+async fn critical_error_is_terminal_and_source_recovery_does_not_revive_sync() {
+    let timings = SyncTimings::fast();
+    let (_blocks, _indexer, index_reader, mockchain) =
+        load_test_vectors_and_sync_chain_index_with_timings(MockchainMode::Active, timings).await;
+
+    let index_tip = || async {
+        index_reader
+            .snapshot_nonfinalized_state()
+            .await
+            .ok()
+            .and_then(|s| s.get_nfs_snapshot().map(|n| n.best_tip.height.0))
+    };
+
+    // The validator becomes unavailable. At startup this is the window in
+    // which it has not yet committed genesis.
+    mockchain.set_failing(true);
+
+    let max_wait = timings.max_backoff_window() * 5;
+    let start = Instant::now();
+    loop {
+        sleep(timings.initial_backoff).await;
+        if index_reader.status() == StatusType::CriticalError {
+            break;
+        }
+        assert!(
+            start.elapsed() < max_wait,
+            "CriticalError was not reached within {max_wait:?}"
+        );
+    }
+    let tip_at_failure = index_tip().await;
+
+    // The validator comes back and extends the chain — the recovery an
+    // operator (or an external start-up delay) would expect zaino to ride out.
+    mockchain.set_failing(false);
+    mockchain.mine_blocks(5);
+    let recovered_source_tip = mockchain.active_height();
+
+    // Give the loop far longer than a full backoff ladder to notice.
+    sleep(max_wait).await;
+
+    assert_eq!(
+        index_reader.status(),
+        StatusType::CriticalError,
+        "sync loop recovered after the source returned — if this now passes, \
+         the terminal-failure behaviour reported in #1006 has been fixed"
+    );
+    assert_eq!(
+        index_tip().await,
+        tip_at_failure,
+        "index tip advanced to {recovered_source_tip} after recovery, so the \
+         sync worker was still alive — #1006's premise no longer holds"
+    );
+}
+
 /// Moved here from the integration test
 /// `chain_cache::sync_large_chain_{zebrad,zcashd}`. That test contained one
 /// whitebox read — `snapshot.best_tip.height` (W11 in the issue #1044


### PR DESCRIPTION

Fixes #1006. Zaino's start-up raced the validator's: if the validator had not yet committed its genesis block, `Mempool::spawn` failed immediately and the daemon never started. It now waits for the chain the same way it already waits for the mempool.

## Root cause

`Mempool::spawn` already anticipated a validator that isn't up, it polls `get_mempool_txids()` in a loop. The very next call had no such tolerance:

```rust
// Wait for mempool in validator to come online.
loop {
    match fetcher.get_mempool_txids().await {
        Ok(_) => break,
        Err(_) => { info!("Waiting for Validator mempool to come online"); sleep(3s).await; }
    }
}

let best_block_hash = match fetcher.get_best_block_hash().await {
    Ok(Some(hash)) => hash.into(),
    Ok(None) => return Err(MempoolError::Critical(...)),   // ← no retry
    Err(_)    => return Err(MempoolError::Critical(...)),
};
```

`get_best_block_hash()` returns `Ok(None)` in exactly one situation: **no block is committed yet.** So a validator that was up and answering mempool queries, but had not yet committed genesis, produced a hard `Critical` and killed start-up. That is the issue's "zaino assumes the genesis block is committed", precisely, and why the reported workaround was an external 10-second delay, which can only narrow the window, never close it.

A second, later failure point compounds it. The chain-index sync loop opens each iteration with `get_best_block_height()`, and a validator with no chain reaches it as the same `SyncError::ErrorFromSource` a *broken* validator produces:

```rust
let chain_height = source.get_best_block_height().await
    .map_err(source_error)?                                      // ← validator broken
    .ok_or_else(|| source_error(std::io::Error::other(
        "node returned no best block height")))?;                // ← validator has no chain yet
```

The loop cannot distinguish the two, so the steady-state budget, 10 consecutive failures, ~40 s, designed for a validator that *was* working and then broke, applied to start-up. On expiry the worker does not merely report `CriticalError`; it `return`s, so it is gone and a validator arriving later can never revive it.

## The fix

**`mempool.rs`**, fold the chain check into the existing wait loop, with a distinct log line per condition. This is the primary fix.

**`chain_index.rs`**, add `startup_max_consecutive_failures` (80 ≈ 10 min), applied until the loop's first successful iteration. The steady-state budget of 10 is unchanged, so a validator that breaks mid-run still escalates in ~40 s. Defence in depth: with the mempool fix in place the sync loop should not see a chainless validator, but the two failure modes are independent and the loop should not be the thing that assumes otherwise.

## Verification

Reproduced first, then fixed. The reproduction test passes against the *unfixed* tree, showing the failure is terminal:

```
WARN  sync loop iteration failed, retrying  consecutive_failures=1   max=10  backoff=25ms
...
ERROR sync loop failed, giving up           consecutive_failures=10
```

— after which the source recovered and mined 5 blocks, and the tip never moved.

Tests added:

| Test | Proves |
|---|---|
| `waits_out_validator_that_is_unavailable_at_startup` | Regression test: construction waits instead of dying, then syncs once the validator arrives |
| `critical_error_is_terminal_and_source_recovery_does_not_revive_sync` | The original reproduction, the worker is *gone*, not merely unhealthy |
| `startup_budget_outlasts_steady_state_budget` | The property the fix rests on; if it ever fails, the fix has silently become a no-op |

Also adds a `build_index_with_source` test helper. None of the existing helpers could express "validator unavailable at construction", they build the source internally and block until synced, so the scenario was previously untestable.

**366/366 tests pass** (`cargo nextest run --no-default-features`), `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean.
