### PR TITLE
Release 0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
     name: Repo guards
     # GitHub-hosted runner so it runs on pull requests. Runs the workbench
     # repo guards: the rustc-pin check (Dockerfile.deterministic's pallet-rust
-    # tag == rust-toolchain.toml channel) and the no-OpenSSL-apt check, plus the
-    # crate's own fmt/clippy/tests.
+    # tag == rust-toolchain.toml channel), the no-OpenSSL-apt check, and the
+    # duplicate-Rust-logic check, plus the crate's own fmt/clippy/tests.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -79,6 +79,9 @@ jobs:
 
       - name: Check no OpenSSL apt packages
         run: cargo run -q --manifest-path tools/workbench/Cargo.toml --bin check-no-openssl-apt
+
+      - name: Check for duplicate Rust logic
+        run: cargo run -q --manifest-path tools/workbench/Cargo.toml --bin check-code-duplication
 
   cargo-deny:
     name: cargo-deny

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,6 +59,16 @@ _Avoid_: mixing vocabularies in one name or one sibling set (e.g. an
 `ORCHARD_ONLY_*` fixture whose sibling is `NU6_3_ACTIVE_*` — the sibling
 is `IRONWOOD_ONLY_*`)
 
+**Unfiltered pool set**:
+The pool set served when a client's `poolTypes` request field is empty —
+every shielded pool (Sapling, Orchard, Ironwood), transparent excluded.
+It has exactly one definition (`PoolTypeFilter::default`); serving any
+narrower backfill makes compact blocks disagree with their own
+`chainMetadata` tree sizes, which scanning wallets read as a phantom
+reorg.
+_Avoid_: default pools, backfill set, "Sapling and Orchard" (stale —
+predates Ironwood)
+
 **Cross-address restriction**:
 The post-NU6.3 rule the Orchard Action circuit enforces: "(g_d, pk_d)
 of the output note must equal (g_d, pk_d) of the spent note" — the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5834,7 +5834,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-fetch"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64",
  "derive_more",
@@ -5861,7 +5861,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-proto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "prost",
  "tonic",
@@ -5874,7 +5874,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-serve"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -5895,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-state"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arc-swap",
  "bitflags 2.13.0",
@@ -5967,7 +5967,7 @@ dependencies = [
 
 [[package]]
 name = "zainod"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,10 +127,10 @@ zaino-common = { path = "packages/zaino-common", version = "0.4.0" }
 # dropped end-to-end via `--no-default-features`; each consumer re-enables it
 # by forwarding `zcashd_support` in its own `default`. See
 # docs/adr/0001-zcashd-support-feature-gate.md.
-zaino-fetch = { path = "packages/zaino-fetch", version = "0.4.0", default-features = false }
-zaino-proto = { path = "packages/zaino-proto", version = "0.2.0" }
-zaino-state = { path = "packages/zaino-state", version = "0.5.0", default-features = false }
-zaino-serve = { path = "packages/zaino-serve", version = "0.5.0", default-features = false }
+zaino-fetch = { path = "packages/zaino-fetch", version = "0.4.1", default-features = false }
+zaino-proto = { path = "packages/zaino-proto", version = "0.3.0" }
+zaino-state = { path = "packages/zaino-state", version = "0.6.0", default-features = false }
+zaino-serve = { path = "packages/zaino-serve", version = "0.5.1", default-features = false }
 zaino-testutils = { path = "live-tests/zaino-testutils" }
 
 # Zingo-infra (validator launcher driving the live tests; not a prod dep).

--- a/docs/adr/0007-block-persistence-is-a-row-set-boundary.md
+++ b/docs/adr/0007-block-persistence-is-a-row-set-boundary.md
@@ -1,0 +1,82 @@
+# Block persistence is a row-set boundary; the domain block is not a storage value
+
+## Status
+
+accepted
+
+## Context and decision
+
+`IndexedBlock` is zaino's domain block aggregate: the typed, tx-major,
+chain-positioned block that the non-finalised state holds in memory and
+that both boundary projections derive from (`to_compact_block()` toward
+the wire, the finalised writer toward disk). For its entire history the
+type also *claimed* to be a storage value: it carried a wholesale
+`ZainoVersionedSerde` impl defining a monolithic single-value block
+format.
+
+That claim was never true in production. The archaeology (July 2026):
+the encoding was written in May 2025, two days after the type itself
+(then named `ChainBlock`), with zero consumers, in anticipation of the
+coming finalised state. When the finalised state actually arrived it
+made a different choice both times — v0 stored wire `CompactBlock`s
+derived via `to_compact_block()`, and v1 stores decomposed **pool-major
+rows** (`BlockHeaderData`, `TxidList`, per-pool tx lists,
+`CommitmentTreeData`), rebuilding blocks by transposition. The wholesale
+format's only callers were ever test-vector fixtures, deleted in autumn
+2025. The impl survived on classification alone: when the October 2025
+types refactor dropped it, commit `ded77d15` restored it as "missing"
+on the reasoning that `IndexedBlock` "is a database-serializable type."
+No bytes in the format ever existed in any production database.
+
+We decide:
+
+1. **The storage form of a block is the set of v1 rows** — pool-major,
+   independently versioned via `ZainoVersionedSerde`, and readable in
+   pool-filtered subsets. There is no single-value block format.
+2. **`IndexedBlock` is not a storage value and does not implement
+   `ZainoVersionedSerde`.** The dead impls (`IndexedBlock`, and
+   `CompactTxData`, whose only caller was `IndexedBlock::decode_v1`)
+   are deleted, not maintained. Do not "fix" this by restoring them —
+   that is precisely the `ded77d15` failure mode this ADR exists to
+   prevent. A block reaches disk only by decomposition into rows and
+   returns only by reassembly from them.
+3. **The block ↔ row-set correspondence gets one type-level home**: a
+   `Persistent*`-doctrine twin (working name `PersistentBlock`) holding
+   the row types as fields, with `from_business(&IndexedBlock)` owning
+   the tx-major → pool-major scatter and `into_business()` owning the
+   reverse transposition. The v1 writer (including the schema-compat
+   downgrade writer, which scatters the same block into old-layout
+   rows) and the v1 reader both delegate to it, so the two directions
+   are halves of one impl with a round-trip law, instead of two distant
+   procedural code paths kept inverse by discipline. `PersistentBlock`
+   itself is **not** a stored value and does not implement
+   `ZainoVersionedSerde`; each row still stores independently.
+
+## Considered options
+
+- **Keep the wholesale impl as a second schema** (status quo):
+  rejected — a complete storage format with no bytes behind it,
+  maintained through two renames and multiple refactors, repeatedly
+  mistaken for load-bearing.
+- **Adopt the wholesale format** (store blocks as single values):
+  rejected by the schema's actual requirements — pool-filtered serving
+  reads row subsets, and the transposed grain is the point of the v1
+  layout.
+- **Keep the correspondence procedural** (writer and reader each state
+  the decomposition): rejected — a field added to one side and
+  forgotten on the other is a runtime bug; in the twin it is a compile
+  error.
+
+## Consequences
+
+- Every role now has exactly one home: proto types for the wire,
+  `IndexedBlock` for the domain, row types (+ `PersistentBlock` as
+  their aggregate correspondence) for storage — with named conversions
+  as the only crossings, per the boundary-conversion doctrine in
+  CLAUDE.md.
+- The deletion needs no data migration: there are no bytes in the
+  removed format anywhere.
+- The wire ↔ domain boundary is already schema-first (`.proto` is the
+  single declaration; prost generates the foreign twin;
+  `to_wire`/`try_from_wire` carry validation) and needs no analogous
+  change.

--- a/live-tests/clientless/Cargo.toml
+++ b/live-tests/clientless/Cargo.toml
@@ -36,6 +36,8 @@ zaino-fetch = { workspace = true }
 zaino-testutils = { workspace = true }
 # The lib's z_validate helper calls `ZcashIndexer::z_validate_address`.
 zaino-state = { workspace = true, features = ["test_dependencies"] }
+# The lib's get_block_header oracle helper matches on `zebra_rpc::methods::GetBlock`.
+zebra-rpc = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/live-tests/clientless/src/lib.rs
+++ b/live-tests/clientless/src/lib.rs
@@ -2,6 +2,41 @@
 //!
 //! This crate also exposes test-vectors.
 
+/// Assert that `oracle` and `subject` return the same `getblockheader` response for
+/// the block at `height`: look the block up on the oracle (verbosity 1) to learn its
+/// hash, then compare the two servers' non-verbose header responses for that hash.
+/// Shared body of the per-backend `get_block_header` oracle tests.
+#[allow(deprecated)]
+pub async fn assert_get_block_header_matches<Oracle, Subject>(
+    oracle: &Oracle,
+    subject: &Subject,
+    height: u32,
+) where
+    Oracle: zaino_state::ZcashIndexer,
+    Subject: zaino_state::ZcashIndexer,
+{
+    let block = oracle
+        .z_get_block(height.to_string(), Some(1))
+        .await
+        .unwrap();
+
+    let block_hash = match block {
+        zebra_rpc::methods::GetBlock::Object(block) => block.hash(),
+        zebra_rpc::methods::GetBlock::Raw(_) => panic!("Expected block object"),
+    };
+
+    let oracle_header = oracle
+        .get_block_header(block_hash.to_string(), false)
+        .await
+        .unwrap();
+
+    let subject_header = subject
+        .get_block_header(block_hash.to_string(), false)
+        .await
+        .unwrap();
+    assert_eq!(oracle_header, subject_header);
+}
+
 pub mod rpc {
     pub mod json_rpc {
         pub const VALID_P2PKH_ADDRESS: &str = "tmVqEASZxBNKFTbmASZikGa5fPLkd68iJyx";

--- a/live-tests/clientless/tests/compact_block_consistency.rs
+++ b/live-tests/clientless/tests/compact_block_consistency.rs
@@ -157,20 +157,42 @@ async fn unfiltered_compact_blocks_match_chain_metadata_zebrad() {
     test_manager.close().await;
 }
 
-/// Class-1 (consensus) predicate: in the NU5-through-NU6.2 era, a shielded
-/// (orchard-receiver) miner's coinbase carries the reward as Orchard actions.
+/// The shielded pool a miner's coinbase routes the reward to: Orchard in the
+/// NU5-through-NU6.2 era (transaction v5), Ironwood from NU6.3 (v6).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CoinbaseRewardPool {
+    Orchard,
+    Ironwood,
+}
+
+/// Shared body of the class-1 (consensus) coinbase predicates: the first
+/// transaction is a coinbase of the era's version, carries the reward as at least
+/// one action in `pool`, and has an empty sapling component and an empty
+/// other-shielded-pool component.
 ///
 /// The action count uses `>= 1` rather than the padded exact count so the predicate
 /// does not couple to the Orchard bundle-padding rule.
-fn is_valid_orchard_coinbase(block: &zebra_chain::block::Block) -> bool {
+fn is_valid_shielded_coinbase(block: &zebra_chain::block::Block, pool: CoinbaseRewardPool) -> bool {
     let Some(coinbase) = block.transactions.first() else {
         return false;
     };
+    let orchard_actions = coinbase.orchard_actions().count();
+    let ironwood_actions = coinbase.ironwood_actions().count();
+    let (version, rewarded_pool_actions, other_pool_actions) = match pool {
+        CoinbaseRewardPool::Orchard => (5, orchard_actions, ironwood_actions),
+        CoinbaseRewardPool::Ironwood => (6, ironwood_actions, orchard_actions),
+    };
     coinbase.is_coinbase()
-        && coinbase.version() == 5
+        && coinbase.version() == version
         && coinbase.sapling_outputs().count() == 0
-        && coinbase.orchard_actions().count() >= 1
-        && coinbase.ironwood_actions().count() == 0
+        && rewarded_pool_actions >= 1
+        && other_pool_actions == 0
+}
+
+/// Class-1 (consensus) predicate: in the NU5-through-NU6.2 era, a shielded
+/// (orchard-receiver) miner's coinbase carries the reward as Orchard actions.
+fn is_valid_orchard_coinbase(block: &zebra_chain::block::Block) -> bool {
+    is_valid_shielded_coinbase(block, CoinbaseRewardPool::Orchard)
 }
 
 /// Class-1 (consensus) predicate: from NU6.3 the same miner's coinbase must have an
@@ -182,14 +204,7 @@ fn is_valid_orchard_coinbase(block: &zebra_chain::block::Block) -> bool {
 /// builder off-by-one vs missing routing vs a zaino pool-swap). This predicate over
 /// raw validator blocks is that issue's disambiguator.
 fn is_valid_ironwood_coinbase(block: &zebra_chain::block::Block) -> bool {
-    let Some(coinbase) = block.transactions.first() else {
-        return false;
-    };
-    coinbase.is_coinbase()
-        && coinbase.version() == 6
-        && coinbase.sapling_outputs().count() == 0
-        && coinbase.orchard_actions().count() == 0
-        && coinbase.ironwood_actions().count() >= 1
+    is_valid_shielded_coinbase(block, CoinbaseRewardPool::Ironwood)
 }
 
 /// One-line coinbase summary for assertion messages, so a predicate failure names the

--- a/live-tests/clientless/tests/json_server.rs
+++ b/live-tests/clientless/tests/json_server.rs
@@ -286,7 +286,6 @@ mod zcashd {
 
     pub(crate) mod zcash_indexer {
         use zaino_state::LightWalletIndexer;
-        use zebra_rpc::methods::GetBlock;
 
         use super::*;
 
@@ -453,29 +452,12 @@ mod zcashd {
                     &services.zaino_subscriber,
                     &services.zcashd_subscriber,
                     async |i| {
-                        let block = services
-                            .zcashd_subscriber
-                            .z_get_block(i.to_string(), Some(1))
-                            .await
-                            .unwrap();
-
-                        let block_hash = match block {
-                            GetBlock::Object(block) => block.hash(),
-                            GetBlock::Raw(_) => panic!("Expected block object"),
-                        };
-
-                        let zcashd_get_block_header = services
-                            .zcashd_subscriber
-                            .get_block_header(block_hash.to_string(), false)
-                            .await
-                            .unwrap();
-
-                        let zainod_block_header_response = services
-                            .zaino_subscriber
-                            .get_block_header(block_hash.to_string(), false)
-                            .await
-                            .unwrap();
-                        assert_eq!(zcashd_get_block_header, zainod_block_header_response);
+                        clientless::assert_get_block_header_matches(
+                            &services.zcashd_subscriber,
+                            &services.zaino_subscriber,
+                            i,
+                        )
+                        .await;
                     },
                 )
                 .await;

--- a/live-tests/clientless/tests/state_service.rs
+++ b/live-tests/clientless/tests/state_service.rs
@@ -650,7 +650,6 @@ mod zebra {
     pub(crate) mod lightwallet_indexer {
         use futures::StreamExt as _;
         use zaino_proto::proto::service::{BlockId, BlockRange, GetSubtreeRootsArg};
-        use zebra_rpc::methods::GetBlock;
 
         use super::*;
 
@@ -712,32 +711,12 @@ mod zebra {
                     &services.fetch_subscriber,
                     &services.state_subscriber,
                     async |i| {
-                        let block = services
-                            .fetch_subscriber
-                            .z_get_block(i.to_string(), Some(1))
-                            .await
-                            .unwrap();
-
-                        let block_hash = match block {
-                            GetBlock::Object(block) => block.hash(),
-                            GetBlock::Raw(_) => panic!("Expected block object"),
-                        };
-
-                        let fetch_service_get_block_header = services
-                            .fetch_subscriber
-                            .get_block_header(block_hash.to_string(), false)
-                            .await
-                            .unwrap();
-
-                        let state_service_block_header_response = services
-                            .state_subscriber
-                            .get_block_header(block_hash.to_string(), false)
-                            .await
-                            .unwrap();
-                        assert_eq!(
-                            fetch_service_get_block_header,
-                            state_service_block_header_response
-                        );
+                        clientless::assert_get_block_header_matches(
+                            &services.fetch_subscriber,
+                            &services.state_subscriber,
+                            i,
+                        )
+                        .await;
                     },
                 )
                 .await;

--- a/live-tests/e2e/src/devtool.rs
+++ b/live-tests/e2e/src/devtool.rs
@@ -250,3 +250,239 @@ impl Pool {
         }
     }
 }
+
+/// Launch a shielded-mining validator of `validator` kind (at `activation_heights`,
+/// or the kind's defaults on `None`) with Zaino serving gRPC, and build the devtool
+/// faucet/recipient wallets against it, without mining or syncing. The shared body
+/// of the per-validator `launch_*_and_build_clients` preambles in the devtool test
+/// binaries.
+pub async fn launch_and_build_devtool_clients<V, Conn>(
+    validator: &zaino_testutils::ValidatorKind,
+    activation_heights: Option<zaino_common::network::ActivationHeights>,
+) -> (zaino_testutils::TestManager<V, Conn>, DevtoolClients)
+where
+    V: zaino_testutils::ValidatorExt,
+    Conn: zaino_testutils::ValidatorConnectionMarker,
+{
+    let test_manager = zaino_testutils::TestManager::<V, Conn>::launch_mining_to(
+        zaino_testutils::SHIELDED_FUNDING_POOL,
+        validator,
+        None, // network -> Regtest
+        activation_heights,
+        None,  // no chain cache: build fresh
+        true,  // enable zaino
+        false, // no json-rpc server
+        false, // no clients (the devtool wallet is built separately)
+    )
+    .await
+    .expect("launch TestManager");
+
+    let clients = build_clients(
+        test_manager
+            .zaino_grpc_listen_address
+            .expect("zaino enabled")
+            .port(),
+        &test_manager.local_net,
+    )
+    .await;
+
+    (test_manager, clients)
+}
+
+/// The faucet sends 250_000 zatoshis to the recipient's `pool` address, the send is
+/// mined in, and the recipient's synced wallet shows the receipt in that pool.
+/// Shared body of the per-validator `send_to_pool` tests; the caller launches and
+/// funds the faucet first.
+pub async fn assert_send_to_pool<V, Conn>(
+    mut test_manager: zaino_testutils::TestManager<V, Conn>,
+    mut clients: DevtoolClients,
+    pool: Pool,
+) where
+    V: zaino_testutils::ValidatorExt,
+    Conn: zaino_testutils::ValidatorConnectionMarker,
+{
+    let recipient = clients.get_recipient_address(pool.address_kind()).await;
+    let txid = clients.send_from_faucet(&recipient, 250_000).await;
+    dbg!(txid);
+
+    test_manager
+        .generate_blocks_and_wait_for_tip(1, test_manager.subscriber())
+        .await;
+    clients.sync_recipient().await;
+
+    assert_eq!(
+        pool.spendable_balance(&clients.recipient_balance().await),
+        250_000
+    );
+
+    test_manager.close().await;
+}
+
+/// The recipient receives a transparent send, confirms it, shields it, and confirms
+/// the shielded balance net of the ZIP-317 fee (250_000 − 15_000 = 235_000) in
+/// `shielded_pool` — [`Pool::Ironwood`] under NU6.3-era heights (devtool routes
+/// `shield` there), [`Pool::Orchard`] under pre-NU6.3 heights. Shared body of the
+/// per-validator `shield` tests; the caller launches and funds the faucet first.
+pub async fn assert_shield_for_validator<V, Conn>(
+    mut test_manager: zaino_testutils::TestManager<V, Conn>,
+    mut clients: DevtoolClients,
+    shielded_pool: Pool,
+) where
+    V: zaino_testutils::ValidatorExt,
+    Conn: zaino_testutils::ValidatorConnectionMarker,
+{
+    let recipient_taddr = clients.get_recipient_address("transparent").await;
+    clients.send_from_faucet(&recipient_taddr, 250_000).await;
+    test_manager
+        .generate_blocks_and_wait_for_tip(1, test_manager.subscriber())
+        .await;
+    clients.sync_recipient().await;
+
+    assert_eq!(
+        Pool::Transparent.spendable_balance(&clients.recipient_balance().await),
+        250_000
+    );
+
+    clients.shield_recipient().await;
+    test_manager
+        .generate_blocks_and_wait_for_tip(1, test_manager.subscriber())
+        .await;
+    clients.sync_recipient().await;
+
+    assert_eq!(
+        shielded_pool.spendable_balance(&clients.recipient_balance().await),
+        235_000
+    );
+
+    test_manager.close().await;
+}
+
+/// A transparent send returns the same address txids from the non-finalized chain
+/// and again after a seam-deep advance lands it in the finalized DB. Shared body of
+/// the per-validator gated `send_to_transparent_finalization` tests; the caller
+/// launches and funds the faucet first. The advance mines shielded coinbase, so the
+/// callers stay `#[ignore]`d until per-call cheap filler mining lands.
+pub async fn assert_send_to_transparent_finalization<V, Conn>(
+    mut test_manager: zaino_testutils::TestManager<V, Conn>,
+    mut clients: DevtoolClients,
+) where
+    V: zaino_testutils::ValidatorExt,
+    Conn: zaino_testutils::ValidatorConnectionMarker,
+{
+    let recipient_taddr = clients.get_recipient_address("transparent").await;
+    clients.send_from_faucet(&recipient_taddr, 250_000).await;
+    test_manager
+        .generate_blocks_and_wait_for_tip(1, test_manager.subscriber())
+        .await;
+
+    let fetch_service = test_manager.full_node_jsonrpc_connector().await;
+    let height = fetch_service.get_blockchain_info().await.unwrap().blocks.0;
+    let unfinalised_transactions = fetch_service
+        .get_address_txids(vec![recipient_taddr.clone()], height, height)
+        .await
+        .unwrap();
+
+    // The load-bearing advance: these blocks push the send below the seam
+    // (`FAST_TEST_MAX_NONFINALISED_DEPTH`) into the finalized DB.
+    test_manager
+        .generate_blocks_bulk_and_wait_for_tips(
+            // Advance past the seam so the send crosses the finalised floor
+            // (`tip - seam`); a small margin above it keeps the boundary unambiguous.
+            zaino_common::consensus::FAST_TEST_MAX_NONFINALISED_DEPTH + 5,
+            test_manager.subscriber(),
+            test_manager.subscriber(),
+        )
+        .await;
+
+    let finalised_transactions = fetch_service
+        .get_address_txids(vec![recipient_taddr], height, height)
+        .await
+        .unwrap();
+
+    clients.sync_recipient().await;
+    assert_eq!(
+        Pool::Transparent.spendable_balance(&clients.recipient_balance().await),
+        250_000
+    );
+    assert_eq!(unfinalised_transactions, finalised_transactions);
+
+    test_manager.close().await;
+}
+
+/// Broadcast two unmined shielded sends, observe them in the validator mempool,
+/// then mine them in. Shared body of the per-validator gated
+/// `monitor_unverified_mempool` tests; the caller launches and funds the faucet
+/// (two notes — one per unmined send) first.
+///
+/// The unconfirmed/confirmed balance assertions of the zingolib original stay
+/// commented out: devtool's `WalletBalance` surfaces only `*_spendable` (its sync
+/// is block-based and never scans the mempool). Restore them and un-ignore the
+/// callers when devtool surfaces unconfirmed balances.
+pub async fn assert_monitor_unverified_mempool<V, Conn>(
+    mut test_manager: zaino_testutils::TestManager<V, Conn>,
+    mut clients: DevtoolClients,
+) where
+    V: zaino_testutils::ValidatorExt,
+    Conn: zaino_testutils::ValidatorConnectionMarker,
+{
+    let recipient_ua = clients.get_recipient_address("unified").await;
+    let txid_1 = clients.send_from_faucet(&recipient_ua, 250_000).await;
+    let recipient_zaddr = clients.get_recipient_address("sapling").await;
+    let txid_2 = clients.send_from_faucet(&recipient_zaddr, 250_000).await;
+
+    clients.rescan_recipient().await;
+
+    let fetch_service = test_manager.full_node_jsonrpc_connector().await;
+    let mempool_txids = fetch_service.get_raw_mempool().await.unwrap();
+    dbg!(txid_1);
+    dbg!(txid_2);
+    dbg!(mempool_txids.clone());
+
+    let _transaction_1 = dbg!(
+        fetch_service
+            .get_raw_transaction(mempool_txids.transactions[0].clone(), Some(1))
+            .await
+    );
+    let _transaction_2 = dbg!(
+        fetch_service
+            .get_raw_transaction(mempool_txids.transactions[1].clone(), Some(1))
+            .await
+    );
+
+    // Unconfirmed (mempool) balances — devtool's WalletBalance has no
+    // unconfirmed_* fields (block-based sync, no mempool scan):
+    // assert_eq!(
+    //     clients.recipient_balance().await.unconfirmed_orchard_balance.unwrap().into_u64(),
+    //     250_000
+    // );
+    // assert_eq!(
+    //     clients.recipient_balance().await.unconfirmed_sapling_balance.unwrap().into_u64(),
+    //     250_000
+    // );
+
+    test_manager
+        .generate_blocks_and_wait_for_tip(1, test_manager.subscriber())
+        .await;
+
+    let _transaction_1 = dbg!(
+        fetch_service
+            .get_raw_transaction(mempool_txids.transactions[0].clone(), Some(1))
+            .await
+    );
+    let _transaction_2 = dbg!(
+        fetch_service
+            .get_raw_transaction(mempool_txids.transactions[1].clone(), Some(1))
+            .await
+    );
+
+    clients.sync_recipient().await;
+
+    // Confirmed balances — original asserts WalletBalance::confirmed_orchard_balance,
+    // also absent on devtool. Restore as e.g.:
+    // assert_eq!(
+    //     Pool::Orchard.spendable_balance(&clients.recipient_balance().await),
+    //     250_000
+    // );
+
+    test_manager.close().await;
+}

--- a/live-tests/e2e/tests/devtool.rs
+++ b/live-tests/e2e/tests/devtool.rs
@@ -100,29 +100,7 @@ async fn launch_and_build_clients<Conn>() -> (TestManager<Zebrad, Conn>, Devtool
 where
     Conn: zaino_testutils::ValidatorConnectionMarker,
 {
-    let test_manager = TestManager::<Zebrad, Conn>::launch_mining_to(
-        zaino_testutils::SHIELDED_FUNDING_POOL,
-        &ValidatorKind::Zebrad,
-        None,
-        None,
-        None,
-        true,
-        false,
-        false,
-    )
-    .await
-    .expect("launch TestManager");
-
-    let clients = e2e::devtool::build_clients(
-        test_manager
-            .zaino_grpc_listen_address
-            .expect("zaino enabled")
-            .port(),
-        &test_manager.local_net,
-    )
-    .await;
-
-    (test_manager, clients)
+    e2e::devtool::launch_and_build_devtool_clients(&ValidatorKind::Zebrad, None).await
 }
 
 /// Port of `connect_to_node_get_info` (wallet_to_validator, zebrad): the faucet
@@ -173,23 +151,8 @@ async fn send_to_pool<Conn>(pool: e2e::Pool)
 where
     Conn: zaino_testutils::ValidatorConnectionMarker,
 {
-    let (mut test_manager, mut clients) = launch_and_fund_faucet::<Conn>(1).await;
-
-    let recipient = clients.get_recipient_address(pool.address_kind()).await;
-    let txid = clients.send_from_faucet(&recipient, 250_000).await;
-    dbg!(txid);
-
-    test_manager
-        .generate_blocks_and_wait_for_tip(1, test_manager.subscriber())
-        .await;
-    clients.sync_recipient().await;
-
-    assert_eq!(
-        pool.spendable_balance(&clients.recipient_balance().await),
-        250_000
-    );
-
-    test_manager.close().await;
+    let (test_manager, clients) = launch_and_fund_faucet::<Conn>(1).await;
+    e2e::devtool::assert_send_to_pool(test_manager, clients, pool).await;
 }
 
 /// Port of `send_to_all` (wallet_to_validator, zebrad): one faucet funds a send
@@ -243,32 +206,8 @@ async fn shield_for_validator<Conn>()
 where
     Conn: zaino_testutils::ValidatorConnectionMarker,
 {
-    let (mut test_manager, mut clients) = launch_and_fund_faucet::<Conn>(1).await;
-
-    let recipient_taddr = clients.get_recipient_address("transparent").await;
-    clients.send_from_faucet(&recipient_taddr, 250_000).await;
-    test_manager
-        .generate_blocks_and_wait_for_tip(1, test_manager.subscriber())
-        .await;
-    clients.sync_recipient().await;
-
-    assert_eq!(
-        e2e::Pool::Transparent.spendable_balance(&clients.recipient_balance().await),
-        250_000
-    );
-
-    clients.shield_recipient().await;
-    test_manager
-        .generate_blocks_and_wait_for_tip(1, test_manager.subscriber())
-        .await;
-    clients.sync_recipient().await;
-
-    assert_eq!(
-        e2e::Pool::Ironwood.spendable_balance(&clients.recipient_balance().await),
-        235_000
-    );
-
-    test_manager.close().await;
+    let (test_manager, clients) = launch_and_fund_faucet::<Conn>(1).await;
+    e2e::devtool::assert_shield_for_validator(test_manager, clients, e2e::Pool::Ironwood).await;
 }
 
 /// Launch, fund the faucet with two orchard notes, and broadcast (without
@@ -1550,47 +1489,8 @@ async fn send_to_transparent_finalization<Conn>()
 where
     Conn: zaino_testutils::ValidatorConnectionMarker,
 {
-    let (mut test_manager, mut clients) = launch_and_fund_faucet::<Conn>(1).await;
-
-    let recipient_taddr = clients.get_recipient_address("transparent").await;
-    clients.send_from_faucet(&recipient_taddr, 250_000).await;
-    test_manager
-        .generate_blocks_and_wait_for_tip(1, test_manager.subscriber())
-        .await;
-
-    let fetch_service = test_manager.full_node_jsonrpc_connector().await;
-    let height = fetch_service.get_blockchain_info().await.unwrap().blocks.0;
-    let unfinalised_transactions = fetch_service
-        .get_address_txids(vec![recipient_taddr.clone()], height, height)
-        .await
-        .unwrap();
-
-    // The load-bearing advance: these blocks push the send below the seam
-    // (`FAST_TEST_MAX_NONFINALISED_DEPTH`) into the finalized DB. Orchard coinbase
-    // here (see #[ignore] rationale).
-    test_manager
-        .generate_blocks_bulk_and_wait_for_tips(
-            // Advance past the seam so the send crosses the finalised floor
-            // (`tip - seam`); a small margin above it keeps the boundary unambiguous.
-            zaino_common::consensus::FAST_TEST_MAX_NONFINALISED_DEPTH + 5,
-            test_manager.subscriber(),
-            test_manager.subscriber(),
-        )
-        .await;
-
-    let finalised_transactions = fetch_service
-        .get_address_txids(vec![recipient_taddr], height, height)
-        .await
-        .unwrap();
-
-    clients.sync_recipient().await;
-    assert_eq!(
-        e2e::Pool::Transparent.spendable_balance(&clients.recipient_balance().await),
-        250_000
-    );
-    assert_eq!(unfinalised_transactions, finalised_transactions);
-
-    test_manager.close().await;
+    let (test_manager, clients) = launch_and_fund_faucet::<Conn>(1).await;
+    e2e::devtool::assert_send_to_transparent_finalization(test_manager, clients).await;
 }
 
 /// Port of `zebra::get::address_deltas` (zebrad): `getaddressdeltas` over a
@@ -2115,68 +2015,9 @@ async fn monitor_unverified_mempool<Conn>()
 where
     Conn: zaino_testutils::ValidatorConnectionMarker,
 {
-    let (mut test_manager, mut clients) = launch_and_fund_faucet::<Conn>(2).await;
-
-    let recipient_ua = clients.get_recipient_address("unified").await;
-    let txid_1 = clients.send_from_faucet(&recipient_ua, 250_000).await;
-    let recipient_zaddr = clients.get_recipient_address("sapling").await;
-    let txid_2 = clients.send_from_faucet(&recipient_zaddr, 250_000).await;
-
-    clients.rescan_recipient().await;
-
-    let fetch_service = test_manager.full_node_jsonrpc_connector().await;
-    let mempool_txids = fetch_service.get_raw_mempool().await.unwrap();
-    dbg!(txid_1);
-    dbg!(txid_2);
-    dbg!(mempool_txids.clone());
-
-    let _transaction_1 = dbg!(
-        fetch_service
-            .get_raw_transaction(mempool_txids.transactions[0].clone(), Some(1))
-            .await
-    );
-    let _transaction_2 = dbg!(
-        fetch_service
-            .get_raw_transaction(mempool_txids.transactions[1].clone(), Some(1))
-            .await
-    );
-
-    // Unconfirmed (mempool) balances — devtool's WalletBalance has no
-    // unconfirmed_* fields (block-based sync, no mempool scan):
-    // assert_eq!(
-    //     clients.recipient_balance().await.unconfirmed_orchard_balance.unwrap().into_u64(),
-    //     250_000
-    // );
-    // assert_eq!(
-    //     clients.recipient_balance().await.unconfirmed_sapling_balance.unwrap().into_u64(),
-    //     250_000
-    // );
-
-    test_manager
-        .generate_blocks_and_wait_for_tip(1, test_manager.subscriber())
-        .await;
-
-    let _transaction_1 = dbg!(
-        fetch_service
-            .get_raw_transaction(mempool_txids.transactions[0].clone(), Some(1))
-            .await
-    );
-    let _transaction_2 = dbg!(
-        fetch_service
-            .get_raw_transaction(mempool_txids.transactions[1].clone(), Some(1))
-            .await
-    );
-
-    clients.sync_recipient().await;
-
-    // Confirmed balances — original asserts WalletBalance::confirmed_orchard_balance,
-    // also absent on devtool. Restore as e.g.:
-    // assert_eq!(
-    //     e2e::Pool::Orchard.spendable_balance(&clients.recipient_balance().await),
-    //     250_000
-    // );
-
-    test_manager.close().await;
+    // Two orchard notes — one per unmined send.
+    let (test_manager, clients) = launch_and_fund_faucet::<Conn>(2).await;
+    e2e::devtool::assert_monitor_unverified_mempool(test_manager, clients).await;
 }
 
 /// Port of `test_get_mempool_info` (fetch_service, zebrad): `get_mempool_info`

--- a/live-tests/e2e/tests/devtool_zcashd.rs
+++ b/live-tests/e2e/tests/devtool_zcashd.rs
@@ -37,30 +37,12 @@ use zebra_rpc::methods::GetAddressTxIdsRequest;
 /// syncing. The zcashd analogue of devtool.rs's `launch_and_build_clients`,
 /// concrete on zcashd (which has no StateService backend).
 async fn launch_zcashd_and_build_clients() -> (TestManager<Zcashd, Rpc>, DevtoolClients) {
-    let test_manager = TestManager::<Zcashd, Rpc>::launch_mining_to(
-        zaino_testutils::SHIELDED_FUNDING_POOL, // ORCHARD
+    e2e::devtool::launch_and_build_devtool_clients(
         &ValidatorKind::Zcashd,
-        None, // network -> Regtest
         // The heights the devtool wallet accepts (same as the zebrad path).
         Some(zaino_testutils::ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS),
-        None,  // no chain cache: build fresh at these heights
-        true,  // enable zaino
-        false, // no json-rpc server
-        false, // no clients (the devtool wallet is built separately)
     )
     .await
-    .expect("launch zcashd TestManager");
-
-    let clients = e2e::devtool::build_clients(
-        test_manager
-            .zaino_grpc_listen_address
-            .expect("zaino enabled")
-            .port(),
-        &test_manager.local_net,
-    )
-    .await;
-
-    (test_manager, clients)
 }
 
 /// [`launch_zcashd_and_build_clients`] plus `orchard_notes` orchard coinbase
@@ -429,55 +411,17 @@ mod json_server {
 /// zcashd analogue of devtool.rs's `send_to_pool`: the faucet sends 250_000 to
 /// the recipient's `pool` address and the recipient sees it.
 async fn send_to_pool(pool: e2e::Pool) {
-    let (mut test_manager, mut clients) = launch_and_fund_zcashd_faucet(1).await;
-
-    let recipient = clients.get_recipient_address(pool.address_kind()).await;
-    let txid = clients.send_from_faucet(&recipient, 250_000).await;
-    dbg!(txid);
-
-    test_manager
-        .generate_blocks_and_wait_for_tip(1, test_manager.subscriber())
-        .await;
-    clients.sync_recipient().await;
-
-    assert_eq!(
-        pool.spendable_balance(&clients.recipient_balance().await),
-        250_000
-    );
-
-    test_manager.close().await;
+    let (test_manager, clients) = launch_and_fund_zcashd_faucet(1).await;
+    e2e::devtool::assert_send_to_pool(test_manager, clients, pool).await;
 }
 
 /// zcashd analogue of devtool.rs's `shield_for_validator`: the recipient
 /// receives a transparent send, then shields it into orchard (235_000 after the
 /// ZIP-317 shielding fee).
 async fn shield_for_validator() {
-    let (mut test_manager, mut clients) = launch_and_fund_zcashd_faucet(1).await;
-
-    let recipient_taddr = clients.get_recipient_address("transparent").await;
-    clients.send_from_faucet(&recipient_taddr, 250_000).await;
-    test_manager
-        .generate_blocks_and_wait_for_tip(1, test_manager.subscriber())
-        .await;
-    clients.sync_recipient().await;
-
-    assert_eq!(
-        e2e::Pool::Transparent.spendable_balance(&clients.recipient_balance().await),
-        250_000
-    );
-
-    clients.shield_recipient().await;
-    test_manager
-        .generate_blocks_and_wait_for_tip(1, test_manager.subscriber())
-        .await;
-    clients.sync_recipient().await;
-
-    assert_eq!(
-        e2e::Pool::Orchard.spendable_balance(&clients.recipient_balance().await),
-        235_000
-    );
-
-    test_manager.close().await;
+    let (test_manager, clients) = launch_and_fund_zcashd_faucet(1).await;
+    // Pre-NU6.3 heights on zcashd: `shield` lands in orchard, not ironwood.
+    e2e::devtool::assert_shield_for_validator(test_manager, clients, e2e::Pool::Orchard).await;
 }
 
 /// Devtool ports of `wallet_to_validator`'s `mod zcashd` send/shield/get-info
@@ -528,44 +472,8 @@ mod wallet_to_validator {
         ignore = "heavy: seam-deep orchard advance (~100 halo2 proofs); un-ignore + transparent filler when cheap filler mining lands"
     )]
     async fn send_to_transparent_finalization() {
-        let (mut test_manager, mut clients) = launch_and_fund_zcashd_faucet(1).await;
-
-        let recipient_taddr = clients.get_recipient_address("transparent").await;
-        clients.send_from_faucet(&recipient_taddr, 250_000).await;
-        test_manager
-            .generate_blocks_and_wait_for_tip(1, test_manager.subscriber())
-            .await;
-
-        let fetch_service = test_manager.full_node_jsonrpc_connector().await;
-        let height = fetch_service.get_blockchain_info().await.unwrap().blocks.0;
-        let unfinalised_transactions = fetch_service
-            .get_address_txids(vec![recipient_taddr.clone()], height, height)
-            .await
-            .unwrap();
-
-        test_manager
-            .generate_blocks_bulk_and_wait_for_tips(
-                // Advance past the seam so the send crosses the finalised floor
-                // (`tip - seam`); a small margin above it keeps the boundary unambiguous.
-                zaino_common::consensus::FAST_TEST_MAX_NONFINALISED_DEPTH + 5,
-                test_manager.subscriber(),
-                test_manager.subscriber(),
-            )
-            .await;
-
-        let finalised_transactions = fetch_service
-            .get_address_txids(vec![recipient_taddr], height, height)
-            .await
-            .unwrap();
-
-        clients.sync_recipient().await;
-        assert_eq!(
-            e2e::Pool::Transparent.spendable_balance(&clients.recipient_balance().await),
-            250_000
-        );
-        assert_eq!(unfinalised_transactions, finalised_transactions);
-
-        test_manager.close().await;
+        let (test_manager, clients) = launch_and_fund_zcashd_faucet(1).await;
+        e2e::devtool::assert_send_to_transparent_finalization(test_manager, clients).await;
     }
 
     /// zcashd port of `sent_to::all` (heavy): one faucet funds a send to all
@@ -617,56 +525,7 @@ mod wallet_to_validator {
         ignore = "devtool WalletBalance has no unconfirmed_*/confirmed_* fields; balance asserts commented out — restore + un-ignore when devtool surfaces unconfirmed balances"
     )]
     async fn monitor_unverified_mempool() {
-        let (mut test_manager, mut clients) = launch_and_fund_zcashd_faucet(2).await;
-
-        let recipient_ua = clients.get_recipient_address("unified").await;
-        let txid_1 = clients.send_from_faucet(&recipient_ua, 250_000).await;
-        let recipient_zaddr = clients.get_recipient_address("sapling").await;
-        let txid_2 = clients.send_from_faucet(&recipient_zaddr, 250_000).await;
-
-        clients.rescan_recipient().await;
-
-        let fetch_service = test_manager.full_node_jsonrpc_connector().await;
-        let mempool_txids = fetch_service.get_raw_mempool().await.unwrap();
-        dbg!(txid_1);
-        dbg!(txid_2);
-        dbg!(mempool_txids.clone());
-
-        let _transaction_1 = dbg!(
-            fetch_service
-                .get_raw_transaction(mempool_txids.transactions[0].clone(), Some(1))
-                .await
-        );
-        let _transaction_2 = dbg!(
-            fetch_service
-                .get_raw_transaction(mempool_txids.transactions[1].clone(), Some(1))
-                .await
-        );
-
-        // Unconfirmed (mempool) balances — devtool's WalletBalance has no
-        // unconfirmed_* fields:
-        // assert_eq!(clients.recipient_balance().await.unconfirmed_orchard_balance.unwrap().into_u64(), 250_000);
-        // assert_eq!(clients.recipient_balance().await.unconfirmed_sapling_balance.unwrap().into_u64(), 250_000);
-
-        test_manager
-            .generate_blocks_and_wait_for_tip(1, test_manager.subscriber())
-            .await;
-
-        let _transaction_1 = dbg!(
-            fetch_service
-                .get_raw_transaction(mempool_txids.transactions[0].clone(), Some(1))
-                .await
-        );
-        let _transaction_2 = dbg!(
-            fetch_service
-                .get_raw_transaction(mempool_txids.transactions[1].clone(), Some(1))
-                .await
-        );
-
-        clients.sync_recipient().await;
-
-        // Confirmed balances — restore as Pool::Orchard.spendable_balance(...) when un-ignoring.
-
-        test_manager.close().await;
+        let (test_manager, clients) = launch_and_fund_zcashd_faucet(2).await;
+        e2e::devtool::assert_monitor_unverified_mempool(test_manager, clients).await;
     }
 }

--- a/live-tests/zaino-testutils/src/lib.rs
+++ b/live-tests/zaino-testutils/src/lib.rs
@@ -149,25 +149,16 @@ pub const ORCHARD_THEN_IRONWOOD_ACTIVATION_HEIGHTS: ActivationHeights = Activati
 /// All four value pools as the `i32`s a `get_block_range` request carries —
 /// the "request everything" pool filter.
 pub fn all_pools_i32() -> Vec<i32> {
-    use zaino_proto::proto::service::PoolType;
-    vec![
-        PoolType::Transparent as i32,
-        PoolType::Sapling as i32,
-        PoolType::Orchard as i32,
-        PoolType::Ironwood as i32,
-    ]
+    use zaino_proto::proto::utils::{pool_types_into_i32_vec, PoolTypeFilter};
+    pool_types_into_i32_vec(&PoolTypeFilter::includes_all().to_pool_types_vector())
 }
 
 /// The shielded pools as request `i32`s — what `get_block_range` defaults to
 /// when a request names no pools (`PoolTypeFilter::default()`: every shielded
 /// pool including Ironwood, transparent excluded).
 pub fn shielded_pools_i32() -> Vec<i32> {
-    use zaino_proto::proto::service::PoolType;
-    vec![
-        PoolType::Sapling as i32,
-        PoolType::Orchard as i32,
-        PoolType::Ironwood as i32,
-    ]
+    use zaino_proto::proto::utils::{pool_types_into_i32_vec, PoolTypeFilter};
+    pool_types_into_i32_vec(&PoolTypeFilter::default().to_pool_types_vector())
 }
 
 /// Collect a `get_block_range` query over heights `[start, end]` for the given

--- a/packages/zaino-common/CHANGELOG.md
+++ b/packages/zaino-common/CHANGELOG.md
@@ -8,33 +8,22 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.4.0] - 2026-07-13
+
+### Added
 - `ActivationHeights.nu6_3` (serde key `"NU6.3"`) for the NU6.3 network
   upgrade. `ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS` currently leaves it `None`
   (inactive); a chain with NU6.3 active needs the height stated explicitly.
-- `StorageConfig::database.sync_checkpoint_interval` (seconds, default 120) — max
-  wall-clock time spent buffering a bulk-sync write batch before flushing. Under
-  the env's `NO_SYNC` mode this also bounds the window of unflushed writes at risk
-  on a hard kill / eviction; lower it to shrink that window.
-- `StorageConfig::database.accumulator_rebuild_memory_size` (GiB, default 8, new
-  `AccumulatorRebuildMemorySize` newtype) — dedicated heap budget for the
-  from-genesis txout-set accumulator rebuild's spent set, kept **separate** from
-  `sync_write_batch_size` so the two operations cannot inflate each other's peak
-  memory.
 ### Changed
 - `crypto::ensure_default_crypto_provider` now installs rustls's
   **aws-lc-rs** provider (was ring) as the process-level default, and the
   crate's rustls features become `aws_lc_rs` + `prefer-post-quantum`
   (ADR-0006). First-install-wins semantics are unchanged.
-- **Breaking** — `StorageConfig::database.sync_write_batch_bytes` (raw bytes) is
-  renamed to `sync_write_batch_size` and now expressed in **GiB** (new
-  `SyncWriteBatchSize` newtype, mirroring `DatabaseSize`); the default is 8 GiB.
-  It is now a heap budget for buffered blocks only — the accumulator rebuild uses
-  the separate `accumulator_rebuild_memory_size`. Existing TOML configs setting
-  `sync_write_batch_bytes` must switch to `sync_write_batch_size` (in GiB).
-- **Breaking** — `DatabaseConfig` now uses `#[serde(deny_unknown_fields)]`: an
-  unrecognized key under `[storage.database]` (e.g. a stale `sync_write_batch_bytes`)
-  is a hard parse error instead of being silently ignored and falling back to the
-  default budget — the silent fallback previously OOM-killed nodes.
 - The `ActivationHeights` ↔ `ConfiguredActivationHeights` conversions and the
   zebra-network → `ActivationHeights` extraction are now generated from a single
   variant/field pair list (internal refactor; conversion behavior unchanged).
@@ -56,6 +45,33 @@ and this library adheres to Rust's notion of
   `show_span_events`, which no caller could reach). Logging is configured via the
   `ZAINOLOG_FORMAT` / `ZAINOLOG_COLOR` / `RUST_LOG` environment variables, whose
   behavior is unchanged.
+### Fixed
+
+## [0.3.0] - 2026-07-02
+
+### Added
+- `StorageConfig::database.sync_checkpoint_interval` (seconds, default 120) — max
+  wall-clock time spent buffering a bulk-sync write batch before flushing. Under
+  the env's `NO_SYNC` mode this also bounds the window of unflushed writes at risk
+  on a hard kill / eviction; lower it to shrink that window.
+- `StorageConfig::database.accumulator_rebuild_memory_size` (GiB, default 8, new
+  `AccumulatorRebuildMemorySize` newtype) — dedicated heap budget for the
+  from-genesis txout-set accumulator rebuild's spent set, kept **separate** from
+  `sync_write_batch_size` so the two operations cannot inflate each other's peak
+  memory.
+### Changed
+- **Breaking** — `StorageConfig::database.sync_write_batch_bytes` (raw bytes) is
+  renamed to `sync_write_batch_size` and now expressed in **GiB** (new
+  `SyncWriteBatchSize` newtype, mirroring `DatabaseSize`); the default is 8 GiB.
+  It is now a heap budget for buffered blocks only — the accumulator rebuild uses
+  the separate `accumulator_rebuild_memory_size`. Existing TOML configs setting
+  `sync_write_batch_bytes` must switch to `sync_write_batch_size` (in GiB).
+- **Breaking** — `DatabaseConfig` now uses `#[serde(deny_unknown_fields)]`: an
+  unrecognized key under `[storage.database]` (e.g. a stale `sync_write_batch_bytes`)
+  is a hard parse error instead of being silently ignored and falling back to the
+  default budget — the silent fallback previously OOM-killed nodes.
+### Deprecated
+### Removed
 ### Fixed
 
 ## [0.2.0] - 2026-06-17

--- a/packages/zaino-fetch/CHANGELOG.md
+++ b/packages/zaino-fetch/CHANGELOG.md
@@ -8,6 +8,25 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.4.1] - 2026-08-04
+
+### Changed
+- Internal DRY refactor with no public API or behavior change: the connector,
+  response, and chain layers were deduplicated; the infallible `ResponseToError`
+  set is now macro-implemented; and one shared serde round-trip test helper is
+  reused across the test suites.
+### Deprecated
+### Removed
+### Fixed
+
+## [0.4.0] - 2026-07-13
+
+### Added
 - Ironwood (NU6.3) / V6 transaction support: ironwood value balances are
   read from parsed transactions, and compact-block construction populates
   `CompactTx.ironwoodActions` and the block's `ironwoodCommitmentTreeSize`.
@@ -19,6 +38,12 @@ and this library adheres to Rust's notion of
 ### Deprecated
 ### Removed
 ### Fixed
+
+## [0.3.0] - 2026-07-02
+
+### Changed
+- Version-alignment bump for the 0.5.0 workspace release; no changes to this
+  crate's own public API or behavior.
 
 ## [0.2.0] - 2026-06-17
 

--- a/packages/zaino-fetch/Cargo.toml
+++ b/packages/zaino-fetch/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.0"
+version = "0.4.1"
 
 [features]
 default = []

--- a/packages/zaino-fetch/src/chain/block.rs
+++ b/packages/zaino-fetch/src/chain/block.rs
@@ -191,19 +191,7 @@ impl FullBlock {
             .enumerate()
             .filter_map(
                 |(index, tx)| match tx.to_compact_tx(Some(index as u64), &pool_types) {
-                    Ok(compact_tx) => {
-                        if !compact_tx.vin.is_empty()
-                            || !compact_tx.vout.is_empty()
-                            || !compact_tx.spends.is_empty()
-                            || !compact_tx.outputs.is_empty()
-                            || !compact_tx.actions.is_empty()
-                            || !compact_tx.ironwood_actions.is_empty()
-                        {
-                            Some(Ok(compact_tx))
-                        } else {
-                            None
-                        }
-                    }
+                    Ok(compact_tx) => compact_tx.has_pool_data().then_some(Ok(compact_tx)),
                     Err(parse_error) => Some(Err(parse_error)),
                 },
             )

--- a/packages/zaino-fetch/src/chain/block.rs
+++ b/packages/zaino-fetch/src/chain/block.rs
@@ -4,12 +4,12 @@ use crate::{
     chain::{error::ParseError, transaction::FullTransaction},
     utils::ParseFromSlice,
 };
-use std::{io::Cursor, sync::Arc};
+use std::sync::Arc;
 use zaino_proto::proto::{
     compact_formats::{ChainMetadata, CompactBlock},
     utils::PoolTypeFilter,
 };
-use zebra_chain::serialization::{ZcashDeserialize as _, ZcashSerialize as _};
+use zebra_chain::serialization::ZcashSerialize as _;
 
 /// Complete block header.
 #[derive(Debug, Clone)]
@@ -100,15 +100,10 @@ impl ParseFromSlice for FullBlock {
         txid: Option<Vec<Vec<u8>>>,
         tx_version: Option<u32>,
     ) -> Result<(&[u8], Self), ParseError> {
-        if tx_version.is_some() {
-            return Err(ParseError::InvalidData(
-                "tx_version must be None for FullBlock::parse_from_slice".to_string(),
-            ));
-        }
+        crate::utils::reject_tx_version(tx_version, "FullBlock")?;
 
-        let mut cursor = Cursor::new(data);
-        let block = zebra_chain::block::Block::zcash_deserialize(&mut cursor)?;
-        let consumed = usize::try_from(cursor.position())?;
+        let (block, consumed) =
+            crate::utils::zcash_deserialize_consumed::<zebra_chain::block::Block>(data)?;
         let txids = txid.unwrap_or_default();
 
         if !txids.is_empty() && txids.len() != block.transactions.len() {

--- a/packages/zaino-fetch/src/chain/transaction.rs
+++ b/packages/zaino-fetch/src/chain/transaction.rs
@@ -1,7 +1,7 @@
 //! Transaction fetching and deserialization functionality.
 
 use crate::{chain::error::ParseError, utils::ParseFromSlice};
-use std::{io::Cursor, sync::Arc};
+use std::sync::Arc;
 use zaino_proto::proto::{
     compact_formats::{
         CompactOrchardAction, CompactSaplingOutput, CompactSaplingSpend, CompactTx, CompactTxIn,
@@ -11,7 +11,7 @@ use zaino_proto::proto::{
 };
 use zebra_chain::{
     parameters::{OVERWINTER_VERSION_GROUP_ID, SAPLING_VERSION_GROUP_ID, TX_V5_VERSION_GROUP_ID},
-    serialization::{ZcashDeserialize as _, ZcashSerialize as _},
+    serialization::ZcashSerialize as _,
     transparent,
 };
 
@@ -28,21 +28,57 @@ pub struct FullTransaction {
     tx_id: Vec<u8>,
 }
 
+/// Maps an iterator of shielded-pool actions to (nullifier, cmx,
+/// ephemeral_key, enc_ciphertext) byte tuples. A macro rather than an `fn`
+/// because the orchard and ironwood action types are distinct nominal types
+/// that only share field names, which functions cannot abstract over.
+macro_rules! actions_to_byte_tuples {
+    ($actions:expr) => {
+        $actions
+            .map(|action| {
+                let nullifier: [u8; 32] = action.nullifier.into();
+                let cmx: [u8; 32] = action.cm_x.into();
+                let ephemeral_key: [u8; 32] = (&action.ephemeral_key).into();
+                let enc_ciphertext: [u8; 580] = action.enc_ciphertext.into();
+
+                (
+                    nullifier.to_vec(),
+                    cmx.to_vec(),
+                    ephemeral_key.to_vec(),
+                    enc_ciphertext.to_vec(),
+                )
+            })
+            .collect()
+    };
+}
+
+/// Collects `items()` mapped through `to_compact` when `included`, and the
+/// empty vector otherwise — the shared shape of every per-pool arm of
+/// `to_compact_tx`. `items` is a closure so an excluded pool's data is never
+/// extracted.
+fn compact_pool_items<T, C>(
+    included: bool,
+    items: impl FnOnce() -> Vec<T>,
+    to_compact: impl Fn(T) -> C,
+) -> Vec<C> {
+    if included {
+        items().into_iter().map(to_compact).collect()
+    } else {
+        Vec::new()
+    }
+}
+
 impl ParseFromSlice for FullTransaction {
     fn parse_from_slice(
         data: &[u8],
         txid: Option<Vec<Vec<u8>>>,
         tx_version: Option<u32>,
     ) -> Result<(&[u8], Self), ParseError> {
-        if tx_version.is_some() {
-            return Err(ParseError::InvalidData(
-                "tx_version must be None for FullTransaction::parse_from_slice".to_string(),
-            ));
-        }
+        crate::utils::reject_tx_version(tx_version, "FullTransaction")?;
 
-        let mut cursor = Cursor::new(data);
-        let transaction = zebra_chain::transaction::Transaction::zcash_deserialize(&mut cursor)?;
-        let consumed = usize::try_from(cursor.position())?;
+        let (transaction, consumed) = crate::utils::zcash_deserialize_consumed::<
+            zebra_chain::transaction::Transaction,
+        >(data)?;
         let tx_id = txid
             .and_then(|txids| txids.into_iter().next())
             .unwrap_or_else(|| transaction.hash().0.to_vec());
@@ -206,43 +242,13 @@ impl FullTransaction {
     /// Returns a vec of orchard actions (nullifier, cmx, ephemeral_key, enc_ciphertext) for the transaction.
     #[allow(clippy::complexity)]
     pub fn orchard_actions(&self) -> Vec<(Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>)> {
-        self.transaction
-            .orchard_actions()
-            .map(|action| {
-                let nullifier: [u8; 32] = action.nullifier.into();
-                let cmx: [u8; 32] = action.cm_x.into();
-                let ephemeral_key: [u8; 32] = (&action.ephemeral_key).into();
-                let enc_ciphertext: [u8; 580] = action.enc_ciphertext.into();
-
-                (
-                    nullifier.to_vec(),
-                    cmx.to_vec(),
-                    ephemeral_key.to_vec(),
-                    enc_ciphertext.to_vec(),
-                )
-            })
-            .collect()
+        actions_to_byte_tuples!(self.transaction.orchard_actions())
     }
 
     /// Returns a vec of ironwood actions (nullifier, cmx, ephemeral_key, enc_ciphertext) for the transaction.
     #[allow(clippy::complexity)]
     pub fn ironwood_actions(&self) -> Vec<(Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>)> {
-        self.transaction
-            .ironwood_actions()
-            .map(|action| {
-                let nullifier: [u8; 32] = action.nullifier.into();
-                let cmx: [u8; 32] = action.cm_x.into();
-                let ephemeral_key: [u8; 32] = (&action.ephemeral_key).into();
-                let enc_ciphertext: [u8; 580] = action.enc_ciphertext.into();
-
-                (
-                    nullifier.to_vec(),
-                    cmx.to_vec(),
-                    ephemeral_key.to_vec(),
-                    enc_ciphertext.to_vec(),
-                )
-            })
-            .collect()
+        actions_to_byte_tuples!(self.transaction.ironwood_actions())
     }
 
     /// Returns the orchard anchor of the transaction.
@@ -279,73 +285,56 @@ impl FullTransaction {
         index: Option<u64>,
         pool_types: &PoolTypeFilter,
     ) -> Result<CompactTx, ParseError> {
-        let spends = if pool_types.includes_sapling() {
-            self.shielded_spends()
-                .into_iter()
-                .map(|nf| CompactSaplingSpend { nf })
-                .collect()
-        } else {
-            Vec::new()
+        // Orchard and ironwood actions share the compact form deliberately:
+        // ironwood actions are packed into `CompactOrchardAction`.
+        let compact_orchard_action = |(nullifier, cmx, ephemeral_key, enc_ciphertext): (
+            Vec<u8>,
+            Vec<u8>,
+            Vec<u8>,
+            Vec<u8>,
+        )| CompactOrchardAction {
+            nullifier,
+            cmx,
+            ephemeral_key,
+            ciphertext: enc_ciphertext[..52].to_vec(),
         };
 
-        let outputs = if pool_types.includes_sapling() {
-            self.shielded_outputs()
-                .into_iter()
-                .map(
-                    |(cmu, ephemeral_key, enc_ciphertext)| CompactSaplingOutput {
-                        cmu,
-                        ephemeral_key,
-                        ciphertext: enc_ciphertext[..52].to_vec(),
-                    },
-                )
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let spends = compact_pool_items(
+            pool_types.includes_sapling(),
+            || self.shielded_spends(),
+            |nf| CompactSaplingSpend { nf },
+        );
 
-        let actions = if pool_types.includes_orchard() {
-            self.orchard_actions()
-                .into_iter()
-                .map(
-                    |(nullifier, cmx, ephemeral_key, enc_ciphertext)| CompactOrchardAction {
-                        nullifier,
-                        cmx,
-                        ephemeral_key,
-                        ciphertext: enc_ciphertext[..52].to_vec(),
-                    },
-                )
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let outputs = compact_pool_items(
+            pool_types.includes_sapling(),
+            || self.shielded_outputs(),
+            |(cmu, ephemeral_key, enc_ciphertext)| CompactSaplingOutput {
+                cmu,
+                ephemeral_key,
+                ciphertext: enc_ciphertext[..52].to_vec(),
+            },
+        );
 
-        let ironwood_actions = if pool_types.includes_ironwood() {
-            self.ironwood_actions()
-                .into_iter()
-                .map(
-                    |(nullifier, cmx, ephemeral_key, enc_ciphertext)| CompactOrchardAction {
-                        nullifier,
-                        cmx,
-                        ephemeral_key,
-                        ciphertext: enc_ciphertext[..52].to_vec(),
-                    },
-                )
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let actions = compact_pool_items(
+            pool_types.includes_orchard(),
+            || self.orchard_actions(),
+            compact_orchard_action,
+        );
 
-        let vout = if pool_types.includes_transparent() {
-            self.transparent_outputs()
-                .into_iter()
-                .map(|(value, script_hash)| CompactTxOut {
-                    value,
-                    script_pub_key: script_hash,
-                })
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let ironwood_actions = compact_pool_items(
+            pool_types.includes_ironwood(),
+            || self.ironwood_actions(),
+            compact_orchard_action,
+        );
+
+        let vout = compact_pool_items(
+            pool_types.includes_transparent(),
+            || self.transparent_outputs(),
+            |(value, script_hash)| CompactTxOut {
+                value,
+                script_pub_key: script_hash,
+            },
+        );
 
         let vin = if pool_types.includes_transparent() {
             self.transaction

--- a/packages/zaino-fetch/src/jsonrpsee/connector.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/connector.rs
@@ -210,6 +210,34 @@ fn record_outbound_rpc_metrics(method: &'static str, start: std::time::Instant, 
     }
 }
 
+/// Serializes one JSON-RPC parameter, mapping the failure into the request
+/// error. The single home for the `to_value` + `JsonRpc` error shape every
+/// parameter-building call site used to repeat.
+fn to_param<T: Serialize, E>(value: T) -> Result<serde_json::Value, RpcRequestError<E>> {
+    serde_json::to_value(value).map_err(RpcRequestError::JsonRpc)
+}
+
+/// Applies the connector's authentication to an outbound request: HTTP basic
+/// auth, or the cookie token encoded the way Zebra's RPC server expects
+/// (`Basic base64("__cookie__:<token>")`).
+fn apply_auth(
+    request_builder: reqwest::RequestBuilder,
+    auth_method: &AuthMethod,
+) -> reqwest::RequestBuilder {
+    match auth_method {
+        AuthMethod::Basic { username, password } => {
+            request_builder.basic_auth(username, Some(password))
+        }
+        AuthMethod::Cookie { cookie } => request_builder.header(
+            reqwest::header::AUTHORIZATION,
+            format!(
+                "Basic {}",
+                general_purpose::STANDARD.encode(format!("__cookie__:{cookie}"))
+            ),
+        ),
+    }
+}
+
 /// Whether the outbound JSON-RPC client keeps a cookie store (required
 /// for cookie-authenticated validators).
 enum CookieSupport {
@@ -413,6 +441,23 @@ impl JsonRpSeeConnector {
         }
     }
 
+    /// Sends `method` with a single JSON-RPC parameter, building the
+    /// one-element parameter vector (and mapping its serialization error)
+    /// here so each single-parameter wrapper stays one line.
+    async fn send_one_param<
+        T: std::fmt::Debug + Serialize,
+        R: std::fmt::Debug + for<'de> Deserialize<'de> + ResponseToError,
+    >(
+        &self,
+        method: &'static str,
+        param: T,
+    ) -> Result<R, RpcRequestError<R::RpcError>>
+    where
+        R::RpcError: Send + Sync + 'static,
+    {
+        self.send_request(method, vec![to_param(param)?]).await
+    }
+
     /// Builds a request from a given method, params, and id.
     fn build_request<T: std::fmt::Debug + Serialize>(
         &self,
@@ -427,30 +472,15 @@ impl JsonRpSeeConnector {
             id,
         };
 
-        let mut request_builder = self
-            .client
-            .post(self.url.clone())
-            .header("Content-Type", "application/json");
-
-        match &self.auth_method {
-            AuthMethod::Basic { username, password } => {
-                request_builder = request_builder.basic_auth(username, Some(password));
-            }
-            AuthMethod::Cookie { cookie } => {
-                request_builder = request_builder.header(
-                    reqwest::header::AUTHORIZATION,
-                    format!(
-                        "Basic {}",
-                        general_purpose::STANDARD.encode(format!("__cookie__:{cookie}"))
-                    ),
-                );
-            }
-        }
+        let request_builder = apply_auth(
+            self.client
+                .post(self.url.clone())
+                .header("Content-Type", "application/json"),
+            &self.auth_method,
+        );
 
         let request_body = serde_json::to_string(&req)?;
-        request_builder = request_builder.body(request_body);
-
-        Ok(request_builder)
+        Ok(request_builder.body(request_body))
     }
 
     /// Returns all changes for an address.
@@ -472,8 +502,7 @@ impl JsonRpSeeConnector {
         &self,
         params: GetAddressDeltasParams,
     ) -> Result<GetAddressDeltasResponse, RpcRequestError<GetAddressDeltasError>> {
-        let params = vec![serde_json::to_value(params).map_err(RpcRequestError::JsonRpc)?];
-        self.send_request("getaddressdeltas", params).await
+        self.send_one_param("getaddressdeltas", params).await
     }
 
     /// Returns software information from the RPC server, as a [`crate::jsonrpsee::connector::GetInfoResponse`] JSON struct.
@@ -549,8 +578,7 @@ impl JsonRpSeeConnector {
         &self,
         height: u32,
     ) -> Result<GetBlockSubsidy, RpcRequestError<Infallible>> {
-        let params = vec![serde_json::to_value(height).map_err(RpcRequestError::JsonRpc)?];
-        self.send_request("getblocksubsidy", params).await
+        self.send_one_param("getblocksubsidy", height).await
     }
 
     /// Returns the total balance of a provided `addresses` in an [`crate::jsonrpsee::response::GetBalanceResponse`] instance.
@@ -584,9 +612,8 @@ impl JsonRpSeeConnector {
         &self,
         raw_transaction_hex: String,
     ) -> Result<SendTransactionResponse, RpcRequestError<SendTransactionError>> {
-        let params =
-            vec![serde_json::to_value(raw_transaction_hex).map_err(RpcRequestError::JsonRpc)?];
-        self.send_request("sendrawtransaction", params).await
+        self.send_one_param("sendrawtransaction", raw_transaction_hex)
+            .await
     }
 
     /// Returns the requested block by hash or height, as a [`GetBlockResponse`].
@@ -607,10 +634,7 @@ impl JsonRpSeeConnector {
         verbosity: Option<u8>,
     ) -> Result<GetBlockResponse, RpcRequestError<GetBlockError>> {
         let v = verbosity.unwrap_or(1);
-        let params = [
-            serde_json::to_value(hash_or_height).map_err(RpcRequestError::JsonRpc)?,
-            serde_json::to_value(v).map_err(RpcRequestError::JsonRpc)?,
-        ];
+        let params = [to_param(hash_or_height)?, to_param(v)?];
 
         if v == 0 {
             self.send_request("getblock", params)
@@ -632,8 +656,7 @@ impl JsonRpSeeConnector {
         &self,
         hash: String,
     ) -> Result<BlockDeltas, RpcRequestError<BlockDeltasError>> {
-        let params = vec![serde_json::to_value(hash).map_err(RpcRequestError::JsonRpc)?];
-        self.send_request("getblockdeltas", params).await
+        self.send_one_param("getblockdeltas", hash).await
     }
 
     /// If verbose is false, returns a string that is serialized, hex-encoded data for blockheader `hash`.
@@ -652,10 +675,7 @@ impl JsonRpSeeConnector {
         hash: String,
         verbose: bool,
     ) -> Result<GetBlockHeader, RpcRequestError<GetBlockHeaderError>> {
-        let params = [
-            serde_json::to_value(hash).map_err(RpcRequestError::JsonRpc)?,
-            serde_json::to_value(verbose).map_err(RpcRequestError::JsonRpc)?,
-        ];
+        let params = [to_param(hash)?, to_param(verbose)?];
         self.send_request("getblockheader", params).await
     }
 
@@ -713,8 +733,7 @@ impl JsonRpSeeConnector {
         &self,
         address: String,
     ) -> Result<ValidateAddressResponse, RpcRequestError<Infallible>> {
-        let params = vec![serde_json::to_value(address).map_err(RpcRequestError::JsonRpc)?];
-        self.send_request("validateaddress", params).await
+        self.send_one_param("validateaddress", address).await
     }
 
     /// Return information about the given address.
@@ -735,8 +754,7 @@ impl JsonRpSeeConnector {
         address: String,
     ) -> Result<ZValidateAddressResponse, RpcRequestError<ZValidateAddressError>> {
         tracing::debug!("Sending jsonrpsee connecter z_validate_address.");
-        let params = vec![serde_json::to_value(address).map_err(RpcRequestError::JsonRpc)?];
-        self.send_request("z_validateaddress", params).await
+        self.send_one_param("z_validateaddress", address).await
     }
 
     /// Returns all transaction ids in the memory pool, as a JSON array.
@@ -762,8 +780,7 @@ impl JsonRpSeeConnector {
         &self,
         hash_or_height: String,
     ) -> Result<GetTreestateResponse, RpcRequestError<GetTreestateError>> {
-        let params = vec![serde_json::to_value(hash_or_height).map_err(RpcRequestError::JsonRpc)?];
-        self.send_request("z_gettreestate", params).await
+        self.send_one_param("z_gettreestate", hash_or_height).await
     }
 
     /// Returns information about a range of Sapling or Orchard subtrees.
@@ -783,17 +800,10 @@ impl JsonRpSeeConnector {
         start_index: u16,
         limit: Option<u16>,
     ) -> Result<GetSubtreesResponse, RpcRequestError<GetSubtreesError>> {
-        let params = match limit {
-            Some(v) => vec![
-                serde_json::to_value(pool).map_err(RpcRequestError::JsonRpc)?,
-                serde_json::to_value(start_index).map_err(RpcRequestError::JsonRpc)?,
-                serde_json::to_value(v).map_err(RpcRequestError::JsonRpc)?,
-            ],
-            None => vec![
-                serde_json::to_value(pool).map_err(RpcRequestError::JsonRpc)?,
-                serde_json::to_value(start_index).map_err(RpcRequestError::JsonRpc)?,
-            ],
-        };
+        let mut params = vec![to_param(pool)?, to_param(start_index)?];
+        if let Some(v) = limit {
+            params.push(to_param(v)?);
+        }
         self.send_request("z_getsubtreesbyindex", params).await
     }
 
@@ -812,16 +822,8 @@ impl JsonRpSeeConnector {
         txid_hex: String,
         verbose: Option<u8>,
     ) -> Result<GetTransactionResponse, RpcRequestError<Infallible>> {
-        let params = match verbose {
-            Some(v) => vec![
-                serde_json::to_value(txid_hex).map_err(RpcRequestError::JsonRpc)?,
-                serde_json::to_value(v).map_err(RpcRequestError::JsonRpc)?,
-            ],
-            None => vec![
-                serde_json::to_value(txid_hex).map_err(RpcRequestError::JsonRpc)?,
-                serde_json::to_value(0).map_err(RpcRequestError::JsonRpc)?,
-            ],
-        };
+        // `verbose` defaults to 0 (hex-encoded data), matching the RPC contract.
+        let params = vec![to_param(txid_hex)?, to_param(verbose.unwrap_or(0))?];
 
         self.send_request("getrawtransaction", params).await
     }
@@ -843,17 +845,10 @@ impl JsonRpSeeConnector {
         n: u32,
         include_mempool: Option<bool>,
     ) -> Result<GetTxOutResponse, RpcRequestError<Infallible>> {
-        let params = match include_mempool {
-            Some(include_mempool) => vec![
-                serde_json::to_value(txid).map_err(RpcRequestError::JsonRpc)?,
-                serde_json::to_value(n).map_err(RpcRequestError::JsonRpc)?,
-                serde_json::to_value(include_mempool).map_err(RpcRequestError::JsonRpc)?,
-            ],
-            None => vec![
-                serde_json::to_value(txid).map_err(RpcRequestError::JsonRpc)?,
-                serde_json::to_value(n).map_err(RpcRequestError::JsonRpc)?,
-            ],
-        };
+        let mut params = vec![to_param(txid)?, to_param(n)?];
+        if let Some(include_mempool) = include_mempool {
+            params.push(to_param(include_mempool)?);
+        }
 
         self.send_request("gettxout", params).await
     }
@@ -869,9 +864,7 @@ impl JsonRpSeeConnector {
         &self,
         request: GetSpentInfoRequest,
     ) -> Result<GetSpentInfoResponse, RpcRequestError<GetSpentInfoError>> {
-        let params = vec![serde_json::to_value(request).map_err(RpcRequestError::JsonRpc)?];
-
-        self.send_request("getspentinfo", params).await
+        self.send_one_param("getspentinfo", request).await
     }
 
     /// Returns the transaction ids made by the provided transparent addresses.
@@ -997,25 +990,13 @@ async fn test_node_connection(
         build_rpc_client(CookieSupport::Disabled).map_err(TestNodeConnectionError::ClientBuild)?;
 
     let request_body = r#"{"jsonrpc":"2.0","method":"getinfo","params":[],"id":1}"#;
-    let mut request_builder = client
-        .post(url.clone())
-        .header("Content-Type", "application/json")
-        .body(request_body);
-
-    match &auth_method {
-        AuthMethod::Basic { username, password } => {
-            request_builder = request_builder.basic_auth(username, Some(password));
-        }
-        AuthMethod::Cookie { cookie } => {
-            request_builder = request_builder.header(
-                reqwest::header::AUTHORIZATION,
-                format!(
-                    "Basic {}",
-                    general_purpose::STANDARD.encode(format!("__cookie__:{cookie}"))
-                ),
-            );
-        }
-    }
+    let request_builder = apply_auth(
+        client
+            .post(url.clone())
+            .header("Content-Type", "application/json")
+            .body(request_body),
+        &auth_method,
+    );
 
     let response = request_builder
         .send()

--- a/packages/zaino-fetch/src/jsonrpsee/response.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response.rs
@@ -55,6 +55,37 @@ macro_rules! impl_rpc_error_passthrough {
 }
 pub(crate) use impl_rpc_error_passthrough;
 
+/// Implements [`ResponseToError`] with the infallible error type, for
+/// responses whose failures always surface as generic transport/RPC errors
+/// rather than method-specific ones.
+macro_rules! impl_infallible_response_to_error {
+    ($($response_type:ty),* $(,)?) => {
+        $(
+            impl crate::jsonrpsee::connector::ResponseToError for $response_type {
+                type RpcError = std::convert::Infallible;
+            }
+        )*
+    };
+}
+pub(crate) use impl_infallible_response_to_error;
+
+impl_infallible_response_to_error!(
+    GetInfoResponse,
+    GetDifficultyResponse,
+    GetTxOutResponse,
+    ErrorsTimestamp,
+    GetBlockchainInfoResponse,
+    GetNetworkSolPsResponse,
+    GetTxOutSetInfoResponse,
+    ChainBalance,
+    GetBlockHash,
+    GetBlockCountResponse,
+    ValidateAddressResponse,
+    RawMempoolResponse,
+    GetTransactionResponse,
+    GetMempoolInfoResponse,
+);
+
 /// Maps a JSON-RPC error carrying `code` to the RPC-specific variant `ctor`
 /// builds from its message, passing every other error through unchanged.
 // The Err type is fixed by the `TryFrom<RpcError>` impls this serves: their
@@ -142,14 +173,6 @@ pub struct GetInfoResponse {
     errors_timestamp: ErrorsTimestamp,
 }
 
-impl ResponseToError for GetInfoResponse {
-    type RpcError = Infallible;
-}
-
-impl ResponseToError for GetDifficultyResponse {
-    type RpcError = Infallible;
-}
-
 /// Response to a `gettxout` RPC request.
 ///
 /// The result is either the validator's output object or `null` when the
@@ -158,10 +181,6 @@ impl ResponseToError for GetDifficultyResponse {
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(transparent)]
 pub struct GetTxOutResponse(pub Option<serde_json::Value>);
-
-impl ResponseToError for GetTxOutResponse {
-    type RpcError = Infallible;
-}
 
 /// Request parameters for the `getspentinfo` RPC request.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -348,9 +367,6 @@ impl From<ErrorsTimestamp> for i64 {
     }
 }
 
-impl ResponseToError for ErrorsTimestamp {
-    type RpcError = Infallible;
-}
 impl std::fmt::Display for ErrorsTimestamp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -457,10 +473,6 @@ pub struct GetBlockchainInfoResponse {
     commitments: u64,
 }
 
-impl ResponseToError for GetBlockchainInfoResponse {
-    type RpcError = Infallible;
-}
-
 /// Response to a `getdifficulty` RPC request.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct GetDifficultyResponse(pub f64);
@@ -468,10 +480,6 @@ pub struct GetDifficultyResponse(pub f64);
 /// Response to a `getnetworksolps` RPC request.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct GetNetworkSolPsResponse(pub u64);
-
-impl ResponseToError for GetNetworkSolPsResponse {
-    type RpcError = Infallible;
-}
 
 /// Response to a `gettxoutsetinfo` RPC request.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -506,10 +514,6 @@ pub struct GetTxOutSetInfo {
 /// Empty `gettxoutsetinfo` response returned by zcashd when stats collection fails.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct EmptyTxOutSetInfo {}
-
-impl ResponseToError for GetTxOutSetInfoResponse {
-    type RpcError = Infallible;
-}
 
 #[cfg(test)]
 mod get_tx_out_set_info_tests {
@@ -712,10 +716,6 @@ impl Default for ChainWork {
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct ChainBalance(GetBlockchainInfoBalance);
 
-impl ResponseToError for ChainBalance {
-    type RpcError = Infallible;
-}
-
 impl<'de> Deserialize<'de> for ChainBalance {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -901,10 +901,6 @@ impl From<SendTransactionResponse> for zebra_rpc::methods::SentTransactionHash {
 )]
 #[serde(transparent)]
 pub struct GetBlockHash(#[serde(with = "hex")] pub zebra_chain::block::Hash);
-
-impl ResponseToError for GetBlockHash {
-    type RpcError = Infallible;
-}
 
 impl Default for GetBlockHash {
     fn default() -> Self {
@@ -1167,18 +1163,10 @@ impl ResponseToError for GetBlockResponse {
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct GetBlockCountResponse(Height);
 
-impl ResponseToError for GetBlockCountResponse {
-    type RpcError = Infallible;
-}
-
 impl From<GetBlockCountResponse> for Height {
     fn from(value: GetBlockCountResponse) -> Self {
         value.0
     }
-}
-
-impl ResponseToError for ValidateAddressResponse {
-    type RpcError = Infallible;
 }
 
 /// A block object containing data and metadata about a block.
@@ -1381,14 +1369,6 @@ pub struct RawMempoolResponse {
     pub transactions: Vec<String>,
 }
 
-impl ResponseToError for RawMempoolResponse {
-    type RpcError = Infallible;
-
-    fn to_error(self) -> Result<Self, Self::RpcError> {
-        Ok(self)
-    }
-}
-
 impl<'de> serde::Deserialize<'de> for TxidsResponse {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -1500,10 +1480,6 @@ pub enum GetTransactionResponse {
     Raw(#[serde(with = "hex")] zebra_chain::transaction::SerializedTransaction),
     /// The transaction object.
     Object(Box<zebra_rpc::client::TransactionObject>),
-}
-
-impl ResponseToError for GetTransactionResponse {
-    type RpcError = Infallible;
 }
 
 impl<'de> serde::Deserialize<'de> for GetTransactionResponse {
@@ -1977,10 +1953,6 @@ pub struct GetMempoolInfoResponse {
     pub bytes: u64,
     /// Total memory usage for the mempool
     pub usage: u64,
-}
-
-impl ResponseToError for GetMempoolInfoResponse {
-    type RpcError = Infallible;
 }
 
 #[cfg(test)]

--- a/packages/zaino-fetch/src/jsonrpsee/response.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response.rs
@@ -33,13 +33,56 @@ use crate::jsonrpsee::connector::ResponseToError;
 
 use super::connector::RpcError;
 
-impl TryFrom<RpcError> for Infallible {
-    type Error = RpcError;
+/// Implements the pass-through `TryFrom<RpcError>` for RPC-specific error
+/// types that map no JSON-RPC error codes to variants of their own: every
+/// server-reported error surfaces unchanged as the generic [`RpcError`].
+// TODO: attempt to convert RpcError into errors specific to each RPC
+// response, removing types from these invocations as mappings become known.
+macro_rules! impl_rpc_error_passthrough {
+    ($($error_type:ty),* $(,)?) => {
+        $(
+            impl TryFrom<$crate::jsonrpsee::connector::RpcError> for $error_type {
+                type Error = $crate::jsonrpsee::connector::RpcError;
 
-    fn try_from(err: RpcError) -> Result<Self, Self::Error> {
-        Err(err)
+                fn try_from(
+                    value: $crate::jsonrpsee::connector::RpcError,
+                ) -> Result<Self, Self::Error> {
+                    Err(value)
+                }
+            }
+        )*
+    };
+}
+pub(crate) use impl_rpc_error_passthrough;
+
+/// Maps a JSON-RPC error carrying `code` to the RPC-specific variant `ctor`
+/// builds from its message, passing every other error through unchanged.
+// The Err type is fixed by the `TryFrom<RpcError>` impls this serves: their
+// `Error = RpcError` (unboxed) is the trait contract, so the large-Err lint
+// cannot be satisfied here without changing every impl's signature.
+#[allow(clippy::result_large_err)]
+pub(crate) fn rpc_error_code_map<T>(
+    value: RpcError,
+    code: i64,
+    ctor: impl FnOnce(String) -> T,
+) -> Result<T, RpcError> {
+    if value.code == code {
+        Ok(ctor(value.message))
+    } else {
+        Err(value)
     }
 }
+
+impl_rpc_error_passthrough!(
+    Infallible,
+    ChainWorkError,
+    GetBalanceError,
+    SendTransactionError,
+    TxidsError,
+    GetTreestateError,
+    GetSubtreesError,
+    GetUtxosError
+);
 
 /// Response to a `getinfo` RPC request.
 ///
@@ -631,15 +674,6 @@ pub enum ChainWorkError {}
 impl ResponseToError for ChainWork {
     type RpcError = ChainWorkError;
 }
-impl TryFrom<RpcError> for ChainWorkError {
-    type Error = RpcError;
-
-    fn try_from(value: RpcError) -> Result<Self, Self::Error> {
-        // TODO: attempt to convert RpcError into errors specific to this RPC response
-        Err(value)
-    }
-}
-
 impl TryFrom<ChainWork> for u64 {
     type Error = ParseIntError;
 
@@ -684,7 +718,8 @@ impl<'de> Deserialize<'de> for ChainBalance {
             monitored: bool,
         }
         let temp = TempBalance::deserialize(deserializer)?;
-        let computed_zat = (temp.chain_value * 100_000_000.0).round() as u64;
+        let computed_zat =
+            (temp.chain_value * (common::amount::ZATS_PER_ZEC as f64)).round() as u64;
         if computed_zat != temp.chain_value_zat {
             return Err(D::Error::custom(format!(
                 "chainValue and chainValueZat mismatch: computed {} but got {}",
@@ -795,15 +830,6 @@ pub enum GetBalanceError {
 impl ResponseToError for GetBalanceResponse {
     type RpcError = GetBalanceError;
 }
-impl TryFrom<RpcError> for GetBalanceError {
-    type Error = RpcError;
-
-    fn try_from(value: RpcError) -> Result<Self, Self::Error> {
-        // TODO: attempt to convert RpcError into errors specific to this RPC response
-        Err(value)
-    }
-}
-
 impl From<GetBalanceResponse> for zebra_rpc::methods::AddressBalance {
     fn from(response: GetBalanceResponse) -> Self {
         zebra_rpc::methods::GetAddressBalanceResponse::new(response.balance, response.received)
@@ -845,15 +871,6 @@ pub enum SendTransactionError {
 impl ResponseToError for SendTransactionResponse {
     type RpcError = SendTransactionError;
 }
-impl TryFrom<RpcError> for SendTransactionError {
-    type Error = RpcError;
-
-    fn try_from(value: RpcError) -> Result<Self, Self::Error> {
-        // TODO: attempt to convert RpcError into errors specific to this RPC response
-        Err(value)
-    }
-}
-
 impl From<SendTransactionResponse> for zebra_rpc::methods::SentTransactionHash {
     fn from(value: SendTransactionResponse) -> Self {
         zebra_rpc::methods::SentTransactionHash::new(value.0)
@@ -925,30 +942,39 @@ impl hex::FromHex for SerializedBlock {
     }
 }
 
+/// Deserializes a hex-encoded JSON string into its decoded bytes. Shared by
+/// the hex-wrapper newtypes whose `Deserialize` impls differ only in the
+/// wrapping constructor applied to the bytes.
+fn deserialize_hex_bytes<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct HexVisitor;
+
+    impl serde::de::Visitor<'_> for HexVisitor {
+        type Value = Vec<u8>;
+
+        fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+            formatter.write_str("a hex-encoded string")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: DeserError,
+        {
+            hex::decode(value).map_err(DeserError::custom)
+        }
+    }
+
+    deserializer.deserialize_str(HexVisitor)
+}
+
 impl<'de> serde::Deserialize<'de> for SerializedBlock {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        struct HexVisitor;
-
-        impl serde::de::Visitor<'_> for HexVisitor {
-            type Value = SerializedBlock;
-
-            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-                formatter.write_str("a hex-encoded string")
-            }
-
-            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-            where
-                E: DeserError,
-            {
-                let bytes = hex::decode(value).map_err(DeserError::custom)?;
-                Ok(SerializedBlock::from(bytes))
-            }
-        }
-
-        deserializer.deserialize_str(HexVisitor)
+        deserialize_hex_bytes(deserializer).map(SerializedBlock::from)
     }
 }
 
@@ -1077,11 +1103,7 @@ impl TryFrom<RpcError> for GetBlockError {
     fn try_from(value: RpcError) -> Result<Self, Self::Error> {
         // If the block is not in Zebra's state, returns
         // [error code `-8`.](https://github.com/zcash/zcash/issues/5758)
-        if value.code == -8 {
-            Ok(Self::MissingBlock(value.message))
-        } else {
-            Err(value)
-        }
+        rpc_error_code_map(value, -8, Self::MissingBlock)
     }
 }
 
@@ -1334,15 +1356,6 @@ pub enum TxidsError {
 impl ResponseToError for TxidsResponse {
     type RpcError = TxidsError;
 }
-impl TryFrom<RpcError> for TxidsError {
-    type Error = RpcError;
-
-    fn try_from(value: RpcError) -> Result<Self, Self::Error> {
-        // TODO: attempt to convert RpcError into errors specific to this RPC response
-        Err(value)
-    }
-}
-
 /// Separate response for the `get_raw_mempool` RPC method.
 ///
 /// Even though the output type is the same as [`TxidsResponse`],
@@ -1428,15 +1441,6 @@ pub enum GetTreestateError {
 impl ResponseToError for GetTreestateResponse {
     type RpcError = GetTreestateError;
 }
-impl TryFrom<RpcError> for GetTreestateError {
-    type Error = RpcError;
-
-    fn try_from(value: RpcError) -> Result<Self, Self::Error> {
-        // TODO: attempt to convert RpcError into errors specific to this RPC response
-        Err(value)
-    }
-}
-
 impl TryFrom<GetTreestateResponse> for zebra_rpc::client::GetTreestateResponse {
     type Error = zebra_chain::serialization::SerializationError;
 
@@ -1808,15 +1812,6 @@ pub enum GetSubtreesError {
 impl ResponseToError for GetSubtreesResponse {
     type RpcError = GetSubtreesError;
 }
-impl TryFrom<RpcError> for GetSubtreesError {
-    type Error = RpcError;
-
-    fn try_from(value: RpcError) -> Result<Self, Self::Error> {
-        // TODO: attempt to convert RpcError into errors specific to this RPC response
-        Err(value)
-    }
-}
-
 impl From<GetSubtreesResponse> for zebra_rpc::client::GetSubtreesByIndexResponse {
     fn from(value: GetSubtreesResponse) -> Self {
         zebra_rpc::client::GetSubtreesByIndexResponse::new(
@@ -1881,14 +1876,8 @@ impl<'de> serde::Deserialize<'de> for Script {
     where
         D: serde::Deserializer<'de>,
     {
-        let v = serde_json::Value::deserialize(deserializer)?;
-        if let Some(hex_str) = v.as_str() {
-            let bytes = hex::decode(hex_str).map_err(DeserError::custom)?;
-            let inner = zebra_chain::transparent::Script::new(&bytes);
-            Ok(Script(inner))
-        } else {
-            Err(DeserError::custom("expected a hex string"))
-        }
+        let bytes = deserialize_hex_bytes(deserializer)?;
+        Ok(Script(zebra_chain::transparent::Script::new(&bytes)))
     }
 }
 
@@ -1928,15 +1917,6 @@ pub enum GetUtxosError {
 impl ResponseToError for GetUtxosResponse {
     type RpcError = GetUtxosError;
 }
-impl TryFrom<RpcError> for GetUtxosError {
-    type Error = RpcError;
-
-    fn try_from(value: RpcError) -> Result<Self, Self::Error> {
-        // TODO: attempt to convert RpcError into errors specific to this RPC response
-        Err(value)
-    }
-}
-
 impl ResponseToError for Vec<GetUtxosResponse> {
     type RpcError = GetUtxosError;
 }

--- a/packages/zaino-fetch/src/jsonrpsee/response.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response.rs
@@ -213,6 +213,22 @@ impl TryFrom<super::connector::RpcError> for GetSpentInfoError {
     }
 }
 
+/// Test helpers shared by the response modules' `#[cfg(test)]` suites.
+#[cfg(test)]
+pub(crate) mod test_util {
+    /// Verifies that a type can be serialized and deserialized with the same shape.
+    ///
+    /// If the type does not have the same shape after serialization and deserialization, this function will panic.
+    pub(crate) fn roundtrip<T>(value: &T)
+    where
+        T: serde::Serialize + for<'de> serde::Deserialize<'de> + std::fmt::Debug + PartialEq,
+    {
+        let s = serde_json::to_string(value).unwrap();
+        let back: T = serde_json::from_str(&s).unwrap();
+        assert_eq!(&back, value);
+    }
+}
+
 #[cfg(test)]
 mod get_spent_info {
     use super::{GetSpentInfoError, GetSpentInfoRequest, GetSpentInfoResponse};

--- a/packages/zaino-fetch/src/jsonrpsee/response/address_deltas.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response/address_deltas.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use zebra_rpc::client::{Input, Output, TransactionObject};
 
-use crate::jsonrpsee::connector::{ResponseToError, RpcError};
+use crate::jsonrpsee::connector::ResponseToError;
 
 /// Request parameters for the `getaddressdeltas` RPC method.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -140,13 +140,7 @@ impl ResponseToError for GetAddressDeltasResponse {
     type RpcError = GetAddressDeltasError;
 }
 
-impl TryFrom<RpcError> for GetAddressDeltasError {
-    type Error = RpcError;
-
-    fn try_from(value: RpcError) -> Result<Self, Self::Error> {
-        Err(value)
-    }
-}
+crate::jsonrpsee::response::impl_rpc_error_passthrough!(GetAddressDeltasError);
 
 /// Represents a change in the balance of a transparent address.
 #[derive(Debug, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]

--- a/packages/zaino-fetch/src/jsonrpsee/response/block_deltas.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response/block_deltas.rs
@@ -86,11 +86,9 @@ impl TryFrom<RpcError> for BlockDeltasError {
     type Error = RpcError;
 
     fn try_from(value: RpcError) -> Result<Self, Self::Error> {
-        if value.code == -8 {
-            Ok(Self::UnexpectedRawBlock)
-        } else {
-            Err(value)
-        }
+        // Same `-8` predicate as the getblock/getblockheader mappings, but
+        // the variant carries no message.
+        crate::jsonrpsee::response::rpc_error_code_map(value, -8, |_| Self::UnexpectedRawBlock)
     }
 }
 

--- a/packages/zaino-fetch/src/jsonrpsee/response/block_header.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response/block_header.rs
@@ -123,11 +123,7 @@ impl TryFrom<RpcError> for GetBlockHeaderError {
     fn try_from(value: RpcError) -> Result<Self, Self::Error> {
         // If the block is not in Zebra's state, returns
         // [error code `-8`.](https://github.com/zcash/zcash/issues/5758)
-        if value.code == -8 {
-            Ok(Self::MissingBlock(value.message))
-        } else {
-            Err(value)
-        }
+        crate::jsonrpsee::response::rpc_error_code_map(value, -8, Self::MissingBlock)
     }
 }
 

--- a/packages/zaino-fetch/src/jsonrpsee/response/block_subsidy.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response/block_subsidy.rs
@@ -1,11 +1,6 @@
 //! Types associated with the `getblocksubsidy` RPC request.
 
-use std::convert::Infallible;
-
-use crate::jsonrpsee::{
-    connector::ResponseToError,
-    response::common::amount::{Zatoshis, ZecAmount},
-};
+use crate::jsonrpsee::response::common::amount::{Zatoshis, ZecAmount};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
@@ -105,9 +100,7 @@ pub enum GetBlockSubsidy {
     Unknown(Value),
 }
 
-impl ResponseToError for GetBlockSubsidy {
-    type RpcError = Infallible;
-}
+crate::jsonrpsee::response::impl_infallible_response_to_error!(GetBlockSubsidy);
 
 impl<'de> Deserialize<'de> for GetBlockSubsidy {
     fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {

--- a/packages/zaino-fetch/src/jsonrpsee/response/chain_tips.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response/chain_tips.rs
@@ -1,10 +1,6 @@
 //! Types associated with the `getchaintips` RPC request.
 
-use std::convert::Infallible;
-
 use serde::{Deserialize, Serialize};
-
-use crate::jsonrpsee::connector::ResponseToError;
 
 /// Response to a `getchaintips` RPC request.
 pub type GetChainTipsResponse = Vec<ChainTip>;
@@ -52,6 +48,4 @@ pub enum ChainTipStatus {
     Unknown,
 }
 
-impl ResponseToError for GetChainTipsResponse {
-    type RpcError = Infallible;
-}
+crate::jsonrpsee::response::impl_infallible_response_to_error!(GetChainTipsResponse);

--- a/packages/zaino-fetch/src/jsonrpsee/response/common/amount.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response/common/amount.rs
@@ -133,7 +133,7 @@ impl<'de> Deserialize<'de> for ZecAmount {
 impl Serialize for ZecAmount {
     fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
         // Emit a JSON number in ZEC.
-        let zec = (self.0 as f64) / 100_000_000.0;
+        let zec = (self.0 as f64) / (ZATS_PER_ZEC as f64);
         ser.serialize_f64(zec)
     }
 }

--- a/packages/zaino-fetch/src/jsonrpsee/response/mining_info.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response/mining_info.rs
@@ -107,6 +107,7 @@ impl From<GetMiningInfoWire> for MiningInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::jsonrpsee::response::test_util::roundtrip;
     use serde_json::json;
 
     fn zebrad_json() -> String {
@@ -163,9 +164,7 @@ mod tests {
         assert!(wire.extras.contains_key("somefuture"));
         assert_eq!(wire.extras["somefuture"], json!({"x": 1}));
 
-        let str_from_wire = serde_json::to_string(&wire).unwrap();
-        let wire2: GetMiningInfoWire = serde_json::from_str(&str_from_wire).unwrap();
-        assert_eq!(wire, wire2);
+        roundtrip(&wire);
     }
 
     #[test]
@@ -190,9 +189,7 @@ mod tests {
         assert_eq!(wire.pooledtx, Some(5));
         assert_eq!(wire.generate, Some(false));
 
-        let s = serde_json::to_string(&wire).unwrap();
-        let wire2: GetMiningInfoWire = serde_json::from_str(&s).unwrap();
-        assert_eq!(wire, wire2);
+        roundtrip(&wire);
     }
 
     #[test]
@@ -213,9 +210,7 @@ mod tests {
         assert_eq!(wire.errors, None);
         assert!(wire.extras.is_empty());
 
-        let blocks_deserialized = serde_json::to_string(&wire).unwrap();
-        let wire2: GetMiningInfoWire = serde_json::from_str(&blocks_deserialized).unwrap();
-        assert_eq!(wire, wire2);
+        roundtrip(&wire);
     }
 
     #[test]

--- a/packages/zaino-fetch/src/jsonrpsee/response/mining_info.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response/mining_info.rs
@@ -1,14 +1,10 @@
 //! Types associated with the `getmininginfo` RPC request.
 
-use std::{collections::HashMap, convert::Infallible};
+use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::jsonrpsee::connector::ResponseToError;
-
-impl ResponseToError for GetMiningInfoWire {
-    type RpcError = Infallible;
-}
+crate::jsonrpsee::response::impl_infallible_response_to_error!(GetMiningInfoWire);
 
 /// Wire superset compatible with `zcashd` and `zebrad`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/packages/zaino-fetch/src/jsonrpsee/response/peer_info.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response/peer_info.rs
@@ -3,14 +3,11 @@
 //! Although the current threat model assumes that `zaino` connects to a trusted validator,
 //! the `getpeerinfo` RPC performs some light validation.
 
-use std::convert::Infallible;
-
 #[cfg(feature = "zcashd_support")]
 use serde::Serializer;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
-use crate::jsonrpsee::connector::ResponseToError;
 #[cfg(feature = "zcashd_support")]
 use crate::jsonrpsee::response::common::{
     BlockHeight, Bytes, MaybeHeight, NodeId, ProtocolVersion, SecondsF64, TimeOffsetSeconds,
@@ -145,9 +142,7 @@ impl<'de> Deserialize<'de> for GetPeerInfo {
     }
 }
 
-impl ResponseToError for GetPeerInfo {
-    type RpcError = Infallible;
-}
+crate::jsonrpsee::response::impl_infallible_response_to_error!(GetPeerInfo);
 
 /// Bitflags for the peer's advertised services (backed by a u64).
 /// Serialized as a zero-padded 16-digit lowercase hex string.

--- a/packages/zaino-fetch/src/jsonrpsee/response/z_validate_address.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response/z_validate_address.rs
@@ -613,19 +613,8 @@ pub enum ZValidateAddressType {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::jsonrpsee::response::test_util::roundtrip;
     use serde_json::json;
-
-    /// Verifies that a type can be serialized and deserialized with the same shape.
-    ///
-    /// If the type does not have the same shape after serialization and deserialization, this function will panic.
-    fn roundtrip<T>(value: &T)
-    where
-        T: serde::Serialize + for<'de> serde::Deserialize<'de> + std::fmt::Debug + PartialEq,
-    {
-        let s = serde_json::to_string(value).unwrap();
-        let back: T = serde_json::from_str(&s).unwrap();
-        assert_eq!(&back, value);
-    }
 
     #[test]
     fn invalid_roundtrip_and_shape() {

--- a/packages/zaino-fetch/src/jsonrpsee/response/z_validate_address.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response/z_validate_address.rs
@@ -20,7 +20,7 @@ use serde::{
 };
 use serde_json::Value;
 
-use crate::jsonrpsee::connector::{ResponseToError, RpcError};
+use crate::jsonrpsee::connector::ResponseToError;
 
 /// Error type for the `z_validateaddress` RPC.
 #[derive(Debug, thiserror::Error)]
@@ -116,13 +116,7 @@ impl ResponseToError for ZValidateAddressResponse {
     type RpcError = ZValidateAddressError;
 }
 
-impl TryFrom<RpcError> for ZValidateAddressError {
-    type Error = RpcError;
-
-    fn try_from(value: RpcError) -> Result<Self, Self::Error> {
-        Err(value)
-    }
-}
+crate::jsonrpsee::response::impl_rpc_error_passthrough!(ZValidateAddressError);
 
 /// An enum that represents the known JSON schema for the `z_validateaddress` RPC.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -252,13 +246,7 @@ impl ValidZValidateAddress {
 
     /// Returns the address type.
     pub fn address_type(&self) -> ZValidateAddressType {
-        match &self.0 {
-            AddressData::P2pkh { .. } => ZValidateAddressType::P2pkh,
-            AddressData::P2sh { .. } => ZValidateAddressType::P2sh,
-            AddressData::Sprout { .. } => ZValidateAddressType::Sprout,
-            AddressData::Sapling { .. } => ZValidateAddressType::Sapling,
-            AddressData::Unified { .. } => ZValidateAddressType::Unified,
-        }
+        self.0.variant_type()
     }
 
     /// Returns the legacy field for the address type.
@@ -329,22 +317,10 @@ impl ValidZValidateAddress {
     }
 
     fn common(&self) -> &CommonFields {
-        match &self.0 {
-            AddressData::P2pkh { common, .. }
-            | AddressData::P2sh { common, .. }
-            | AddressData::Sprout { common, .. }
-            | AddressData::Sapling { common, .. }
-            | AddressData::Unified { common, .. } => common,
-        }
+        self.0.common()
     }
     fn common_mut(&mut self) -> &mut CommonFields {
-        match &mut self.0 {
-            AddressData::P2pkh { common, .. }
-            | AddressData::P2sh { common, .. }
-            | AddressData::Sprout { common, .. }
-            | AddressData::Sapling { common, .. }
-            | AddressData::Unified { common, .. } => common,
-        }
+        self.0.common_mut()
     }
 
     /// Returns the address data.
@@ -429,6 +405,16 @@ pub enum AddressData {
 
 impl AddressData {
     fn common(&self) -> &CommonFields {
+        match self {
+            AddressData::P2pkh { common, .. }
+            | AddressData::P2sh { common, .. }
+            | AddressData::Sprout { common, .. }
+            | AddressData::Sapling { common, .. }
+            | AddressData::Unified { common, .. } => common,
+        }
+    }
+
+    fn common_mut(&mut self) -> &mut CommonFields {
         match self {
             AddressData::P2pkh { common, .. }
             | AddressData::P2sh { common, .. }

--- a/packages/zaino-fetch/src/utils.rs
+++ b/packages/zaino-fetch/src/utils.rs
@@ -17,3 +17,28 @@ pub trait ParseFromSlice {
     where
         Self: Sized;
 }
+
+/// Rejects a `tx_version` argument for the Zebra-backed parsers, which take
+/// none; `type_name` labels the caller in the error message.
+pub(crate) fn reject_tx_version(
+    tx_version: Option<u32>,
+    type_name: &str,
+) -> Result<(), ParseError> {
+    if tx_version.is_some() {
+        return Err(ParseError::InvalidData(format!(
+            "tx_version must be None for {type_name}::parse_from_slice"
+        )));
+    }
+    Ok(())
+}
+
+/// Deserializes one Zcash structure from the front of `data`, returning the
+/// value together with the number of bytes consumed.
+pub(crate) fn zcash_deserialize_consumed<T: zebra_chain::serialization::ZcashDeserialize>(
+    data: &[u8],
+) -> Result<(T, usize), ParseError> {
+    let mut cursor = std::io::Cursor::new(data);
+    let value = T::zcash_deserialize(&mut cursor)?;
+    let consumed = usize::try_from(cursor.position())?;
+    Ok((value, consumed))
+}

--- a/packages/zaino-proto/CHANGELOG.md
+++ b/packages/zaino-proto/CHANGELOG.md
@@ -8,6 +8,32 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.3.0] - 2026-08-04
+
+### Added
+- `PoolTypeError::DuplicatePoolType` variant.
+### Changed
+- **Breaking** — `ValidatedBlockRangeRequest` now stores its parsed `u32`
+  block-height endpoints. Consumers read the heights directly and drop their
+  own `as u32` casts at the call site.
+- **Breaking** — pool-type validation now rejects a request that names the
+  same pool more than once (returning `PoolTypeError::DuplicatePoolType`)
+  instead of silently collapsing the duplicate into a single pool.
+- Internal — the hand-written proto utility helpers were DRY'd and made
+  expression-oriented (parse-don't-validate), and the build script was
+  deduplicated. No effect on the generated wire types beyond the changes above.
+### Deprecated
+### Removed
+### Fixed
+
+## [0.2.0] - 2026-07-13
+
+### Added
 - Pool-type filter serves Ironwood by default (`include_ironwood: true`), so
   clients that predate the field still receive `ironwoodActions` (unknown
   protobuf fields are carried harmlessly).

--- a/packages/zaino-proto/Cargo.toml
+++ b/packages/zaino-proto/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.0"
+version = "0.3.0"
 
 [features]
 default = ["heavy"]

--- a/packages/zaino-proto/build.rs
+++ b/packages/zaino-proto/build.rs
@@ -70,37 +70,30 @@ fn build() -> io::Result<()> {
         "src/proto/compact_formats.rs",
     )?;
 
-    // Build the gRPC types and client.
-    configure()
-        .build_server(true)
-        // .client_mod_attribute(
-        //     "cash.z.wallet.sdk.rpc",
-        //     r#"#[cfg(feature = "lightwalletd-tonic")]"#,
-        // )
-        .extern_path(
-            ".cash.z.wallet.sdk.rpc.ChainMetadata",
-            "crate::proto::compact_formats::ChainMetadata",
-        )
-        .extern_path(
-            ".cash.z.wallet.sdk.rpc.CompactBlock",
-            "crate::proto::compact_formats::CompactBlock",
-        )
-        .extern_path(
-            ".cash.z.wallet.sdk.rpc.CompactTx",
-            "crate::proto::compact_formats::CompactTx",
-        )
-        .extern_path(
-            ".cash.z.wallet.sdk.rpc.CompactSaplingSpend",
-            "crate::proto::compact_formats::CompactSaplingSpend",
-        )
-        .extern_path(
-            ".cash.z.wallet.sdk.rpc.CompactSaplingOutput",
-            "crate::proto::compact_formats::CompactSaplingOutput",
-        )
-        .extern_path(
-            ".cash.z.wallet.sdk.rpc.CompactOrchardAction",
-            "crate::proto::compact_formats::CompactOrchardAction",
-        )
+    // Build the gRPC types and client, remapping every compact-format type
+    // the service references onto the module compiled above.
+    const COMPACT_FORMAT_TYPES: [&str; 6] = [
+        "ChainMetadata",
+        "CompactBlock",
+        "CompactTx",
+        "CompactSaplingSpend",
+        "CompactSaplingOutput",
+        "CompactOrchardAction",
+    ];
+    // A gating attribute once considered for the generated client would be
+    // restored on this builder:
+    // .client_mod_attribute(
+    //     "cash.z.wallet.sdk.rpc",
+    //     r#"#[cfg(feature = "lightwalletd-tonic")]"#,
+    // )
+    COMPACT_FORMAT_TYPES
+        .iter()
+        .fold(configure().build_server(true), |builder, name| {
+            builder.extern_path(
+                format!(".cash.z.wallet.sdk.rpc.{name}"),
+                format!("crate::proto::compact_formats::{name}"),
+            )
+        })
         .compile_protos(&[SERVICE_PROTO], &["proto/"])?;
 
     // Build the proposal types.

--- a/packages/zaino-proto/src/proto/utils.rs
+++ b/packages/zaino-proto/src/proto/utils.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use crate::proto::{
     compact_formats::{ChainMetadata, CompactBlock, CompactOrchardAction},
     service::{BlockId, BlockRange, PoolType},
@@ -6,6 +8,14 @@ use crate::proto::{
 use zebra_chain::block::Height;
 #[cfg(feature = "heavy")]
 use zebra_state::HashOrHeight;
+
+/// Every pool a request may name — the `PoolType` variants minus `Invalid`.
+const KNOWN_POOLS: [PoolType; 4] = [
+    PoolType::Transparent,
+    PoolType::Sapling,
+    PoolType::Orchard,
+    PoolType::Ironwood,
+];
 
 #[derive(Debug, PartialEq, Eq)]
 /// Errors that can arise when mapping `PoolType` from an `i32` value.
@@ -32,34 +42,22 @@ pub enum PoolTypeError {
 /// two cannot drift again (they had: the filter default gained Ironwood while
 /// this backfill still listed only Sapling and Orchard).
 pub fn pool_types_from_vector(pool_types: &[i32]) -> Result<Vec<PoolType>, PoolTypeError> {
-    let pools = if pool_types.is_empty() {
-        PoolTypeFilter::default().to_pool_types_vector()
-    } else {
-        let mut pools: Vec<PoolType> = vec![];
-
-        for pool in pool_types.iter() {
-            match PoolType::try_from(*pool) {
-                Ok(pool_type) => {
-                    if pool_type == PoolType::Invalid {
-                        return Err(PoolTypeError::InvalidPoolType);
-                    } else {
-                        pools.push(pool_type);
-                    }
-                }
-                Err(_) => {
-                    return Err(PoolTypeError::UnknownPoolType(*pool));
-                }
-            };
-        }
-
-        pools.clone()
-    };
-    Ok(pools)
+    if pool_types.is_empty() {
+        return Ok(PoolTypeFilter::default().to_pool_types_vector());
+    }
+    pool_types
+        .iter()
+        .map(|&raw| match PoolType::try_from(raw) {
+            Ok(PoolType::Invalid) => Err(PoolTypeError::InvalidPoolType),
+            Ok(pool_type) => Ok(pool_type),
+            Err(_) => Err(PoolTypeError::UnknownPoolType(raw)),
+        })
+        .collect()
 }
 
-/// Converts a `Vec<Pooltype>` into a `Vec<i32>`
-pub fn pool_types_into_i32_vec(pool_types: Vec<PoolType>) -> Vec<i32> {
-    pool_types.iter().map(|p| *p as i32).collect()
+/// Converts a slice of `PoolType`s into the `Vec<i32>` wire representation.
+pub fn pool_types_into_i32_vec(pool_types: &[PoolType]) -> Vec<i32> {
+    pool_types.iter().map(|&p| p as i32).collect()
 }
 
 /// Errors that can be present in the request of the GetBlockRange RPC
@@ -107,25 +105,13 @@ impl ValidatedBlockRangeRequest {
     pub fn new_from_block_range(
         request: &BlockRange,
     ) -> Result<ValidatedBlockRangeRequest, GetBlockRangeError> {
-        let start = match &request.start {
-            Some(block_id) => block_id.height,
-            None => {
-                return Err(GetBlockRangeError::NoStartHeightProvided);
-            }
-        };
-        let end = match &request.end {
-            Some(block_id) => block_id.height,
-            None => {
-                return Err(GetBlockRangeError::NoEndHeightProvided);
-            }
-        };
+        // Presence is checked for both endpoints before either range check so
+        // a request failing both reports the same error it always has.
+        let start = provided_height(&request.start, GetBlockRangeError::NoStartHeightProvided)?;
+        let end = provided_height(&request.end, GetBlockRangeError::NoEndHeightProvided)?;
 
-        if u32::try_from(start).is_err() {
-            return Err(GetBlockRangeError::StartHeightOutOfRange);
-        }
-        if u32::try_from(end).is_err() {
-            return Err(GetBlockRangeError::EndHeightOutOfRange);
-        }
+        fits_in_u32(start, GetBlockRangeError::StartHeightOutOfRange)?;
+        fits_in_u32(end, GetBlockRangeError::EndHeightOutOfRange)?;
 
         let pool_types = pool_types_from_vector(&request.pool_types)
             .map_err(GetBlockRangeError::PoolTypeArgumentError)?;
@@ -163,158 +149,130 @@ impl ValidatedBlockRangeRequest {
     }
 }
 
+/// The height of a range endpoint, or `missing` when the endpoint was not
+/// provided in the request.
+fn provided_height(
+    endpoint: &Option<BlockId>,
+    missing: GetBlockRangeError,
+) -> Result<u64, GetBlockRangeError> {
+    Ok(endpoint.as_ref().ok_or(missing)?.height)
+}
+
+/// Errors with `out_of_range` when `height` cannot be represented as a `u32`.
+fn fits_in_u32(height: u64, out_of_range: GetBlockRangeError) -> Result<(), GetBlockRangeError> {
+    u32::try_from(height).map(|_| ()).map_err(|_| out_of_range)
+}
+
+/// The set of pools a request asks to be served.
+///
+/// Internally a set keyed by [`PoolType`], so "which pools exist" is
+/// recorded once, in the enum (plus [`KNOWN_POOLS`]) — not once per method.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PoolTypeFilter {
-    include_transparent: bool,
-    include_sapling: bool,
-    include_orchard: bool,
-    include_ironwood: bool,
+    included: BTreeSet<PoolType>,
 }
 
 impl std::default::Default for PoolTypeFilter {
     /// The unfiltered pool set: every shielded pool, transparent excluded.
     fn default() -> Self {
-        PoolTypeFilter {
-            include_transparent: false,
-            include_sapling: true,
-            include_orchard: true,
-            include_ironwood: true,
-        }
+        Self::containing(|pool| pool != PoolType::Transparent)
     }
 }
 
 impl PoolTypeFilter {
     /// A PoolType Filter that will include all existing pool types.
     pub fn includes_all() -> Self {
+        Self::containing(|_| true)
+    }
+
+    /// The filter holding every known pool that satisfies `include`.
+    fn containing(include: impl Fn(PoolType) -> bool) -> Self {
         PoolTypeFilter {
-            include_transparent: true,
-            include_sapling: true,
-            include_orchard: true,
-            include_ironwood: true,
+            included: KNOWN_POOLS.into_iter().filter(|&p| include(p)).collect(),
         }
     }
 
     /// create a `PoolTypeFilter` from a vector of raw i32 `PoolType`s
     /// If the vector is empty it will return `Self::default()`.
-    /// If the vector contains `PoolType::Invalid` or the vector contains more than 3 elements
-    /// returns `PoolTypeError::InvalidPoolType`
+    /// If the vector contains `PoolType::Invalid` or the vector contains more
+    /// elements than there are known pools, returns `PoolTypeError::InvalidPoolType`.
     pub fn new_from_slice(pool_types: &[i32]) -> Result<Self, PoolTypeError> {
         let pool_types = pool_types_from_vector(pool_types)?;
 
         Self::new_from_pool_types(&pool_types)
     }
 
-    /// create a `PoolTypeFilter` from a vector of `PoolType`
-    /// If the vector is empty it will return `Self::default()`.
-    /// If the vector contains `PoolType::Invalid` or the vector contains more than 3 elements
-    /// returns `PoolTypeError::InvalidPoolType`
-    pub fn new_from_pool_types(
-        pool_types: &Vec<PoolType>,
-    ) -> Result<PoolTypeFilter, PoolTypeError> {
-        if pool_types.len() > PoolType::Ironwood as usize {
+    /// create a `PoolTypeFilter` from a slice of `PoolType`
+    /// If the slice is empty it will return `Self::default()`.
+    /// If the slice contains `PoolType::Invalid` or the slice contains more
+    /// elements than there are known pools, returns `PoolTypeError::InvalidPoolType`.
+    pub fn new_from_pool_types(pool_types: &[PoolType]) -> Result<PoolTypeFilter, PoolTypeError> {
+        if pool_types.len() > KNOWN_POOLS.len() {
             return Err(PoolTypeError::InvalidPoolType);
         }
 
         if pool_types.is_empty() {
-            Ok(Self::default())
-        } else {
-            let mut filter = PoolTypeFilter::empty();
-
-            for pool_type in pool_types {
-                match pool_type {
-                    PoolType::Invalid => return Err(PoolTypeError::InvalidPoolType),
-                    PoolType::Transparent => filter.include_transparent = true,
-                    PoolType::Sapling => filter.include_sapling = true,
-                    PoolType::Orchard => filter.include_orchard = true,
-                    PoolType::Ironwood => filter.include_ironwood = true,
-                }
-            }
-
-            // guard against returning an invalid state this shouls never happen.
-            if filter.is_empty() {
-                Ok(Self::default())
-            } else {
-                Ok(filter)
-            }
+            return Ok(Self::default());
         }
-    }
 
-    /// only internal use. this in an invalid state.
-    fn empty() -> Self {
-        Self {
-            include_transparent: false,
-            include_sapling: false,
-            include_orchard: false,
-            include_ironwood: false,
+        let mut included = BTreeSet::new();
+        for &pool_type in pool_types {
+            if pool_type == PoolType::Invalid {
+                return Err(PoolTypeError::InvalidPoolType);
+            }
+            included.insert(pool_type);
         }
+        Ok(PoolTypeFilter { included })
     }
 
-    /// only internal use
-    fn is_empty(&self) -> bool {
-        !self.include_transparent
-            && !self.include_sapling
-            && !self.include_orchard
-            && !self.include_ironwood
-    }
-
-    /// retuns whether the filter includes transparent data
+    /// returns whether the filter includes transparent data
     pub fn includes_transparent(&self) -> bool {
-        self.include_transparent
+        self.included.contains(&PoolType::Transparent)
+    }
+
+    /// returns whether the filter includes sapling data
+    pub fn includes_sapling(&self) -> bool {
+        self.included.contains(&PoolType::Sapling)
     }
 
     /// returns whether the filter includes orchard data
-    pub fn includes_sapling(&self) -> bool {
-        self.include_sapling
-    }
-
-    // returnw whether the filter includes orchard data
     pub fn includes_orchard(&self) -> bool {
-        self.include_orchard
+        self.included.contains(&PoolType::Orchard)
     }
 
     /// returns whether the filter includes ironwood data
     pub fn includes_ironwood(&self) -> bool {
-        self.include_ironwood
+        self.included.contains(&PoolType::Ironwood)
     }
 
     /// Convert this filter into the corresponding `Vec<PoolType>`.
     ///
-    /// The resulting vector contains each included pool type at most once.
+    /// The resulting vector contains each included pool type at most once,
+    /// in `PoolType` declaration order.
     pub fn to_pool_types_vector(&self) -> Vec<PoolType> {
-        let mut pool_types: Vec<PoolType> = Vec::new();
-
-        if self.include_transparent {
-            pool_types.push(PoolType::Transparent);
-        }
-
-        if self.include_sapling {
-            pool_types.push(PoolType::Sapling);
-        }
-
-        if self.include_orchard {
-            pool_types.push(PoolType::Orchard);
-        }
-
-        if self.include_ironwood {
-            pool_types.push(PoolType::Ironwood);
-        }
-
-        pool_types
+        self.included.iter().copied().collect()
     }
 
     /// testing only
-    #[allow(dead_code)]
-    pub(crate) fn from_checked_parts(
+    #[cfg(test)]
+    fn from_checked_parts(
         include_transparent: bool,
         include_sapling: bool,
         include_orchard: bool,
         include_ironwood: bool,
     ) -> Self {
-        PoolTypeFilter {
+        let flags = [
             include_transparent,
             include_sapling,
             include_orchard,
             include_ironwood,
+        ];
+        PoolTypeFilter {
+            included: KNOWN_POOLS
+                .into_iter()
+                .zip(flags)
+                .filter_map(|(pool, included)| included.then_some(pool))
+                .collect(),
         }
     }
 }
@@ -334,83 +292,67 @@ pub fn blockid_to_hashorheight(block_id: BlockId) -> Option<HashOrHeight> {
         .ok()
 }
 
-/// prunes a compact block from transaction in formation related to pools not included in the
-/// `pool_types` vector.
-/// Note: for backwards compatibility an empty vector will return Sapling and Orchard Tx info.
+/// Prunes a compact block of transaction information related to pools not
+/// included in the `pool_types` vector.
+/// An empty vector means the client did not filter, so the unfiltered pool
+/// set ([`PoolTypeFilter::default`]) is served.
 pub fn compact_block_with_pool_types(
     mut block: CompactBlock,
     pool_types: &[PoolType],
 ) -> CompactBlock {
-    if pool_types.is_empty() {
-        for compact_tx in &mut block.vtx {
-            // strip out transparent inputs if not Requested
+    let unfiltered;
+    let pool_types = if pool_types.is_empty() {
+        unfiltered = PoolTypeFilter::default().to_pool_types_vector();
+        &unfiltered
+    } else {
+        pool_types
+    };
+
+    for compact_tx in &mut block.vtx {
+        // strip out transparent inputs if not requested
+        if !pool_types.contains(&PoolType::Transparent) {
             compact_tx.vin.clear();
             compact_tx.vout.clear();
         }
-
-        // Omit transactions that have no Sapling/Orchard elements.
-        block.vtx.retain(|compact_tx| {
-            !compact_tx.spends.is_empty()
-                || !compact_tx.outputs.is_empty()
-                || !compact_tx.actions.is_empty()
-                || !compact_tx.ironwood_actions.is_empty()
-        });
-    } else {
-        for compact_tx in &mut block.vtx {
-            // strip out transparent inputs if not Requested
-            if !pool_types.contains(&PoolType::Transparent) {
-                compact_tx.vin.clear();
-                compact_tx.vout.clear();
-            }
-            // strip out sapling if not requested
-            if !pool_types.contains(&PoolType::Sapling) {
-                compact_tx.spends.clear();
-                compact_tx.outputs.clear();
-            }
-            // strip out orchard if not requested
-            if !pool_types.contains(&PoolType::Orchard) {
-                compact_tx.actions.clear();
-            }
-            // strip out ironwood if not requested
-            if !pool_types.contains(&PoolType::Ironwood) {
-                compact_tx.ironwood_actions.clear();
-            }
+        // strip out sapling if not requested
+        if !pool_types.contains(&PoolType::Sapling) {
+            compact_tx.spends.clear();
+            compact_tx.outputs.clear();
         }
-
-        // Omit transactions that have no elements in any requested pool type.
-        block.vtx.retain(|compact_tx| {
-            !compact_tx.vin.is_empty()
-                || !compact_tx.vout.is_empty()
-                || !compact_tx.spends.is_empty()
-                || !compact_tx.outputs.is_empty()
-                || !compact_tx.actions.is_empty()
-                || !compact_tx.ironwood_actions.is_empty()
-        });
+        // strip out orchard if not requested
+        if !pool_types.contains(&PoolType::Orchard) {
+            compact_tx.actions.clear();
+        }
+        // strip out ironwood if not requested
+        if !pool_types.contains(&PoolType::Ironwood) {
+            compact_tx.ironwood_actions.clear();
+        }
     }
+
+    // Omit transactions that have no elements in any requested pool type.
+    block.vtx.retain(|compact_tx| {
+        !compact_tx.vin.is_empty()
+            || !compact_tx.vout.is_empty()
+            || !compact_tx.spends.is_empty()
+            || !compact_tx.outputs.is_empty()
+            || !compact_tx.actions.is_empty()
+            || !compact_tx.ironwood_actions.is_empty()
+    });
 
     block
 }
 
-/// Strips the ouputs and from all transactions, retains only
-/// the nullifier from all orcard actions, and clears the chain
-/// metadata from the block
+/// Strips the outputs and transparent data from all transactions, retains
+/// only the nullifier from all Orchard and Ironwood actions, and clears the
+/// chain metadata from the block. Sapling spends are kept whole: the spend
+/// itself is the nullifier carrier.
 pub fn compact_block_to_nullifiers(mut block: CompactBlock) -> CompactBlock {
     for ctransaction in &mut block.vtx {
         ctransaction.outputs = Vec::new();
         ctransaction.vin = Vec::new();
         ctransaction.vout = Vec::new();
-        for caction in &mut ctransaction.actions {
-            *caction = CompactOrchardAction {
-                nullifier: caction.nullifier.clone(),
-                ..Default::default()
-            }
-        }
-        for caction in &mut ctransaction.ironwood_actions {
-            *caction = CompactOrchardAction {
-                nullifier: caction.nullifier.clone(),
-                ..Default::default()
-            }
-        }
+        retain_only_nullifiers(&mut ctransaction.actions);
+        retain_only_nullifiers(&mut ctransaction.ironwood_actions);
     }
 
     block.chain_metadata = Some(ChainMetadata {
@@ -419,6 +361,16 @@ pub fn compact_block_to_nullifiers(mut block: CompactBlock) -> CompactBlock {
         ironwood_commitment_tree_size: 0,
     });
     block
+}
+
+/// Reduces each action to one carrying only its nullifier.
+fn retain_only_nullifiers(actions: &mut [CompactOrchardAction]) {
+    for action in actions {
+        *action = CompactOrchardAction {
+            nullifier: std::mem::take(&mut action.nullifier),
+            ..Default::default()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -492,7 +444,7 @@ mod test {
     #[test]
     fn test_pool_type_filter_default() {
         assert_eq!(
-            PoolTypeFilter::new_from_pool_types(&vec![]),
+            PoolTypeFilter::new_from_pool_types(&[]),
             Ok(PoolTypeFilter::default())
         );
     }

--- a/packages/zaino-proto/src/proto/utils.rs
+++ b/packages/zaino-proto/src/proto/utils.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use crate::proto::{
-    compact_formats::{ChainMetadata, CompactBlock, CompactOrchardAction},
+    compact_formats::{ChainMetadata, CompactBlock, CompactOrchardAction, CompactTx},
     service::{BlockId, BlockRange, PoolType},
 };
 #[cfg(feature = "heavy")]
@@ -84,11 +84,11 @@ pub enum GetBlockRangeError {
 /// - `start` and `end` are in the inclusive range `0..=u32::MAX`, so they can be
 ///   safely converted to `u32` (for example via `u32::try_from(...)`) without
 ///   failing.
-/// - `pool_types` has been validated via `pool_types_from_vector`.
+/// - the requested pools have been validated into a [`PoolTypeFilter`].
 pub struct ValidatedBlockRangeRequest {
     start: u64,
     end: u64,
-    pool_types: Vec<PoolType>,
+    filter: PoolTypeFilter,
 }
 
 impl ValidatedBlockRangeRequest {
@@ -113,14 +113,10 @@ impl ValidatedBlockRangeRequest {
         fits_in_u32(start, GetBlockRangeError::StartHeightOutOfRange)?;
         fits_in_u32(end, GetBlockRangeError::EndHeightOutOfRange)?;
 
-        let pool_types = pool_types_from_vector(&request.pool_types)
+        let filter = PoolTypeFilter::new_from_slice(&request.pool_types)
             .map_err(GetBlockRangeError::PoolTypeArgumentError)?;
 
-        Ok(ValidatedBlockRangeRequest {
-            start,
-            end,
-            pool_types,
-        })
+        Ok(ValidatedBlockRangeRequest { start, end, filter })
     }
 
     /// Start Height of the BlockRange Request
@@ -133,19 +129,9 @@ impl ValidatedBlockRangeRequest {
         self.end
     }
 
-    /// Pool Types of the BlockRange request
-    pub fn pool_types(&self) -> Vec<PoolType> {
-        self.pool_types.clone()
-    }
-
-    /// checks whether this request is specified in reversed order
-    pub fn is_reverse_ordered(&self) -> bool {
-        self.start > self.end
-    }
-
-    /// Reverses the order of this request
-    pub fn reverse(&mut self) {
-        (self.start, self.end) = (self.end, self.start);
+    /// The validated pool filter of the BlockRange request
+    pub fn pool_type_filter(&self) -> &PoolTypeFilter {
+        &self.filter
     }
 }
 
@@ -292,52 +278,48 @@ pub fn blockid_to_hashorheight(block_id: BlockId) -> Option<HashOrHeight> {
         .ok()
 }
 
-/// Prunes a compact block of transaction information related to pools not
-/// included in the `pool_types` vector.
-/// An empty vector means the client did not filter, so the unfiltered pool
-/// set ([`PoolTypeFilter::default`]) is served.
-pub fn compact_block_with_pool_types(
-    mut block: CompactBlock,
-    pool_types: &[PoolType],
-) -> CompactBlock {
-    let unfiltered;
-    let pool_types = if pool_types.is_empty() {
-        unfiltered = PoolTypeFilter::default().to_pool_types_vector();
-        &unfiltered
-    } else {
-        pool_types
-    };
+impl CompactTx {
+    /// Whether any per-pool field of this transaction is non-empty.
+    pub fn has_pool_data(&self) -> bool {
+        !self.vin.is_empty()
+            || !self.vout.is_empty()
+            || !self.spends.is_empty()
+            || !self.outputs.is_empty()
+            || !self.actions.is_empty()
+            || !self.ironwood_actions.is_empty()
+    }
+}
 
+/// Prunes a compact block of transaction information related to pools the
+/// filter excludes, then omits transactions left with no pool data at all.
+///
+/// An unfiltered request is expressed as [`PoolTypeFilter::default`]; the
+/// request-decode path ([`PoolTypeFilter::new_from_slice`]) produces it for
+/// an empty `poolTypes` field.
+pub fn prune_compact_block(mut block: CompactBlock, filter: &PoolTypeFilter) -> CompactBlock {
     for compact_tx in &mut block.vtx {
         // strip out transparent inputs if not requested
-        if !pool_types.contains(&PoolType::Transparent) {
+        if !filter.includes_transparent() {
             compact_tx.vin.clear();
             compact_tx.vout.clear();
         }
         // strip out sapling if not requested
-        if !pool_types.contains(&PoolType::Sapling) {
+        if !filter.includes_sapling() {
             compact_tx.spends.clear();
             compact_tx.outputs.clear();
         }
         // strip out orchard if not requested
-        if !pool_types.contains(&PoolType::Orchard) {
+        if !filter.includes_orchard() {
             compact_tx.actions.clear();
         }
         // strip out ironwood if not requested
-        if !pool_types.contains(&PoolType::Ironwood) {
+        if !filter.includes_ironwood() {
             compact_tx.ironwood_actions.clear();
         }
     }
 
     // Omit transactions that have no elements in any requested pool type.
-    block.vtx.retain(|compact_tx| {
-        !compact_tx.vin.is_empty()
-            || !compact_tx.vout.is_empty()
-            || !compact_tx.spends.is_empty()
-            || !compact_tx.outputs.is_empty()
-            || !compact_tx.actions.is_empty()
-            || !compact_tx.ironwood_actions.is_empty()
-    });
+    block.vtx.retain(CompactTx::has_pool_data);
 
     block
 }

--- a/packages/zaino-proto/src/proto/utils.rs
+++ b/packages/zaino-proto/src/proto/utils.rs
@@ -24,6 +24,8 @@ pub enum PoolTypeError {
     InvalidPoolType,
     /// Pool Type value was mapped to value that can't be mapped to a known pool type.
     UnknownPoolType(i32),
+    /// The same pool type was named more than once in one request.
+    DuplicatePoolType,
 }
 
 /// Converts a vector of pool_types (i32) into its rich-type representation
@@ -80,14 +82,13 @@ pub enum GetBlockRangeError {
 ///
 /// # Guarantees
 ///
-/// - `start` and `end` were provided in the request.
-/// - `start` and `end` are in the inclusive range `0..=u32::MAX`, so they can be
-///   safely converted to `u32` (for example via `u32::try_from(...)`) without
-///   failing.
+/// - `start` and `end` were provided in the request and are held as the
+///   `u32`s they parsed to, so the range guarantee is a type fact rather
+///   than a documented promise.
 /// - the requested pools have been validated into a [`PoolTypeFilter`].
 pub struct ValidatedBlockRangeRequest {
-    start: u64,
-    end: u64,
+    start: u32,
+    end: u32,
     filter: PoolTypeFilter,
 }
 
@@ -110,8 +111,8 @@ impl ValidatedBlockRangeRequest {
         let start = provided_height(&request.start, GetBlockRangeError::NoStartHeightProvided)?;
         let end = provided_height(&request.end, GetBlockRangeError::NoEndHeightProvided)?;
 
-        fits_in_u32(start, GetBlockRangeError::StartHeightOutOfRange)?;
-        fits_in_u32(end, GetBlockRangeError::EndHeightOutOfRange)?;
+        let start = u32::try_from(start).map_err(|_| GetBlockRangeError::StartHeightOutOfRange)?;
+        let end = u32::try_from(end).map_err(|_| GetBlockRangeError::EndHeightOutOfRange)?;
 
         let filter = PoolTypeFilter::new_from_slice(&request.pool_types)
             .map_err(GetBlockRangeError::PoolTypeArgumentError)?;
@@ -120,12 +121,12 @@ impl ValidatedBlockRangeRequest {
     }
 
     /// Start Height of the BlockRange Request
-    pub fn start(&self) -> u64 {
+    pub fn start(&self) -> u32 {
         self.start
     }
 
     /// End Height of the BlockRange Request
-    pub fn end(&self) -> u64 {
+    pub fn end(&self) -> u32 {
         self.end
     }
 
@@ -141,12 +142,10 @@ fn provided_height(
     endpoint: &Option<BlockId>,
     missing: GetBlockRangeError,
 ) -> Result<u64, GetBlockRangeError> {
-    Ok(endpoint.as_ref().ok_or(missing)?.height)
-}
-
-/// Errors with `out_of_range` when `height` cannot be represented as a `u32`.
-fn fits_in_u32(height: u64, out_of_range: GetBlockRangeError) -> Result<(), GetBlockRangeError> {
-    u32::try_from(height).map(|_| ()).map_err(|_| out_of_range)
+    endpoint
+        .as_ref()
+        .map(|block_id| block_id.height)
+        .ok_or(missing)
 }
 
 /// The set of pools a request asks to be served.
@@ -180,8 +179,9 @@ impl PoolTypeFilter {
 
     /// create a `PoolTypeFilter` from a vector of raw i32 `PoolType`s
     /// If the vector is empty it will return `Self::default()`.
-    /// If the vector contains `PoolType::Invalid` or the vector contains more
-    /// elements than there are known pools, returns `PoolTypeError::InvalidPoolType`.
+    /// If the vector contains `PoolType::Invalid` returns
+    /// `PoolTypeError::InvalidPoolType`; if it names any pool more than
+    /// once, returns `PoolTypeError::DuplicatePoolType`.
     pub fn new_from_slice(pool_types: &[i32]) -> Result<Self, PoolTypeError> {
         let pool_types = pool_types_from_vector(pool_types)?;
 
@@ -190,23 +190,24 @@ impl PoolTypeFilter {
 
     /// create a `PoolTypeFilter` from a slice of `PoolType`
     /// If the slice is empty it will return `Self::default()`.
-    /// If the slice contains `PoolType::Invalid` or the slice contains more
-    /// elements than there are known pools, returns `PoolTypeError::InvalidPoolType`.
+    /// If the slice contains `PoolType::Invalid`, returns
+    /// `PoolTypeError::InvalidPoolType`; if it names any pool more than
+    /// once, returns `PoolTypeError::DuplicatePoolType`. A valid request
+    /// therefore names at most the four known pools, each exactly once.
     pub fn new_from_pool_types(pool_types: &[PoolType]) -> Result<PoolTypeFilter, PoolTypeError> {
-        if pool_types.len() > KNOWN_POOLS.len() {
-            return Err(PoolTypeError::InvalidPoolType);
-        }
-
         if pool_types.is_empty() {
             return Ok(Self::default());
         }
 
-        let mut included = BTreeSet::new();
-        for &pool_type in pool_types {
-            if pool_type == PoolType::Invalid {
-                return Err(PoolTypeError::InvalidPoolType);
-            }
-            included.insert(pool_type);
+        let included = pool_types
+            .iter()
+            .map(|&pool_type| match pool_type {
+                PoolType::Invalid => Err(PoolTypeError::InvalidPoolType),
+                pool_type => Ok(pool_type),
+            })
+            .collect::<Result<BTreeSet<_>, _>>()?;
+        if included.len() != pool_types.len() {
+            return Err(PoolTypeError::DuplicatePoolType);
         }
         Ok(PoolTypeFilter { included })
     }
@@ -297,45 +298,71 @@ impl CompactTx {
 /// request-decode path ([`PoolTypeFilter::new_from_slice`]) produces it for
 /// an empty `poolTypes` field.
 pub fn prune_compact_block(mut block: CompactBlock, filter: &PoolTypeFilter) -> CompactBlock {
-    for compact_tx in &mut block.vtx {
-        // strip out transparent inputs if not requested
-        if !filter.includes_transparent() {
-            compact_tx.vin.clear();
-            compact_tx.vout.clear();
-        }
-        // strip out sapling if not requested
-        if !filter.includes_sapling() {
-            compact_tx.spends.clear();
-            compact_tx.outputs.clear();
-        }
-        // strip out orchard if not requested
-        if !filter.includes_orchard() {
-            compact_tx.actions.clear();
-        }
-        // strip out ironwood if not requested
-        if !filter.includes_ironwood() {
-            compact_tx.ironwood_actions.clear();
-        }
-    }
-
-    // Omit transactions that have no elements in any requested pool type.
-    block.vtx.retain(CompactTx::has_pool_data);
-
+    block.vtx = block
+        .vtx
+        .into_iter()
+        .map(|compact_tx| prune_compact_tx(compact_tx, filter))
+        .filter(CompactTx::has_pool_data)
+        .collect();
     block
 }
 
-/// Strips the outputs and transparent data from all transactions, retains
-/// only the nullifier from all Orchard and Ironwood actions, and clears the
-/// chain metadata from the block. Sapling spends are kept whole: the spend
-/// itself is the nullifier carrier.
-pub fn compact_block_to_nullifiers(mut block: CompactBlock) -> CompactBlock {
-    for ctransaction in &mut block.vtx {
-        ctransaction.outputs = Vec::new();
-        ctransaction.vin = Vec::new();
-        ctransaction.vout = Vec::new();
-        retain_only_nullifiers(&mut ctransaction.actions);
-        retain_only_nullifiers(&mut ctransaction.ironwood_actions);
+/// Rebuilds one transaction keeping only the data of pools the filter
+/// includes.
+fn prune_compact_tx(compact_tx: CompactTx, filter: &PoolTypeFilter) -> CompactTx {
+    let CompactTx {
+        index,
+        txid,
+        fee,
+        spends,
+        outputs,
+        actions,
+        ironwood_actions,
+        vin,
+        vout,
+    } = compact_tx;
+    CompactTx {
+        index,
+        txid,
+        fee,
+        spends: included_or_empty(filter.includes_sapling(), spends),
+        outputs: included_or_empty(filter.includes_sapling(), outputs),
+        actions: included_or_empty(filter.includes_orchard(), actions),
+        ironwood_actions: included_or_empty(filter.includes_ironwood(), ironwood_actions),
+        vin: included_or_empty(filter.includes_transparent(), vin),
+        vout: included_or_empty(filter.includes_transparent(), vout),
     }
+}
+
+/// `items` when `included`, the empty vector otherwise.
+fn included_or_empty<T>(included: bool, items: Vec<T>) -> Vec<T> {
+    if included {
+        items
+    } else {
+        Vec::new()
+    }
+}
+
+/// Rebuilds the block so each transaction carries only its nullifier
+/// carriers: Sapling spends whole (the spend is its own nullifier record),
+/// Orchard and Ironwood actions reduced to nullifier-only, and every other
+/// field emptied. Chain metadata is zeroed.
+pub fn compact_block_to_nullifiers(mut block: CompactBlock) -> CompactBlock {
+    block.vtx = block
+        .vtx
+        .into_iter()
+        .map(|compact_tx| CompactTx {
+            index: compact_tx.index,
+            txid: compact_tx.txid,
+            fee: compact_tx.fee,
+            spends: compact_tx.spends,
+            outputs: Vec::new(),
+            actions: nullifiers_only(compact_tx.actions),
+            ironwood_actions: nullifiers_only(compact_tx.ironwood_actions),
+            vin: Vec::new(),
+            vout: Vec::new(),
+        })
+        .collect();
 
     block.chain_metadata = Some(ChainMetadata {
         sapling_commitment_tree_size: 0,
@@ -346,13 +373,14 @@ pub fn compact_block_to_nullifiers(mut block: CompactBlock) -> CompactBlock {
 }
 
 /// Reduces each action to one carrying only its nullifier.
-fn retain_only_nullifiers(actions: &mut [CompactOrchardAction]) {
-    for action in actions {
-        *action = CompactOrchardAction {
-            nullifier: std::mem::take(&mut action.nullifier),
+fn nullifiers_only(actions: Vec<CompactOrchardAction>) -> Vec<CompactOrchardAction> {
+    actions
+        .into_iter()
+        .map(|action| CompactOrchardAction {
+            nullifier: action.nullifier,
             ..Default::default()
-        }
-    }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -379,7 +407,7 @@ mod test {
     }
 
     #[test]
-    fn test_pool_type_filter_fails_when_too_many_items() {
+    fn test_pool_type_filter_fails_when_duplicated() {
         let pools = [
             PoolType::Transparent,
             PoolType::Sapling,
@@ -391,7 +419,15 @@ mod test {
 
         assert_eq!(
             PoolTypeFilter::new_from_pool_types(&pools),
-            Err(PoolTypeError::InvalidPoolType)
+            Err(PoolTypeError::DuplicatePoolType)
+        );
+    }
+
+    #[test]
+    fn test_pool_type_filter_fails_on_minimal_duplicate() {
+        assert_eq!(
+            PoolTypeFilter::new_from_pool_types(&[PoolType::Orchard, PoolType::Orchard]),
+            Err(PoolTypeError::DuplicatePoolType)
         );
     }
 

--- a/packages/zaino-serve/CHANGELOG.md
+++ b/packages/zaino-serve/CHANGELOG.md
@@ -9,11 +9,35 @@ and this library adheres to Rust's notion of
 
 ### Added
 ### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.5.1] - 2026-08-04
+
+### Changed
+- Internal DRY refactor with no public API or behavior change: JSON-RPC
+  error-object construction is deduplicated, and the error-source walk is
+  expressed as an `unfold`.
+### Deprecated
+### Removed
+### Fixed
+
+## [0.5.0] - 2026-07-13
+
+### Added
+### Changed
 - tonic's TLS provider feature switches from `tls-ring` to `tls-aws-lc`,
   following the workspace's aws-lc-rs preferred CryptoProvider (ADR-0006).
 ### Deprecated
 ### Removed
 ### Fixed
+
+## [0.4.0] - 2026-07-02
+
+### Changed
+- Version-alignment bump for the 0.5.0 workspace release; no changes to this
+  crate's own public API or behavior.
 
 ## [0.3.0] - 2026-06-17
 

--- a/packages/zaino-serve/Cargo.toml
+++ b/packages/zaino-serve/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.5.0"
+version = "0.5.1"
 
 [features]
 default = []

--- a/packages/zaino-serve/src/rpc/jsonrpc/service.rs
+++ b/packages/zaino-serve/src/rpc/jsonrpc/service.rs
@@ -514,21 +514,18 @@ fn error_object_from_source_chain<Error>(
 where
     Error: std::error::Error + 'static,
 {
-    let mut current_error: Option<&(dyn std::error::Error + 'static)> = Some(&error);
-
-    while let Some(error_source) = current_error {
-        if let Some(error_object) = map(error_source) {
-            return error_object;
-        }
-
-        current_error = error_source.source();
-    }
-
-    ErrorObjectOwned::owned(
-        ErrorCode::InternalError.code(),
-        "Internal server error",
-        Some(error.to_string()),
+    std::iter::successors(
+        Some(&error as &(dyn std::error::Error + 'static)),
+        |error_source| error_source.source(),
     )
+    .find_map(map)
+    .unwrap_or_else(|| {
+        ErrorObjectOwned::owned(
+            ErrorCode::InternalError.code(),
+            "Internal server error",
+            Some(error.to_string()),
+        )
+    })
 }
 
 fn getblock_error_object_from_indexer_error<Error>(error: Error) -> ErrorObjectOwned

--- a/packages/zaino-serve/src/rpc/jsonrpc/service.rs
+++ b/packages/zaino-serve/src/rpc/jsonrpc/service.rs
@@ -476,6 +476,17 @@ pub trait ZcashIndexerRpc {
     ) -> Result<GetNetworkSolPsResponse, ErrorObjectOwned>;
 }
 
+/// Maps an indexer error to the JSON-RPC error object every plain-delegation
+/// method returns: `InvalidParams` (converted to the zcash legacy "misc" code
+/// in RPC middleware) carrying the error's message as data.
+fn invalid_params_error_object(error: impl std::fmt::Display) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(
+        ErrorCode::InvalidParams.code(),
+        "Internal server error",
+        Some(error.to_string()),
+    )
+}
+
 // Currently all errors are hidden from downstream client, a full fix should be implemented. this is a temporary fix to
 // get zaino working, propagating a 500 error code to "block not found". This is still not the full correct behaviour
 // but fixes the current bugs in zaino and gets tests running.
@@ -491,25 +502,23 @@ fn error_object_from_rpc_error(
     ErrorObjectOwned::owned(rpc_error.code as i32, rpc_error.message.clone(), None::<()>)
 }
 
-fn getblock_error_object_from_indexer_error<Error>(error: Error) -> ErrorObjectOwned
+/// Walks `error`'s `source` chain and returns the first error object `map`
+/// produces, falling back to a generic internal-server-error object carrying
+/// the original error's message. The shared skeleton of the per-method error
+/// translators below, which differ only in the mapping they apply to each
+/// source.
+fn error_object_from_source_chain<Error>(
+    error: Error,
+    map: impl Fn(&(dyn std::error::Error + 'static)) -> Option<ErrorObjectOwned>,
+) -> ErrorObjectOwned
 where
     Error: std::error::Error + 'static,
 {
     let mut current_error: Option<&(dyn std::error::Error + 'static)> = Some(&error);
 
     while let Some(error_source) = current_error {
-        if let Some(zaino_fetch::jsonrpsee::error::TransportError::ErrorStatusCode(500)) =
-            error_source.downcast_ref::<zaino_fetch::jsonrpsee::error::TransportError>()
-        {
-            return ErrorObjectOwned::owned(
-                zaino_fetch::jsonrpsee::connector::RpcError::new_from_legacycode(
-                    zebra_rpc::server::error::LegacyCode::InvalidParameter,
-                    "block not found",
-                )
-                .code as i32,
-                "block not found",
-                None::<()>,
-            );
+        if let Some(error_object) = map(error_source) {
+            return error_object;
         }
 
         current_error = error_source.source();
@@ -522,25 +531,36 @@ where
     )
 }
 
+fn getblock_error_object_from_indexer_error<Error>(error: Error) -> ErrorObjectOwned
+where
+    Error: std::error::Error + 'static,
+{
+    error_object_from_source_chain(error, |error_source| {
+        if let Some(zaino_fetch::jsonrpsee::error::TransportError::ErrorStatusCode(500)) =
+            error_source.downcast_ref::<zaino_fetch::jsonrpsee::error::TransportError>()
+        {
+            Some(ErrorObjectOwned::owned(
+                zaino_fetch::jsonrpsee::connector::RpcError::new_from_legacycode(
+                    zebra_rpc::server::error::LegacyCode::InvalidParameter,
+                    "block not found",
+                )
+                .code as i32,
+                "block not found",
+                None::<()>,
+            ))
+        } else {
+            None
+        }
+    })
+}
+
 fn sendrawtransaction_error_object_from_indexer_error<Error>(error: Error) -> ErrorObjectOwned
 where
     Error: std::error::Error + 'static,
 {
-    let mut current_error: Option<&(dyn std::error::Error + 'static)> = Some(&error);
-
-    while let Some(error_source) = current_error {
-        if let Some(rpc_error) = rpc_error_from_error_source(error_source) {
-            return error_object_from_rpc_error(rpc_error);
-        }
-
-        current_error = error_source.source();
-    }
-
-    ErrorObjectOwned::owned(
-        ErrorCode::InternalError.code(),
-        "Internal server error",
-        Some(error.to_string()),
-    )
+    error_object_from_source_chain(error, |error_source| {
+        rpc_error_from_error_source(error_source).map(error_object_from_rpc_error)
+    })
 }
 
 /// Uses ErrorCode::InvalidParams as this is converted to zcash legacy "minsc" ErrorCode in RPC middleware.
@@ -551,28 +571,15 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_info()
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_mining_info(&self) -> Result<GetMiningInfoWire, ErrorObjectOwned> {
-        Ok(self
-            .service_subscriber
+        self.service_subscriber
             .inner_ref()
             .get_mining_info()
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })?)
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_tx_out_set_info(&self) -> Result<GetTxOutSetInfoResponse, ErrorObjectOwned> {
@@ -580,13 +587,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_tx_out_set_info()
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_best_blockhash(&self) -> Result<GetBlockHash, ErrorObjectOwned> {
@@ -594,13 +595,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_best_blockhash()
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_blockchain_info(&self) -> Result<GetBlockchainInfoResponse, ErrorObjectOwned> {
@@ -608,13 +603,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_blockchain_info()
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_mempool_info(&self) -> Result<GetMempoolInfoResponse, ErrorObjectOwned> {
@@ -622,13 +611,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_mempool_info()
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_difficulty(&self) -> Result<f64, ErrorObjectOwned> {
@@ -636,13 +619,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_difficulty()
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_block_deltas(&self, hash: String) -> Result<BlockDeltas, ErrorObjectOwned> {
@@ -650,13 +627,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_block_deltas(hash)
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_peer_info(&self) -> Result<GetPeerInfo, ErrorObjectOwned> {
@@ -664,13 +635,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_peer_info()
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_block_subsidy(&self, height: u32) -> Result<GetBlockSubsidy, ErrorObjectOwned> {
@@ -678,13 +643,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_block_subsidy(height)
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_block_count(&self) -> Result<Height, ErrorObjectOwned> {
@@ -692,13 +651,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_block_count()
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_chain_tips(&self) -> Result<GetChainTipsResponse, ErrorObjectOwned> {
@@ -706,13 +659,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_chain_tips()
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn validate_address(
@@ -723,13 +670,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .validate_address(address)
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     #[allow(deprecated)]
@@ -742,13 +683,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .z_validate_address(address)
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn z_get_address_balance(
@@ -759,13 +694,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .z_get_address_balance(address_strings)
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn send_raw_transaction(
@@ -800,13 +729,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_block_header(hash, verbose)
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_raw_mempool(&self) -> Result<Vec<String>, ErrorObjectOwned> {
@@ -814,13 +737,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_raw_mempool()
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn z_get_treestate(
@@ -831,13 +748,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .z_get_treestate(hash_or_height)
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn z_get_subtrees_by_index(
@@ -850,13 +761,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .z_get_subtrees_by_index(pool, start_index, limit)
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_raw_transaction(
@@ -868,13 +773,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_raw_transaction(txid_hex, verbose)
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_tx_out(
@@ -887,13 +786,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_tx_out(txid, n, include_mempool)
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_spent_info(
@@ -904,13 +797,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_spent_info(request)
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn get_address_tx_ids(
@@ -921,13 +808,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_address_tx_ids(request)
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
     async fn z_get_address_utxos(
@@ -938,28 +819,9 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .z_get_address_utxos(address_strings)
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 
-    /// Returns the estimated network solutions per second based on the last n blocks.
-    ///
-    /// zcashd reference: [`getnetworksolps`](https://zcash.github.io/rpc/getnetworksolps.html)
-    /// method: post
-    /// tags: blockchain
-    ///
-    /// This RPC is implemented in the [mining.cpp](https://github.com/zcash/zcash/blob/d00fc6f4365048339c83f463874e4d6c240b63af/src/rpc/mining.cpp#L104)
-    /// file of the Zcash repository. The Zebra implementation can be found [here](https://github.com/ZcashFoundation/zebra/blob/19bca3f1159f9cb9344c9944f7e1cb8d6a82a07f/zebra-rpc/src/methods.rs#L2687).
-    ///
-    /// # Parameters
-    ///
-    /// - `blocks`: (number, optional, default=120) Number of blocks, or -1 for blocks over difficulty averaging window.
-    /// - `height`: (number, optional, default=-1) To estimate network speed at the time of a specific block height.
     async fn get_network_sol_ps(
         &self,
         blocks: Option<i32>,
@@ -969,12 +831,6 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .get_network_sol_ps(blocks, height)
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(invalid_params_error_object)
     }
 }

--- a/packages/zaino-state/CHANGELOG.md
+++ b/packages/zaino-state/CHANGELOG.md
@@ -8,9 +8,46 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.6.0] - 2026-08-04
+
+### Added
+### Changed
+- The six public stream types (`RawTransactionStream`,
+  `CompactTransactionStream`, `CompactBlockStream`, `UtxoReplyStream`,
+  `SubtreeRootReplyStream`, `AddressStream`) are collapsed to
+  `pub type X = ChannelStream<T>` aliases. Their names, constructors, and
+  `Stream` impls are preserved, so this is **not** a breaking change for
+  typical use.
+- Adopted the DRY'd `zaino-proto` proto utilities.
+- Internal refactor of the error and indexer plumbing.
+### Deprecated
+### Removed
+- **Breaking** — the public constructors `BlockData::new` and
+  `BlockMetadata::new` (construct these types via struct literals instead).
+- **Breaking** — `impl ZainoVersionedSerde for IndexedBlock` and
+  `impl ZainoVersionedSerde for CompactTxData` (the never-adopted
+  wholesale-block serde path).
+### Fixed
+
+## [0.5.0] - 2026-07-13
+
+### Added
 - The chain index tracks Ironwood (NU6.3) note-commitment treestate roots,
   storing `None` while the pool has no treestate rather than fabricating a
   root.
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.4.0] - 2026-07-02
+
+### Added
 - `ChainIndex` / `NodeBackedChainIndexSubscriber` gain `get_outpoint_spenders` —
   for each transparent `Outpoint`, returns the txid that spent it on the best
   chain (index-aligned with the input, `None` if unspent or unknown).

--- a/packages/zaino-state/Cargo.toml
+++ b/packages/zaino-state/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.5.0"
+version = "0.6.0"
 
 [features]
 default = []

--- a/packages/zaino-state/src/broadcast.rs
+++ b/packages/zaino-state/src/broadcast.rs
@@ -153,19 +153,29 @@ impl<K: Eq + Hash + Clone, V: Clone> Default for Broadcast<K, V> {
     }
 }
 
+/// Formats either side of the broadcast pair: the shared dashmap contents plus a
+/// placeholder naming the watch-channel endpoint (the channel itself is not `Debug`-useful).
+fn fmt_broadcast_state<K: Eq + Hash + Clone + std::fmt::Debug, V: Clone + std::fmt::Debug>(
+    struct_name: &str,
+    state: &DashMap<K, V>,
+    notifier_placeholder: &str,
+    f: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
+    let state_contents: Vec<_> = state
+        .iter()
+        .map(|entry| (entry.key().clone(), entry.value().clone()))
+        .collect();
+    f.debug_struct(struct_name)
+        .field("state", &state_contents)
+        .field("notifier", &notifier_placeholder)
+        .finish()
+}
+
 impl<K: Eq + Hash + Clone + std::fmt::Debug, V: Clone + std::fmt::Debug> std::fmt::Debug
     for Broadcast<K, V>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let state_contents: Vec<_> = self
-            .state
-            .iter()
-            .map(|entry| (entry.key().clone(), entry.value().clone()))
-            .collect();
-        f.debug_struct("Broadcast")
-            .field("state", &state_contents)
-            .field("notifier", &"watch::Sender<StatusType>")
-            .finish()
+        fmt_broadcast_state("Broadcast", &self.state, "watch::Sender<StatusType>", f)
     }
 }
 
@@ -236,14 +246,11 @@ impl<K: Eq + Hash + Clone + std::fmt::Debug, V: Clone + std::fmt::Debug> std::fm
     for BroadcastSubscriber<K, V>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let state_contents: Vec<_> = self
-            .state
-            .iter()
-            .map(|entry| (entry.key().clone(), entry.value().clone()))
-            .collect();
-        f.debug_struct("Broadcast")
-            .field("state", &state_contents)
-            .field("notifier", &"watch::Sender<StatusType>")
-            .finish()
+        fmt_broadcast_state(
+            "BroadcastSubscriber",
+            &self.state,
+            "watch::Receiver<StatusType>",
+            f,
+        )
     }
 }

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -1282,22 +1282,22 @@ async fn compact_block_from_source<Source: BlockchainSource>(
     let (sapling_root, sapling_size, orchard_root, orchard_size, ironwood) =
         TreeRootData::new(tree_roots.0, tree_roots.1, tree_roots.2).extract_with_defaults();
 
-    let metadata = BlockMetadata::new(
+    let metadata = BlockMetadata {
         sapling_root,
-        sapling_size.try_into().map_err(|_| {
+        sapling_size: sapling_size.try_into().map_err(|_| {
             ChainIndexError::backing_validator(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "sapling commitment tree size overflow",
             ))
         })?,
         orchard_root,
-        orchard_size.try_into().map_err(|_| {
+        orchard_size: orchard_size.try_into().map_err(|_| {
             ChainIndexError::backing_validator(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "orchard commitment tree size overflow",
             ))
         })?,
-        ironwood
+        ironwood: ironwood
             .map(|(root, size)| {
                 Ok::<_, ChainIndexError>((
                     root,
@@ -1310,9 +1310,10 @@ async fn compact_block_from_source<Source: BlockchainSource>(
                 ))
             })
             .transpose()?,
-        None, // parent chainwork unknown — single-block construction
+        // parent chainwork unknown — single-block construction
+        parent_chainwork: None,
         network,
-    );
+    };
     let indexed_block =
         IndexedBlock::try_from(BlockWithMetadata::new(&block, metadata)).map_err(|error| {
             ChainIndexError::backing_validator(std::io::Error::new(

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -49,7 +49,7 @@ use zaino_fetch::jsonrpsee::response::{
     EmptyTxOutSetInfo, GetNetworkSolPsResponse, GetSpentInfoRequest, GetSpentInfoResponse,
     GetTxOutResponse, GetTxOutSetInfo, GetTxOutSetInfoResponse,
 };
-use zaino_proto::proto::utils::{compact_block_with_pool_types, PoolTypeFilter};
+use zaino_proto::proto::utils::{prune_compact_block, PoolTypeFilter};
 use zebra_chain::parameters::ConsensusBranchId;
 pub use zebra_chain::parameters::Network as ZebraNetwork;
 use zebra_chain::serialization::ZcashSerialize;
@@ -1321,9 +1321,9 @@ async fn compact_block_from_source<Source: BlockchainSource>(
             ))
         })?;
 
-    Ok(Some(compact_block_with_pool_types(
+    Ok(Some(prune_compact_block(
         indexed_block.to_compact_block(),
-        &pool_types.to_pool_types_vector(),
+        pool_types,
     )))
 }
 
@@ -2489,10 +2489,7 @@ impl<Source: BlockchainSource> ChainIndexRpcExt for NodeBackedChainIndexSubscrib
             } => {
                 if height <= non_finalized_snapshot.best_tip.height {
                     Ok(Some(match snapshot.get_chainblock_by_height(&height) {
-                        Some(block) => compact_block_with_pool_types(
-                            block.to_compact_block(),
-                            &pool_types.to_pool_types_vector(),
-                        ),
+                        Some(block) => prune_compact_block(block.to_compact_block(), &pool_types),
                         None => {
                             match self
                                 .finalized_state
@@ -2561,8 +2558,6 @@ impl<Source: BlockchainSource> ChainIndexRpcExt for NodeBackedChainIndexSubscrib
         if !is_ascending && start_height > chain_tip_height {
             return Ok(None);
         }
-
-        let pool_types_vector = pool_types.to_pool_types_vector();
 
         // For ascending requests that extend past the tip: cap the streaming range at the tip,
         // then append a trailing out_of_range error after all valid blocks have been sent.
@@ -2677,10 +2672,8 @@ impl<Source: BlockchainSource> ChainIndexRpcExt for NodeBackedChainIndexSubscrib
                             }
                         }
                     };
-                    let compact_block = compact_block_with_pool_types(
-                        indexed_block.to_compact_block(),
-                        &pool_types_vector,
-                    );
+                    let compact_block =
+                        prune_compact_block(indexed_block.to_compact_block(), &pool_types);
                     if channel_sender.send(Ok(compact_block)).await.is_err() {
                         return;
                     }
@@ -2734,10 +2727,8 @@ impl<Source: BlockchainSource> ChainIndexRpcExt for NodeBackedChainIndexSubscrib
                                 }
                             }
                         };
-                        let compact_block = compact_block_with_pool_types(
-                            indexed_block.to_compact_block(),
-                            &pool_types_vector,
-                        );
+                        let compact_block =
+                            prune_compact_block(indexed_block.to_compact_block(), &pool_types);
                         if channel_sender.send(Ok(compact_block)).await.is_err() {
                             return;
                         }

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -332,7 +332,7 @@ pub(crate) async fn build_indexed_block_from_source<S: BlockchainSource>(
         || format!("block {block_hash}"),
     )?;
 
-    let metadata = BlockMetadata::new(
+    let metadata = BlockMetadata {
         sapling_root,
         sapling_size,
         orchard_root,
@@ -340,7 +340,7 @@ pub(crate) async fn build_indexed_block_from_source<S: BlockchainSource>(
         ironwood,
         parent_chainwork,
         network,
-    );
+    };
 
     let block_with_metadata = BlockWithMetadata::new(block.as_ref(), metadata);
     IndexedBlock::try_from(block_with_metadata).map_err(|_| {
@@ -1185,15 +1185,15 @@ impl<T: BlockchainSource> FinalisedState<T> {
                 || format!("block {block_hash}"),
             )?;
 
-            let metadata = BlockMetadata::new(
+            let metadata = BlockMetadata {
                 sapling_root,
                 sapling_size,
                 orchard_root,
                 orchard_size,
                 ironwood,
                 parent_chainwork,
-                cfg.network.clone(),
-            );
+                network: cfg.network.clone(),
+            };
             let block_with_metadata = BlockWithMetadata::new(block.as_ref(), metadata);
             let chain_block = IndexedBlock::try_from(block_with_metadata).map_err(|_| {
                 FinalisedStateError::BlockchainSourceError(BlockchainSourceError::Unrecoverable(

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/ephemeral.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/ephemeral.rs
@@ -301,15 +301,16 @@ impl<T: BlockchainSource> EphemeralFinalisedState<T> {
                 format!("block at height {height}")
             })?;
 
-        let block_metadata = BlockMetadata::new(
+        let block_metadata = BlockMetadata {
             sapling_root,
             sapling_size,
             orchard_root,
             orchard_size,
             ironwood,
-            None, // ephemeral store does not track chainwork
-            self.network.clone(),
-        );
+            // ephemeral store does not track chainwork
+            parent_chainwork: None,
+            network: self.network.clone(),
+        };
         let block_with_metadata = BlockWithMetadata::new(block.as_ref(), block_metadata);
         let indexed_block = IndexedBlock::try_from(block_with_metadata).map_err(|error| {
             FinalisedStateError::BlockchainSourceError(BlockchainSourceError::Unrecoverable(

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/ephemeral.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/ephemeral.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 use crate::{BlockMetadata, BlockWithMetadata, NamedAtomicStatus};
 
-use zaino_proto::proto::utils::{compact_block_with_pool_types, PoolTypeFilter};
+use zaino_proto::proto::utils::{prune_compact_block, PoolTypeFilter};
 
 const EPHEMERAL_FINALISED_STATE_STATUS_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -756,9 +756,9 @@ impl<T: BlockchainSource> CompactBlockExt for EphemeralFinalisedState<T> {
         pool_types: PoolTypeFilter,
     ) -> Result<zaino_proto::proto::compact_formats::CompactBlock, FinalisedStateError> {
         let chain_block = self.get_required_chain_block(height).await?;
-        Ok(compact_block_with_pool_types(
+        Ok(prune_compact_block(
             chain_block.to_compact_block(),
-            &pool_types.to_pool_types_vector(),
+            &pool_types,
         ))
     }
 

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/compact_block.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/compact_block.rs
@@ -233,17 +233,7 @@ impl DbV1 {
                     // TODO: Re-evaluate whether omitting "empty-for-filter" transactions is the desired API behaviour.
                     //       Some clients may expect a position-preserving representation (one entry per txid), even if
                     //       the per-pool fields are empty for a given filter.
-                    if spends.is_empty()
-                        && outputs.is_empty()
-                        && actions.is_empty()
-                        && ironwood_actions.is_empty()
-                        && vin.is_empty()
-                        && vout.is_empty()
-                    {
-                        return None;
-                    }
-
-                    Some(zaino_proto::proto::compact_formats::CompactTx {
+                    let compact_tx = zaino_proto::proto::compact_formats::CompactTx {
                         index: i as u64,
                         txid: txid.0.to_vec(),
                         fee: 0,
@@ -253,7 +243,8 @@ impl DbV1 {
                         ironwood_actions,
                         vin,
                         vout,
-                    })
+                    };
+                    compact_tx.has_pool_data().then_some(compact_tx)
                 })
                 .collect();
 
@@ -1154,17 +1145,7 @@ impl DbV1 {
                         // `CompactTx.index` rather than assuming contiguous ordering.
                         //
                         // TODO: Re-evaluate whether omission is the desired API behaviour for all consumers.
-                        if spends.is_empty()
-                            && outputs.is_empty()
-                            && actions.is_empty()
-                            && ironwood_actions.is_empty()
-                            && vin.is_empty()
-                            && vout.is_empty()
-                        {
-                            continue;
-                        }
-
-                        vtx.push(zaino_proto::proto::compact_formats::CompactTx {
+                        let compact_tx = zaino_proto::proto::compact_formats::CompactTx {
                             index: i as u64,
                             txid: txid.0.to_vec(),
                             fee: 0,
@@ -1174,7 +1155,12 @@ impl DbV1 {
                             ironwood_actions,
                             vin,
                             vout,
-                        });
+                        };
+                        if !compact_tx.has_pool_data() {
+                            continue;
+                        }
+
+                        vtx.push(compact_tx);
                     }
 
                     // ----- Decode commitment tree data and construct block -----

--- a/packages/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/non_finalised_state.rs
@@ -838,15 +838,15 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
         let (sapling_root, sapling_size, orchard_root, orchard_size, ironwood) =
             tree_roots.clone().extract_with_defaults();
 
-        let metadata = BlockMetadata::new(
+        let metadata = BlockMetadata {
             sapling_root,
-            sapling_size as u32,
+            sapling_size: sapling_size as u32,
             orchard_root,
-            orchard_size as u32,
-            ironwood.map(|(root, size)| (root, size as u32)),
+            orchard_size: orchard_size as u32,
+            ironwood: ironwood.map(|(root, size)| (root, size as u32)),
             parent_chainwork,
             network,
-        );
+        };
 
         let block_with_metadata = BlockWithMetadata::new(block, metadata);
         IndexedBlock::try_from(block_with_metadata)

--- a/packages/zaino-state/src/chain_index/source/mockchain_source.rs
+++ b/packages/zaino-state/src/chain_index/source/mockchain_source.rs
@@ -2,7 +2,7 @@
 
 use super::validator_connector::{
     assemble_block_deltas, build_block_header_object, build_verbose_block,
-    confirmations_from_depth, final_orchard_root, final_sapling_root, median_of_block_times,
+    confirmations_from_depth, final_orchard_root, final_sapling_root, median_time_past_via,
     zebra_block_header_to_wire,
 };
 use super::*;
@@ -415,34 +415,10 @@ impl MockchainSource {
     /// Median time past over the 11-block window ending at `start`, walking backwards via
     /// verbosity-1 `getblock` lookups against the mock vectors.
     async fn median_time_past(&self, start: &BlockObject) -> BlockchainSourceResult<i64> {
-        const MEDIAN_TIME_PAST_WINDOW: usize = 11;
-        let mut times = Vec::with_capacity(MEDIAN_TIME_PAST_WINDOW);
-        let start_time = start.time().ok_or_else(|| {
-            BlockchainSourceError::Unrecoverable("getblockdeltas: start block missing time".into())
-        })?;
-        times.push(start_time);
-
-        let mut prev = start.previous_block_hash();
-        for _ in 0..(MEDIAN_TIME_PAST_WINDOW - 1) {
-            let Some(hash) = prev else {
-                break; // genesis
-            };
-            match self
-                .get_block_verbose(HashOrHeight::Hash(hash), Some(1))
-                .await
-            {
-                Ok(GetBlock::Object(object)) => {
-                    if let Some(time) = object.time() {
-                        times.push(time);
-                    }
-                    prev = object.previous_block_hash();
-                }
-                Ok(GetBlock::Raw(_)) => break,
-                Err(_) => break,
-            }
-        }
-
-        median_of_block_times(times)
+        median_time_past_via(start, |hash| {
+            self.get_block_verbose(HashOrHeight::Hash(hash), Some(1))
+        })
+        .await
     }
 
     fn block_height_at_index(&self, block_index: usize) -> Height {

--- a/packages/zaino-state/src/chain_index/source/validator_connector.rs
+++ b/packages/zaino-state/src/chain_index/source/validator_connector.rs
@@ -2044,37 +2044,11 @@ impl State {
 
     /// Median time past over the 11-block window ending at `start`, walking backwards via
     /// verbosity-1 `getblock` lookups against the `ReadStateService`.
-    // TODO(DRY): MockchainSource duplicates this walk; the only difference is the
-    // per-block fetch. A shared helper generic over an async block fetcher would unify them.
     async fn median_time_past(&self, start: &BlockObject) -> BlockchainSourceResult<i64> {
-        const MEDIAN_TIME_PAST_WINDOW: usize = 11;
-        let mut times = Vec::with_capacity(MEDIAN_TIME_PAST_WINDOW);
-        let start_time = start.time().ok_or_else(|| {
-            BlockchainSourceError::Unrecoverable("getblockdeltas: start block missing time".into())
-        })?;
-        times.push(start_time);
-
-        let mut prev = start.previous_block_hash();
-        for _ in 0..(MEDIAN_TIME_PAST_WINDOW - 1) {
-            let Some(hash) = prev else {
-                break; // genesis
-            };
-            match self
-                .get_block_inner(HashOrHeight::Hash(hash), Some(1))
-                .await
-            {
-                Ok(GetBlock::Object(object)) => {
-                    if let Some(time) = object.time() {
-                        times.push(time);
-                    }
-                    prev = object.previous_block_hash();
-                }
-                Ok(GetBlock::Raw(_)) => break,
-                Err(_) => break, // use values collected so far
-            }
-        }
-
-        median_of_block_times(times)
+        median_time_past_via(start, |hash| {
+            self.get_block_inner(HashOrHeight::Hash(hash), Some(1))
+        })
+        .await
     }
 
     /// Builds the `getblockchaininfo` response from the `ReadStateService`.
@@ -2386,6 +2360,46 @@ pub(crate) fn zebra_block_header_to_wire(
 ) -> BlockchainSourceResult<GetBlockHeader> {
     let value = serde_json::to_value(&header).map_err(BlockchainSourceError::unrecoverable)?;
     serde_json::from_value(value).map_err(BlockchainSourceError::unrecoverable)
+}
+
+/// Median time past over the 11-block window ending at `start`, walking parent hashes
+/// backwards via `fetch_prev` (a verbosity-1 `getblock` lookup against the caller's source).
+///
+/// The walk tolerates short histories: it stops at genesis, at a raw (non-verbose)
+/// response, or on a fetch error, and takes the median of the times collected so far.
+pub(crate) async fn median_time_past_via<Fetch, Fut, FetchError>(
+    start: &BlockObject,
+    fetch_prev: Fetch,
+) -> BlockchainSourceResult<i64>
+where
+    Fetch: Fn(zebra_chain::block::Hash) -> Fut,
+    Fut: std::future::Future<Output = Result<GetBlock, FetchError>>,
+{
+    const MEDIAN_TIME_PAST_WINDOW: usize = 11;
+    let mut times = Vec::with_capacity(MEDIAN_TIME_PAST_WINDOW);
+    let start_time = start.time().ok_or_else(|| {
+        BlockchainSourceError::Unrecoverable("getblockdeltas: start block missing time".into())
+    })?;
+    times.push(start_time);
+
+    let mut prev = start.previous_block_hash();
+    for _ in 0..(MEDIAN_TIME_PAST_WINDOW - 1) {
+        let Some(hash) = prev else {
+            break; // genesis
+        };
+        match fetch_prev(hash).await {
+            Ok(GetBlock::Object(object)) => {
+                if let Some(time) = object.time() {
+                    times.push(time);
+                }
+                prev = object.previous_block_hash();
+            }
+            Ok(GetBlock::Raw(_)) => break,
+            Err(_) => break, // use values collected so far
+        }
+    }
+
+    median_of_block_times(times)
 }
 
 /// Returns the median of a non-empty set of block times.

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/ephemeral.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/ephemeral.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use tempfile::TempDir;
 use zaino_common::network::ActivationHeights;
 use zaino_common::{DatabaseConfig, StorageConfig};
-use zaino_proto::proto::utils::{compact_block_with_pool_types, PoolTypeFilter};
+use zaino_proto::proto::utils::{prune_compact_block, PoolTypeFilter};
 
 use crate::chain_index::finalised_state::FinalisedState;
 use crate::chain_index::source::mockchain_source::MockchainSource;
@@ -138,20 +138,15 @@ async fn reader_compact_blocks_match_source() {
             .get_compact_block(height, PoolTypeFilter::default())
             .await
             .unwrap();
-        let expected_default = compact_block_with_pool_types(
-            compact_block.clone(),
-            &PoolTypeFilter::default().to_pool_types_vector(),
-        );
+        let expected_default =
+            prune_compact_block(compact_block.clone(), &PoolTypeFilter::default());
         assert_eq!(expected_default, reader_default);
 
         let reader_all = reader
             .get_compact_block(height, PoolTypeFilter::includes_all())
             .await
             .unwrap();
-        let expected_all = compact_block_with_pool_types(
-            compact_block,
-            &PoolTypeFilter::includes_all().to_pool_types_vector(),
-        );
+        let expected_all = prune_compact_block(compact_block, &PoolTypeFilter::includes_all());
         assert_eq!(expected_all, reader_all);
     }
 }

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use tempfile::TempDir;
 use zaino_common::network::ActivationHeights;
 use zaino_common::{DatabaseConfig, StorageConfig};
-use zaino_proto::proto::utils::{compact_block_with_pool_types, PoolTypeFilter};
+use zaino_proto::proto::utils::{prune_compact_block, PoolTypeFilter};
 
 use crate::chain_index::finalised_state::finalised_source::FinalisedSource;
 use crate::chain_index::finalised_state::reader::DbReader;
@@ -427,20 +427,16 @@ async fn get_compact_blocks() {
             .get_compact_block(height, PoolTypeFilter::default())
             .await
             .unwrap();
-        let default_compact_block = compact_block_with_pool_types(
-            compact_block.clone(),
-            &PoolTypeFilter::default().to_pool_types_vector(),
-        );
+        let default_compact_block =
+            prune_compact_block(compact_block.clone(), &PoolTypeFilter::default());
         assert_eq!(default_compact_block, reader_compact_block_default);
 
         let reader_compact_block_all_data = db_reader
             .get_compact_block(height, PoolTypeFilter::includes_all())
             .await
             .unwrap();
-        let all_data_compact_block = compact_block_with_pool_types(
-            compact_block,
-            &PoolTypeFilter::includes_all().to_pool_types_vector(),
-        );
+        let all_data_compact_block =
+            prune_compact_block(compact_block, &PoolTypeFilter::includes_all());
         assert_eq!(all_data_compact_block, reader_compact_block_all_data);
 
         println!("CompactBlock at height {} OK", height.0);

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -331,15 +331,16 @@ async fn try_write_invalid_block() {
         ..
     } = blocks.last().unwrap().clone();
 
-    let metadata = BlockMetadata::new(
+    let metadata = BlockMetadata {
         sapling_root,
-        sapling_tree_size as u32,
+        sapling_size: sapling_tree_size as u32,
         orchard_root,
-        orchard_tree_size as u32,
-        None,
-        None, // no parent chainwork for this test
-        ActivationHeights::default().to_regtest_network(),
-    );
+        orchard_size: orchard_tree_size as u32,
+        ironwood: None,
+        // no parent chainwork for this test
+        parent_chainwork: None,
+        network: ActivationHeights::default().to_regtest_network(),
+    };
 
     let mut chain_block =
         IndexedBlock::try_from(BlockWithMetadata::new(&zebra_block, metadata)).unwrap();

--- a/packages/zaino-state/src/chain_index/tests/types.rs
+++ b/packages/zaino-state/src/chain_index/tests/types.rs
@@ -27,7 +27,15 @@ pub(crate) fn canonical_blockheaderdata() -> BlockHeaderData {
     let bits = CompactDifficulty::try_from_bits(TEST_VALID_NBITS).expect("valid nBits");
 
     let bctx = BlockContext::new(hash, parent_hash, chainwork, height);
-    let bdata = BlockData::new(1, 2, [3u8; 32], [4u8; 32], bits, [5u8; 32], solution);
+    let bdata = BlockData {
+        version: 1,
+        time: 2,
+        merkle_root: [3u8; 32],
+        block_commitments: [4u8; 32],
+        bits,
+        nonce: [5u8; 32],
+        solution,
+    };
     BlockHeaderData::new(bctx, bdata)
 }
 

--- a/packages/zaino-state/src/chain_index/tests/vectors.rs
+++ b/packages/zaino-state/src/chain_index/tests/vectors.rs
@@ -92,14 +92,14 @@ pub(crate) fn indexed_block_chain(
 ) -> impl Iterator<Item = IndexedBlock> + '_ {
     let mut parent_chain_work: Option<ChainWork> = None;
     blocks.iter().map(move |vector| {
-        let metadata = BlockMetadata::new(
-            vector.sapling_root,
-            vector.sapling_tree_size as u32,
-            vector.orchard_root,
-            vector.orchard_tree_size as u32,
-            None,
-            parent_chain_work,
-            zebra_chain::parameters::Network::new_regtest(
+        let metadata = BlockMetadata {
+            sapling_root: vector.sapling_root,
+            sapling_size: vector.sapling_tree_size as u32,
+            orchard_root: vector.orchard_root,
+            orchard_size: vector.orchard_tree_size as u32,
+            ironwood: None,
+            parent_chainwork: parent_chain_work,
+            network: zebra_chain::parameters::Network::new_regtest(
                 zebra_chain::parameters::testnet::ConfiguredActivationHeights {
                     before_overwinter: Some(1),
                     overwinter: Some(1),
@@ -117,7 +117,7 @@ pub(crate) fn indexed_block_chain(
                 }
                 .into(),
             ),
-        );
+        };
         let chain_block =
             IndexedBlock::try_from(BlockWithMetadata::new(&vector.zebra_block, metadata)).unwrap();
         parent_chain_work = Some(chain_block.context.chainwork);

--- a/packages/zaino-state/src/chain_index/types/db/legacy.rs
+++ b/packages/zaino-state/src/chain_index/types/db/legacy.rs
@@ -1097,11 +1097,9 @@ impl IndexedBlock {
 
     /// Converts this `IndexedBlock` into a CompactBlock protobuf message using proto v4 format.
     ///
-    /// NOTE: This method currently includes transparent tx data in the compact block produced,
-    ///       `zaino-state::local_cache::compact_block_with_pool_types` should be used to selectively
-    ///       remove tx data by pool type. Alternatively this method could be updated to take a
-    ///       `zaino-proto::proto::utils::PoolTypeFilter` could be  added as an input to this method,
-    ///       with tx data being added selectively here.
+    /// The block produced is unfiltered: it carries every pool's tx data,
+    /// transparent included. Callers serving a pool-filtered request apply
+    /// `zaino_proto::proto::utils::prune_compact_block` to the result.
     pub fn to_compact_block(&self) -> zaino_proto::proto::compact_formats::CompactBlock {
         // NOTE: Returns u64::MAX if the block is not in the best chain.
         let height: u64 = self.height().0.into();

--- a/packages/zaino-state/src/chain_index/types/db/legacy.rs
+++ b/packages/zaino-state/src/chain_index/types/db/legacy.rs
@@ -793,28 +793,6 @@ pub struct BlockData {
 }
 
 impl BlockData {
-    /// Creates a new  BlockData instance.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        version: u32,
-        time: i64,
-        merkle_root: [u8; 32],
-        block_commitments: [u8; 32],
-        bits: CompactDifficulty,
-        nonse: [u8; 32],
-        solution: EquihashSolution,
-    ) -> Self {
-        Self {
-            version,
-            time,
-            merkle_root,
-            block_commitments,
-            bits,
-            nonce: nonse,
-            solution,
-        }
-    }
-
     /// Convert zebra block commitment to 32-byte array
     pub fn commitment_to_bytes(commitment: zebra_chain::block::Commitment) -> [u8; 32] {
         match commitment {
@@ -908,15 +886,15 @@ impl ZainoVersionedSerde for BlockData {
 
         let solution = EquihashSolution::deserialize(&mut r)?;
 
-        Ok(BlockData::new(
+        Ok(BlockData {
             version,
             time,
             merkle_root,
             block_commitments,
             bits,
-            nonse,
+            nonce: nonse,
             solution,
-        ))
+        })
     }
 }
 
@@ -1264,15 +1242,15 @@ impl
         );
 
         // --- Compute chainwork ---
-        let block_data = BlockData::new(
-            header.version() as u32,
-            header.time() as i64,
+        let block_data = BlockData {
+            version: header.version() as u32,
+            time: header.time() as i64,
             merkle_root,
             block_commitments,
             bits,
-            nonse,
+            nonce: nonse,
             solution,
-        );
+        };
 
         let block_work = block_data.bits.to_work();
         let chainwork = match parent_chainwork {

--- a/packages/zaino-state/src/chain_index/types/db/legacy.rs
+++ b/packages/zaino-state/src/chain_index/types/db/legacy.rs
@@ -1134,36 +1134,6 @@ impl IndexedBlock {
     }
 }
 
-impl ZainoVersionedSerde for IndexedBlock {
-    const VERSION: u8 = version::V1;
-
-    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        Self::encode_v1(self, w)
-    }
-
-    fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
-        Self::decode_v1(r)
-    }
-
-    fn encode_v1<W: Write>(&self, mut w: &mut W) -> io::Result<()> {
-        PersistentBlockContext::from_business(&self.context).serialize_with_version(&mut w, 1)?;
-        self.data.serialize_with_version(&mut w, 1)?;
-        write_vec(&mut w, &self.transactions, |w, tx| {
-            tx.serialize_with_version(w, 1)
-        })?;
-        self.commitment_tree_data.serialize_with_version(&mut w, 1)
-    }
-
-    fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
-        let mut r = r;
-        let context = PersistentBlockContext::deserialize(&mut r)?.into_business()?;
-        let data = BlockData::deserialize(&mut r)?;
-        let tx = read_vec(&mut r, |r| CompactTxData::deserialize(r))?;
-        let ctd = CommitmentTreeData::deserialize(&mut r)?;
-
-        Ok(IndexedBlock::new(context, data, tx, ctd))
-    }
-}
 /// TryFrom inputs:
 /// - FullBlock:
 ///   - Holds block data.
@@ -1578,76 +1548,6 @@ impl TryFrom<(u64, zaino_fetch::chain::transaction::FullTransaction)> for Compac
             index,
             // NOTE: do we need to use from_bytes_in_display_order here?
             txid.into(),
-            transparent,
-            sapling,
-            orchard,
-            ironwood,
-        ))
-    }
-}
-
-impl ZainoVersionedSerde for CompactTxData {
-    const VERSION: u8 = version::V2;
-
-    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        Self::encode_v2(self, w)
-    }
-
-    fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
-        Self::decode_v2(r)
-    }
-
-    fn encode_v1<W: Write>(&self, mut w: &mut W) -> io::Result<()> {
-        write_u64_le(&mut w, self.index)?;
-
-        self.txid.serialize_with_version(&mut w, 1)?;
-        self.transparent.serialize_with_version(&mut w, 1)?;
-        self.sapling.serialize_with_version(&mut w, 1)?;
-        self.orchard.serialize_with_version(&mut w, 1)
-    }
-
-    fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
-        let mut r = r;
-        let index = read_u64_le(&mut r)?;
-
-        let txid = TransactionHash::deserialize(&mut r)?;
-        let transparent = TransparentCompactTx::deserialize(&mut r)?;
-        let sapling = SaplingCompactTx::deserialize(&mut r)?;
-        let orchard = OrchardCompactTx::deserialize(&mut r)?;
-
-        Ok(CompactTxData::new(
-            index,
-            txid,
-            transparent,
-            sapling,
-            orchard,
-            OrchardCompactTx::empty(),
-        ))
-    }
-
-    fn encode_v2<W: Write>(&self, mut w: &mut W) -> io::Result<()> {
-        write_u64_le(&mut w, self.index)?;
-
-        self.txid.serialize_with_version(&mut w, 1)?;
-        self.transparent.serialize_with_version(&mut w, 1)?;
-        self.sapling.serialize_with_version(&mut w, 1)?;
-        self.orchard.serialize_with_version(&mut w, 1)?;
-        self.ironwood.serialize_with_version(&mut w, 1)
-    }
-
-    fn decode_v2<R: Read>(r: &mut R) -> io::Result<Self> {
-        let mut r = r;
-        let index = read_u64_le(&mut r)?;
-
-        let txid = TransactionHash::deserialize(&mut r)?;
-        let transparent = TransparentCompactTx::deserialize(&mut r)?;
-        let sapling = SaplingCompactTx::deserialize(&mut r)?;
-        let orchard = OrchardCompactTx::deserialize(&mut r)?;
-        let ironwood = OrchardCompactTx::deserialize(&mut r)?;
-
-        Ok(CompactTxData::new(
-            index,
-            txid,
             transparent,
             sapling,
             orchard,

--- a/packages/zaino-state/src/chain_index/types/db/metadata.rs
+++ b/packages/zaino-state/src/chain_index/types/db/metadata.rs
@@ -206,23 +206,34 @@ impl FinalisedTxOutSetInfoAccumulator {
         outpoint: &Outpoint,
         out: &TxOutCompact,
     ) -> Result<(), AccumulatorDeltaError> {
-        let digest = tx_out_set_entry_digest(outpoint, out);
+        self.apply_output_delta(outpoint, out, OutputDelta::Added)
+    }
+
+    /// Applies one output entering or leaving the set: XOR its digest into the multiset
+    /// commitment and step every per-output counter in the delta's direction.
+    fn apply_output_delta(
+        &mut self,
+        outpoint: &Outpoint,
+        out: &TxOutCompact,
+        delta: OutputDelta,
+    ) -> Result<(), AccumulatorDeltaError> {
+        self.xor_into_hash_serialized(&tx_out_set_entry_digest(outpoint, out));
+        self.transaction_outputs =
+            delta.step(self.transaction_outputs, 1, "transaction_outputs")?;
+        self.bytes_serialized = delta.step(
+            self.bytes_serialized,
+            ZAINO_TXOUTSET_ENTRY_LEN,
+            "bytes_serialized",
+        )?;
+        self.total_zatoshis = delta.step(self.total_zatoshis, out.value(), "total_zatoshis")?;
+        Ok(())
+    }
+
+    /// XORs `digest` into the multiset commitment (self-inverse and order-independent).
+    fn xor_into_hash_serialized(&mut self, digest: &[u8; 32]) {
         for (dst, src) in self.hash_serialized.iter_mut().zip(digest.iter()) {
             *dst ^= *src;
         }
-        self.transaction_outputs = self
-            .transaction_outputs
-            .checked_add(1)
-            .ok_or(AccumulatorDeltaError::Overflow("transaction_outputs"))?;
-        self.bytes_serialized = self
-            .bytes_serialized
-            .checked_add(ZAINO_TXOUTSET_ENTRY_LEN)
-            .ok_or(AccumulatorDeltaError::Overflow("bytes_serialized"))?;
-        self.total_zatoshis = self
-            .total_zatoshis
-            .checked_add(out.value())
-            .ok_or(AccumulatorDeltaError::Overflow("total_zatoshis"))?;
-        Ok(())
     }
 
     /// Folds another accumulator into this one: XOR the multiset commitments (self-inverse and
@@ -232,13 +243,7 @@ impl FinalisedTxOutSetInfoAccumulator {
     /// both commutative and associative, the recombined result is independent of the shard count and
     /// of the order shards are folded in.
     pub fn combine(&mut self, other: &Self) -> Result<(), AccumulatorDeltaError> {
-        for (dst, src) in self
-            .hash_serialized
-            .iter_mut()
-            .zip(other.hash_serialized.iter())
-        {
-            *dst ^= *src;
-        }
+        self.xor_into_hash_serialized(&other.hash_serialized);
         self.transactions = self
             .transactions
             .checked_add(other.transactions)
@@ -265,23 +270,35 @@ impl FinalisedTxOutSetInfoAccumulator {
         outpoint: &Outpoint,
         out: &TxOutCompact,
     ) -> Result<(), AccumulatorDeltaError> {
-        let digest = tx_out_set_entry_digest(outpoint, out);
-        for (dst, src) in self.hash_serialized.iter_mut().zip(digest.iter()) {
-            *dst ^= *src;
+        self.apply_output_delta(outpoint, out, OutputDelta::Removed)
+    }
+}
+
+/// Direction of a single-output change applied to the accumulator's counters.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OutputDelta {
+    /// The output enters the UTXO set: counters are checked-added.
+    Added,
+    /// The output leaves the UTXO set: counters are checked-subtracted.
+    Removed,
+}
+
+impl OutputDelta {
+    /// Steps `field` by `amount` in this direction, naming `field_name` in the error.
+    fn step(
+        self,
+        field: u64,
+        amount: u64,
+        field_name: &'static str,
+    ) -> Result<u64, AccumulatorDeltaError> {
+        match self {
+            OutputDelta::Added => field
+                .checked_add(amount)
+                .ok_or(AccumulatorDeltaError::Overflow(field_name)),
+            OutputDelta::Removed => field
+                .checked_sub(amount)
+                .ok_or(AccumulatorDeltaError::Underflow(field_name)),
         }
-        self.transaction_outputs = self
-            .transaction_outputs
-            .checked_sub(1)
-            .ok_or(AccumulatorDeltaError::Underflow("transaction_outputs"))?;
-        self.bytes_serialized = self
-            .bytes_serialized
-            .checked_sub(ZAINO_TXOUTSET_ENTRY_LEN)
-            .ok_or(AccumulatorDeltaError::Underflow("bytes_serialized"))?;
-        self.total_zatoshis = self
-            .total_zatoshis
-            .checked_sub(out.value())
-            .ok_or(AccumulatorDeltaError::Underflow("total_zatoshis"))?;
-        Ok(())
     }
 }
 

--- a/packages/zaino-state/src/chain_index/types/helpers.rs
+++ b/packages/zaino-state/src/chain_index/types/helpers.rs
@@ -124,29 +124,6 @@ pub struct BlockMetadata {
     pub network: zebra_chain::parameters::Network,
 }
 
-impl BlockMetadata {
-    /// Create new block metadata
-    pub fn new(
-        sapling_root: zebra_chain::sapling::tree::Root,
-        sapling_size: u32,
-        orchard_root: zebra_chain::orchard::tree::Root,
-        orchard_size: u32,
-        ironwood: Option<(zebra_chain::orchard::tree::Root, u32)>,
-        parent_chainwork: Option<ChainWork>,
-        network: zebra_chain::parameters::Network,
-    ) -> Self {
-        Self {
-            sapling_root,
-            sapling_size,
-            orchard_root,
-            orchard_size,
-            ironwood,
-            parent_chainwork,
-            network,
-        }
-    }
-}
-
 /// Intermediate type combining a block with its metadata
 #[derive(Debug, Clone)]
 pub struct BlockWithMetadata<'a> {
@@ -402,15 +379,15 @@ mod create_commitment_tree_data {
     fn absent_ironwood_root_is_stored_as_none() {
         let (sapling_root, sapling_size, orchard_root, orchard_size, ironwood) =
             TreeRootData::new(None, None, None).extract_with_defaults();
-        let metadata = BlockMetadata::new(
+        let metadata = BlockMetadata {
             sapling_root,
-            sapling_size as u32,
+            sapling_size: sapling_size as u32,
             orchard_root,
-            orchard_size as u32,
-            ironwood.map(|(root, size)| (root, size as u32)),
-            None,
-            zebra_chain::parameters::Network::Mainnet,
-        );
+            orchard_size: orchard_size as u32,
+            ironwood: ironwood.map(|(root, size)| (root, size as u32)),
+            parent_chainwork: None,
+            network: zebra_chain::parameters::Network::Mainnet,
+        };
 
         let commitment_tree_data = metadata.create_commitment_tree_data();
 

--- a/packages/zaino-state/src/error.rs
+++ b/packages/zaino-state/src/error.rs
@@ -192,29 +192,11 @@ impl<T: ToString> From<RpcRequestError<T>> for NodeBackedIndexerServiceError {
 /// in favor of a new type with the new chain cache is complete
 impl<T: ToString> From<RpcRequestError<T>> for MempoolError {
     fn from(value: RpcRequestError<T>) -> Self {
-        match value {
-            RpcRequestError::Transport(transport_error) => {
+        match RpcRequestFallback::classify(value) {
+            RpcRequestFallback::Transport(transport_error) => {
                 MempoolError::JsonRpcConnectorError(transport_error)
             }
-            RpcRequestError::JsonRpc(error) => {
-                MempoolError::Critical(format!("argument failed to serialze: {error}"))
-            }
-            RpcRequestError::InternalUnrecoverable(e) => {
-                MempoolError::Critical(format!("Internal unrecoverable error: {e}"))
-            }
-            RpcRequestError::ServerWorkQueueFull => MempoolError::Critical(
-                "Server queue full. Handling for this not yet implemented".to_string(),
-            ),
-            RpcRequestError::Method(e) => MempoolError::Critical(format!(
-                "unhandled rpc-specific {} error: {}",
-                type_name::<T>(),
-                e.to_string()
-            )),
-            RpcRequestError::UnexpectedErrorResponse(error) => MempoolError::Critical(format!(
-                "unhandled rpc-specific {} error: {}",
-                type_name::<T>(),
-                error
-            )),
+            RpcRequestFallback::Message(message) => MempoolError::Critical(message),
         }
     }
 }
@@ -320,35 +302,58 @@ pub enum NonFinalisedStateError {
     StatusError(StatusError),
 }
 
-/// These aren't the best conversions, but the NonFinalizedStateError should go away
-/// in favor of a new type with the new chain cache is complete
-impl<T: ToString> From<RpcRequestError<T>> for NonFinalisedStateError {
-    fn from(value: RpcRequestError<T>) -> Self {
+/// Either a transport error passed through intact, or the formatted message for the
+/// target error type's degraded catch-all variant.
+///
+/// Shared classification behind the `From<RpcRequestError<T>>` conversions for
+/// [`MempoolError`], [`NonFinalisedStateError`], and [`FinalisedStateError`]: all
+/// three map transport errors to their `JsonRpcConnectorError` variant and degrade
+/// every other case to a message-carrying variant (`Critical` or `Custom`).
+enum RpcRequestFallback {
+    Transport(zaino_fetch::jsonrpsee::error::TransportError),
+    Message(String),
+}
+
+impl RpcRequestFallback {
+    fn classify<T: ToString>(value: RpcRequestError<T>) -> Self {
         match value {
             RpcRequestError::Transport(transport_error) => {
-                NonFinalisedStateError::JsonRpcConnectorError(transport_error)
+                RpcRequestFallback::Transport(transport_error)
             }
             RpcRequestError::JsonRpc(error) => {
-                NonFinalisedStateError::Custom(format!("argument failed to serialze: {error}"))
+                RpcRequestFallback::Message(format!("argument failed to serialze: {error}"))
             }
             RpcRequestError::InternalUnrecoverable(e) => {
-                NonFinalisedStateError::Custom(format!("Internal unrecoverable error: {e}"))
+                RpcRequestFallback::Message(format!("Internal unrecoverable error: {e}"))
             }
-            RpcRequestError::ServerWorkQueueFull => NonFinalisedStateError::Custom(
+            RpcRequestError::ServerWorkQueueFull => RpcRequestFallback::Message(
                 "Server queue full. Handling for this not yet implemented".to_string(),
             ),
-            RpcRequestError::Method(e) => NonFinalisedStateError::Custom(format!(
+            RpcRequestError::Method(e) => RpcRequestFallback::Message(format!(
                 "unhandled rpc-specific {} error: {}",
                 type_name::<T>(),
                 e.to_string()
             )),
             RpcRequestError::UnexpectedErrorResponse(error) => {
-                NonFinalisedStateError::Custom(format!(
+                RpcRequestFallback::Message(format!(
                     "unhandled rpc-specific {} error: {}",
                     type_name::<T>(),
                     error
                 ))
             }
+        }
+    }
+}
+
+/// These aren't the best conversions, but the NonFinalizedStateError should go away
+/// in favor of a new type with the new chain cache is complete
+impl<T: ToString> From<RpcRequestError<T>> for NonFinalisedStateError {
+    fn from(value: RpcRequestError<T>) -> Self {
+        match RpcRequestFallback::classify(value) {
+            RpcRequestFallback::Transport(transport_error) => {
+                NonFinalisedStateError::JsonRpcConnectorError(transport_error)
+            }
+            RpcRequestFallback::Message(message) => NonFinalisedStateError::Custom(message),
         }
     }
 }
@@ -423,31 +428,11 @@ pub enum FinalisedStateError {
 /// in favor of a new type with the new chain cache is complete
 impl<T: ToString> From<RpcRequestError<T>> for FinalisedStateError {
     fn from(value: RpcRequestError<T>) -> Self {
-        match value {
-            RpcRequestError::Transport(transport_error) => {
+        match RpcRequestFallback::classify(value) {
+            RpcRequestFallback::Transport(transport_error) => {
                 FinalisedStateError::JsonRpcConnectorError(transport_error)
             }
-            RpcRequestError::JsonRpc(error) => {
-                FinalisedStateError::Custom(format!("argument failed to serialze: {error}"))
-            }
-            RpcRequestError::InternalUnrecoverable(e) => {
-                FinalisedStateError::Custom(format!("Internal unrecoverable error: {e}"))
-            }
-            RpcRequestError::ServerWorkQueueFull => FinalisedStateError::Custom(
-                "Server queue full. Handling for this not yet implemented".to_string(),
-            ),
-            RpcRequestError::Method(e) => FinalisedStateError::Custom(format!(
-                "unhandled rpc-specific {} error: {}",
-                type_name::<T>(),
-                e.to_string()
-            )),
-            RpcRequestError::UnexpectedErrorResponse(error) => {
-                FinalisedStateError::Custom(format!(
-                    "unhandled rpc-specific {} error: {}",
-                    type_name::<T>(),
-                    error
-                ))
-            }
+            RpcRequestFallback::Message(message) => FinalisedStateError::Custom(message),
         }
     }
 }

--- a/packages/zaino-state/src/indexer.rs
+++ b/packages/zaino-state/src/indexer.rs
@@ -606,38 +606,20 @@ pub trait ZcashIndexer: Send + Sync + 'static {
             let chain_height = self.chain_height().await?;
             let (start, end) = match request.range {
                 Some(range) => {
-                    let start = if let Some(start) = range.start {
-                        match u32::try_from(start.height) {
-                            Ok(height) => Some(height.min(chain_height.0)),
-                            Err(_) => {
-                                return Err(Self::Error::from(tonic::Status::invalid_argument(
-                                    "Error: Start height out of range. Failed to convert to u32.",
-                                )))
-                            }
-                        }
-                    } else {
-                        None
-                    };
-                    let end = if let Some(end) = range.end {
-                        match u32::try_from(end.height) {
-                            Ok(height) => Some(height.min(chain_height.0)),
-                            Err(_) => {
-                                return Err(Self::Error::from(tonic::Status::invalid_argument(
-                                    "Error: End height out of range. Failed to convert to u32.",
-                                )))
-                            }
-                        }
-                    } else {
-                        None
-                    };
+                    let start = clamped_optional_height(
+                        range.start,
+                        chain_height,
+                        "Error: Start height out of range. Failed to convert to u32.",
+                    )
+                    .map_err(Self::Error::from)?;
+                    let end = clamped_optional_height(
+                        range.end,
+                        chain_height,
+                        "Error: End height out of range. Failed to convert to u32.",
+                    )
+                    .map_err(Self::Error::from)?;
                     match (start, end) {
-                        (Some(start), Some(end)) => {
-                            if start > end {
-                                (Some(end), Some(start))
-                            } else {
-                                (Some(start), Some(end))
-                            }
-                        }
+                        (Some(start), Some(end)) if start > end => (Some(end), Some(start)),
                         _ => (start, end),
                     }
                 }
@@ -655,6 +637,22 @@ pub trait ZcashIndexer: Send + Sync + 'static {
             .await
         }
     }
+}
+
+/// Clamps an optional block-range endpoint to the chain height, or errors
+/// with `out_of_range_message` when the provided height cannot be
+/// represented as a `u32`.
+fn clamped_optional_height(
+    endpoint: Option<BlockId>,
+    chain_height: Height,
+    out_of_range_message: &'static str,
+) -> Result<Option<u32>, tonic::Status> {
+    endpoint
+        .map(|block_id| match u32::try_from(block_id.height) {
+            Ok(height) => Ok(height.min(chain_height.0)),
+            Err(_) => Err(tonic::Status::invalid_argument(out_of_range_message)),
+        })
+        .transpose()
 }
 
 /// Light Client Protocol gRPC method signatures.

--- a/packages/zaino-state/src/indexer/node_backed_indexer.rs
+++ b/packages/zaino-state/src/indexer/node_backed_indexer.rs
@@ -1256,9 +1256,8 @@ impl<Source: BlockchainSource> LightWalletIndexer for NodeBackedIndexerServiceSu
 
         let pool_type_filter = validated_request.pool_type_filter().clone();
 
-        // Note conversion here is safe due to the use of [`ValidatedBlockRangeRequest::new_from_block_range`]
-        let start = validated_request.start() as u32;
-        let end = validated_request.end() as u32;
+        let start = validated_request.start();
+        let end = validated_request.end();
 
         let service_clone = self.clone();
         let service_timeout = self.config.service.timeout;
@@ -1383,9 +1382,8 @@ impl<Source: BlockchainSource> LightWalletIndexer for NodeBackedIndexerServiceSu
 
         let pool_type_filter = validated_request.pool_type_filter().clone();
 
-        // Note conversion here is safe due to the use of [`ValidatedBlockRangeRequest::new_from_block_range`]
-        let start = validated_request.start() as u32;
-        let end = validated_request.end() as u32;
+        let start = validated_request.start();
+        let end = validated_request.end();
 
         let service_clone = self.clone();
         let service_timeout = self.config.service.timeout;

--- a/packages/zaino-state/src/indexer/node_backed_indexer.rs
+++ b/packages/zaino-state/src/indexer/node_backed_indexer.rs
@@ -49,7 +49,7 @@ use zaino_proto::proto::{
         TxFilter,
     },
     utils::{
-        blockid_to_hashorheight, compact_block_to_nullifiers, GetBlockRangeError, PoolTypeFilter,
+        blockid_to_hashorheight, compact_block_to_nullifiers, PoolTypeFilter,
         ValidatedBlockRangeRequest,
     },
 };
@@ -1254,9 +1254,7 @@ impl<Source: BlockchainSource> LightWalletIndexer for NodeBackedIndexerServiceSu
         let validated_request = ValidatedBlockRangeRequest::new_from_block_range(&request)
             .map_err(NodeBackedIndexerServiceError::from)?;
 
-        let pool_type_filter = PoolTypeFilter::new_from_pool_types(&validated_request.pool_types())
-            .map_err(GetBlockRangeError::PoolTypeArgumentError)
-            .map_err(NodeBackedIndexerServiceError::from)?;
+        let pool_type_filter = validated_request.pool_type_filter().clone();
 
         // Note conversion here is safe due to the use of [`ValidatedBlockRangeRequest::new_from_block_range`]
         let start = validated_request.start() as u32;
@@ -1383,9 +1381,7 @@ impl<Source: BlockchainSource> LightWalletIndexer for NodeBackedIndexerServiceSu
         let validated_request = ValidatedBlockRangeRequest::new_from_block_range(&request)
             .map_err(NodeBackedIndexerServiceError::from)?;
 
-        let pool_type_filter = PoolTypeFilter::new_from_pool_types(&validated_request.pool_types())
-            .map_err(GetBlockRangeError::PoolTypeArgumentError)
-            .map_err(NodeBackedIndexerServiceError::from)?;
+        let pool_type_filter = validated_request.pool_type_filter().clone();
 
         // Note conversion here is safe due to the use of [`ValidatedBlockRangeRequest::new_from_block_range`]
         let start = validated_request.start() as u32;

--- a/packages/zaino-state/src/indexer/node_backed_indexer.rs
+++ b/packages/zaino-state/src/indexer/node_backed_indexer.rs
@@ -373,6 +373,121 @@ impl<Source: BlockchainSource> NodeBackedIndexerServiceSubscriber<Source> {
             monitor: self.indexer.source().chain_tip_change()?,
         })
     }
+
+    /// Shared body of `get_block_range` and `get_block_range_nullifiers`: streams the
+    /// requested compact-block range through a channel, applying `map_block` to every
+    /// block before it is sent. `rpc_name` labels log lines and nothing else.
+    #[allow(deprecated)]
+    async fn spawn_block_range_stream(
+        &self,
+        request: &BlockRange,
+        rpc_name: &'static str,
+        map_block: impl Fn(CompactBlock) -> CompactBlock + Send + Sync + 'static,
+    ) -> Result<CompactBlockStream, NodeBackedIndexerServiceError> {
+        let validated_request = ValidatedBlockRangeRequest::new_from_block_range(request)
+            .map_err(NodeBackedIndexerServiceError::from)?;
+
+        let pool_type_filter = validated_request.pool_type_filter().clone();
+
+        let start = validated_request.start();
+        let end = validated_request.end();
+
+        let service_clone = self.clone();
+        let service_timeout = self.config.service.timeout;
+        let (channel_tx, channel_rx) = mpsc::channel(self.config.service.channel_size as usize);
+        let snapshot = service_clone.indexer.snapshot_nonfinalized_state().await?;
+
+        tokio::spawn(async move {
+            let timeout_result = timeout(
+                time::Duration::from_secs((service_timeout * 4) as u64),
+                async {
+                    let Some(non_finalized_snapshot) = snapshot.get_nfs_snapshot() else {
+                        // TODO: This probably shouldn't be an error.
+                        // this is an improvement over previous behaviour of
+                        // acting as if we are only synced to the genesis block
+                        if let Err(e) = channel_tx
+                            .send(Err(tonic::Status::failed_precondition(
+                                "zaino not yet synced".to_string(),
+                            )))
+                            .await
+                        {
+                            warn!(%e, "{rpc_name} channel closed unexpectedly");
+                        };
+                        return;
+                    };
+                    // Use the snapshot tip directly, as this function doesn't support passthrough
+                    let chain_height = non_finalized_snapshot.best_tip.height.0;
+
+                    let height_out_of_range_status = move || {
+                        let offending_height = if start > chain_height { start } else { end };
+                        tonic::Status::out_of_range(format!(
+                            "Error: Height out of range [{offending_height}]. \
+                            Height requested is greater than the best \
+                            chain tip [{chain_height}].",
+                        ))
+                    };
+
+                    match service_clone
+                        .indexer
+                        .get_compact_block_stream(
+                            &snapshot,
+                            types::Height(start),
+                            types::Height(end),
+                            pool_type_filter.clone(),
+                        )
+                        .await
+                    {
+                        Ok(Some(mut compact_block_stream)) => {
+                            while let Some(stream_item) = compact_block_stream.next().await {
+                                if channel_tx.send(stream_item.map(&map_block)).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                        Ok(None) => {
+                            // Per `get_compact_block_stream` semantics: `None` means at least one bound is above the tip.
+                            if let Err(e) = channel_tx.send(Err(height_out_of_range_status())).await
+                            {
+                                warn!(%e, "{rpc_name} channel closed unexpectedly");
+                            }
+                        }
+                        Err(e) => {
+                            // Preserve previous behaviour: if the request is above tip, surface OutOfRange;
+                            // otherwise return the error (currently exposed for dev).
+                            if start > chain_height || end > chain_height {
+                                if let Err(e) =
+                                    channel_tx.send(Err(height_out_of_range_status())).await
+                                {
+                                    warn!(%e, "{rpc_name} channel closed unexpectedly");
+                                }
+                            } else {
+                                // TODO: Hide server error from clients before release. Currently useful for dev purposes.
+                                if channel_tx
+                                    .send(Err(tonic::Status::unknown(e.to_string())))
+                                    .await
+                                    .is_err()
+                                {
+                                    warn!(%e, "{rpc_name} stream closed unexpectedly");
+                                }
+                            }
+                        }
+                    }
+                },
+            )
+            .await;
+
+            if timeout_result.is_err() {
+                channel_tx
+                    .send(Err(tonic::Status::deadline_exceeded(
+                        "Error: get_block_range gRPC request timed out.",
+                    )))
+                    .await
+                    .ok();
+            }
+        });
+
+        Ok(CompactBlockStream::new(channel_rx))
+    }
 }
 
 /// Methods available only on the production (`ValidatorConnector`-backed) subscriber:
@@ -1251,122 +1366,8 @@ impl<Source: BlockchainSource> LightWalletIndexer for NodeBackedIndexerServiceSu
         &self,
         request: BlockRange,
     ) -> Result<CompactBlockStream, Self::Error> {
-        let validated_request = ValidatedBlockRangeRequest::new_from_block_range(&request)
-            .map_err(NodeBackedIndexerServiceError::from)?;
-
-        let pool_type_filter = validated_request.pool_type_filter().clone();
-
-        let start = validated_request.start();
-        let end = validated_request.end();
-
-        let service_clone = self.clone();
-        let service_timeout = self.config.service.timeout;
-        let (channel_tx, channel_rx) = mpsc::channel(self.config.service.channel_size as usize);
-        let snapshot = service_clone.indexer.snapshot_nonfinalized_state().await?;
-
-        tokio::spawn(async move {
-            let timeout_result = timeout(
-                time::Duration::from_secs((service_timeout * 4) as u64),
-                async {
-                    let Some(non_finalized_snapshot) = snapshot.get_nfs_snapshot() else {
-                        // TODO: This probably shouldn't be an error.
-                        // this is an improvement over previous behaviour of
-                        // acting as if we are only synced to the genesis block
-                        if let Err(e) = channel_tx
-                            .send(Err(tonic::Status::failed_precondition(
-                                "zaino not yet synced".to_string(),
-                            )))
-                            .await
-                        {
-                            warn!(%e, "GetBlockRange channel closed unexpectedly");
-                        };
-                        return;
-                    };
-                    // Use the snapshot tip directly, as this function doesn't support passthrough
-                    let chain_height = non_finalized_snapshot.best_tip.height.0;
-
-                    match service_clone
-                        .indexer
-                        .get_compact_block_stream(
-                            &snapshot,
-                            types::Height(start),
-                            types::Height(end),
-                            pool_type_filter.clone(),
-                        )
-                        .await
-                    {
-                        Ok(Some(mut compact_block_stream)) => {
-                            while let Some(stream_item) = compact_block_stream.next().await {
-                                if channel_tx.send(stream_item).await.is_err() {
-                                    break;
-                                }
-                            }
-                        }
-                        Ok(None) => {
-                            // Per `get_compact_block_stream` semantics: `None` means at least one bound is above the tip.
-                            let offending_height = if start > chain_height { start } else { end };
-
-                            match channel_tx
-                                .send(Err(tonic::Status::out_of_range(format!(
-                                    "Error: Height out of range [{offending_height}]. \
-                                Height requested is greater than the best \
-                                chain tip [{chain_height}].",
-                                ))))
-                                .await
-                            {
-                                Ok(_) => {}
-                                Err(e) => {
-                                    warn!(%e, "GetBlockRange channel closed unexpectedly");
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            // Preserve previous behaviour: if the request is above tip, surface OutOfRange;
-                            // otherwise return the error (currently exposed for dev).
-                            if start > chain_height || end > chain_height {
-                                let offending_height =
-                                    if start > chain_height { start } else { end };
-
-                                match channel_tx
-                                    .send(Err(tonic::Status::out_of_range(format!(
-                                        "Error: Height out of range [{offending_height}]. \
-                                    Height requested is greater than the best \
-                                    chain tip [{chain_height}].",
-                                    ))))
-                                    .await
-                                {
-                                    Ok(_) => {}
-                                    Err(e) => {
-                                        warn!(%e, "GetBlockRange channel closed unexpectedly");
-                                    }
-                                }
-                            } else {
-                                // TODO: Hide server error from clients before release. Currently useful for dev purposes.
-                                if channel_tx
-                                    .send(Err(tonic::Status::unknown(e.to_string())))
-                                    .await
-                                    .is_err()
-                                {
-                                    warn!(%e, "GetBlockRangeStream closed unexpectedly");
-                                }
-                            }
-                        }
-                    }
-                },
-            )
-            .await;
-
-            if timeout_result.is_err() {
-                channel_tx
-                    .send(Err(tonic::Status::deadline_exceeded(
-                        "Error: get_block_range gRPC request timed out.",
-                    )))
-                    .await
-                    .ok();
-            }
-        });
-
-        Ok(CompactBlockStream::new(channel_rx))
+        self.spawn_block_range_stream(&request, "GetBlockRange", |block| block)
+            .await
     }
 
     /// Same as GetBlockRange except actions contain only nullifiers
@@ -1377,138 +1378,12 @@ impl<Source: BlockchainSource> LightWalletIndexer for NodeBackedIndexerServiceSu
         &self,
         request: BlockRange,
     ) -> Result<CompactBlockStream, Self::Error> {
-        let validated_request = ValidatedBlockRangeRequest::new_from_block_range(&request)
-            .map_err(NodeBackedIndexerServiceError::from)?;
-
-        let pool_type_filter = validated_request.pool_type_filter().clone();
-
-        let start = validated_request.start();
-        let end = validated_request.end();
-
-        let service_clone = self.clone();
-        let service_timeout = self.config.service.timeout;
-        let (channel_tx, channel_rx) = mpsc::channel(self.config.service.channel_size as usize);
-        let snapshot = service_clone.indexer.snapshot_nonfinalized_state().await?;
-
-        tokio::spawn(async move {
-            let timeout_result = timeout(
-                time::Duration::from_secs((service_timeout * 4) as u64),
-                async {
-                    let Some(non_finalized_snapshot) = snapshot.get_nfs_snapshot() else {
-                        // TODO: This probably shouldn't be an error.
-                        // this is an improvement over previous behaviour of
-                        // acting as if we are only synced to the genesis block
-                        if let Err(e) = channel_tx
-                            .send(Err(tonic::Status::failed_precondition(
-                                "zaino not yet synced".to_string(),
-                            )))
-                            .await
-                        {
-                            warn!(%e, "GetBlockRangeNullifiers channel closed unexpectedly");
-                        };
-                        return;
-                    };
-
-                    // Use the snapshot tip directly, as this function doesn't support passthrough
-                    let chain_height = non_finalized_snapshot.best_tip.height.0;
-
-                    match service_clone
-                        .indexer
-                        .get_compact_block_stream(
-                            &snapshot,
-                            types::Height(start),
-                            types::Height(end),
-                            pool_type_filter.clone(),
-                        )
-                        .await
-                    {
-                        Ok(Some(mut compact_block_stream)) => {
-                            while let Some(stream_item) = compact_block_stream.next().await {
-                                match stream_item {
-                                    Ok(block) => {
-                                        if channel_tx
-                                            .send(Ok(compact_block_to_nullifiers(block)))
-                                            .await
-                                            .is_err()
-                                        {
-                                            break;
-                                        }
-                                    }
-                                    Err(status) => {
-                                        if channel_tx.send(Err(status)).await.is_err() {
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        Ok(None) => {
-                            // Per `get_compact_block_stream` semantics: `None` means at least one bound is above the tip.
-                            let offending_height = if start > chain_height { start } else { end };
-
-                            match channel_tx
-                                .send(Err(tonic::Status::out_of_range(format!(
-                                    "Error: Height out of range [{offending_height}]. \
-                                Height requested is greater than the best \
-                                chain tip [{chain_height}].",
-                                ))))
-                                .await
-                            {
-                                Ok(_) => {}
-                                Err(e) => {
-                                    warn!(%e, "GetBlockRange channel closed unexpectedly");
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            // Preserve previous behaviour: if the request
-                            // is above tip, surface OutOfRange;
-                            // otherwise return the error (currently exposed for dev).
-                            if start > chain_height || end > chain_height {
-                                let offending_height =
-                                    if start > chain_height { start } else { end };
-
-                                match channel_tx
-                                    .send(Err(tonic::Status::out_of_range(format!(
-                                        "Error: Height out of range [{offending_height}]. \
-                                    Height requested is greater than the best chain tip \
-                                    [{chain_height}].",
-                                    ))))
-                                    .await
-                                {
-                                    Ok(_) => {}
-                                    Err(e) => {
-                                        warn!(%e, "GetBlockRange channel closed unexpectedly");
-                                    }
-                                }
-                            } else {
-                                // TODO: Hide server error from clients before release.
-                                // Currently useful for dev purposes.
-                                if channel_tx
-                                    .send(Err(tonic::Status::unknown(e.to_string())))
-                                    .await
-                                    .is_err()
-                                {
-                                    warn!(%e, "GetBlockRangeStream closed unexpectedly");
-                                }
-                            }
-                        }
-                    }
-                },
-            )
-            .await;
-
-            if timeout_result.is_err() {
-                channel_tx
-                    .send(Err(tonic::Status::deadline_exceeded(
-                        "Error: get_block_range gRPC request timed out.",
-                    )))
-                    .await
-                    .ok();
-            }
-        });
-
-        Ok(CompactBlockStream::new(channel_rx))
+        self.spawn_block_range_stream(
+            &request,
+            "GetBlockRangeNullifiers",
+            compact_block_to_nullifiers,
+        )
+        .await
     }
 
     /// Return the requested full (not compact) transaction (as from zcashd)

--- a/packages/zaino-state/src/stream.rs
+++ b/packages/zaino-state/src/stream.rs
@@ -6,191 +6,46 @@ use zaino_proto::proto::{
     service::{Address, GetAddressUtxosReply, RawTransaction, SubtreeRoot},
 };
 
-/// Stream of RawTransactions, output type of get_taddress_txids.
+/// A stream of `Result<T, tonic::Status>` items read from a tokio mpsc receiver.
 #[derive(Debug)]
-pub struct RawTransactionStream {
-    inner: ReceiverStream<Result<RawTransaction, tonic::Status>>,
+pub struct ChannelStream<T> {
+    inner: ReceiverStream<Result<T, tonic::Status>>,
 }
 
-impl RawTransactionStream {
-    /// Returns new instance of RawTransactionStream.
-    pub fn new(rx: tokio::sync::mpsc::Receiver<Result<RawTransaction, tonic::Status>>) -> Self {
-        RawTransactionStream {
+impl<T> ChannelStream<T> {
+    /// Wraps the receiving half of an mpsc channel as a stream.
+    pub fn new(rx: tokio::sync::mpsc::Receiver<Result<T, tonic::Status>>) -> Self {
+        ChannelStream {
             inner: ReceiverStream::new(rx),
         }
     }
 }
 
-impl futures::Stream for RawTransactionStream {
-    type Item = Result<RawTransaction, tonic::Status>;
+impl<T> futures::Stream for ChannelStream<T> {
+    type Item = Result<T, tonic::Status>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
-        let poll = std::pin::Pin::new(&mut self.inner).poll_next(cx);
-        match poll {
-            std::task::Poll::Ready(Some(Ok(raw_tx))) => std::task::Poll::Ready(Some(Ok(raw_tx))),
-            std::task::Poll::Ready(Some(Err(e))) => std::task::Poll::Ready(Some(Err(e))),
-            std::task::Poll::Ready(None) => std::task::Poll::Ready(None),
-            std::task::Poll::Pending => std::task::Poll::Pending,
-        }
+        std::pin::Pin::new(&mut self.inner).poll_next(cx)
     }
 }
 
-/// Stream of RawTransactions, output type of get_taddress_txids.
-pub struct CompactTransactionStream {
-    inner: ReceiverStream<Result<CompactTx, tonic::Status>>,
-}
+/// Stream of `RawTransaction` items, output type of get_taddress_txids.
+pub type RawTransactionStream = ChannelStream<RawTransaction>;
 
-impl CompactTransactionStream {
-    /// Returns new instance of RawTransactionStream.
-    pub fn new(rx: tokio::sync::mpsc::Receiver<Result<CompactTx, tonic::Status>>) -> Self {
-        CompactTransactionStream {
-            inner: ReceiverStream::new(rx),
-        }
-    }
-}
+/// Stream of `CompactTx` items, output type of get_mempool_tx.
+pub type CompactTransactionStream = ChannelStream<CompactTx>;
 
-impl futures::Stream for CompactTransactionStream {
-    type Item = Result<CompactTx, tonic::Status>;
+/// Stream of `CompactBlock` items, output type of get_block_range.
+pub type CompactBlockStream = ChannelStream<CompactBlock>;
 
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        let poll = std::pin::Pin::new(&mut self.inner).poll_next(cx);
-        match poll {
-            std::task::Poll::Ready(Some(Ok(raw_tx))) => std::task::Poll::Ready(Some(Ok(raw_tx))),
-            std::task::Poll::Ready(Some(Err(e))) => std::task::Poll::Ready(Some(Err(e))),
-            std::task::Poll::Ready(None) => std::task::Poll::Ready(None),
-            std::task::Poll::Pending => std::task::Poll::Pending,
-        }
-    }
-}
+/// Stream of `GetAddressUtxosReply` items, output type of get_address_utxos_stream.
+pub type UtxoReplyStream = ChannelStream<GetAddressUtxosReply>;
 
-/// Stream of CompactBlocks, output type of get_block_range.
-pub struct CompactBlockStream {
-    inner: ReceiverStream<Result<CompactBlock, tonic::Status>>,
-}
+/// Stream of `SubtreeRoot` items, output type of get_subtree_roots.
+pub type SubtreeRootReplyStream = ChannelStream<SubtreeRoot>;
 
-impl CompactBlockStream {
-    /// Returns new instance of CompactBlockStream.
-    pub fn new(rx: tokio::sync::mpsc::Receiver<Result<CompactBlock, tonic::Status>>) -> Self {
-        CompactBlockStream {
-            inner: ReceiverStream::new(rx),
-        }
-    }
-}
-
-impl futures::Stream for CompactBlockStream {
-    type Item = Result<CompactBlock, tonic::Status>;
-
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        let poll = std::pin::Pin::new(&mut self.inner).poll_next(cx);
-        match poll {
-            std::task::Poll::Ready(Some(Ok(raw_tx))) => std::task::Poll::Ready(Some(Ok(raw_tx))),
-            std::task::Poll::Ready(Some(Err(e))) => std::task::Poll::Ready(Some(Err(e))),
-            std::task::Poll::Ready(None) => std::task::Poll::Ready(None),
-            std::task::Poll::Pending => std::task::Poll::Pending,
-        }
-    }
-}
-
-/// Stream of CompactBlocks, output type of get_block_range.
-pub struct UtxoReplyStream {
-    inner: ReceiverStream<Result<GetAddressUtxosReply, tonic::Status>>,
-}
-
-impl UtxoReplyStream {
-    /// Returns new instance of CompactBlockStream.
-    pub fn new(
-        rx: tokio::sync::mpsc::Receiver<Result<GetAddressUtxosReply, tonic::Status>>,
-    ) -> Self {
-        UtxoReplyStream {
-            inner: ReceiverStream::new(rx),
-        }
-    }
-}
-
-impl futures::Stream for UtxoReplyStream {
-    type Item = Result<GetAddressUtxosReply, tonic::Status>;
-
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        let poll = std::pin::Pin::new(&mut self.inner).poll_next(cx);
-        match poll {
-            std::task::Poll::Ready(Some(Ok(raw_tx))) => std::task::Poll::Ready(Some(Ok(raw_tx))),
-            std::task::Poll::Ready(Some(Err(e))) => std::task::Poll::Ready(Some(Err(e))),
-            std::task::Poll::Ready(None) => std::task::Poll::Ready(None),
-            std::task::Poll::Pending => std::task::Poll::Pending,
-        }
-    }
-}
-
-/// Stream of CompactBlocks, output type of get_block_range.
-pub struct SubtreeRootReplyStream {
-    inner: ReceiverStream<Result<SubtreeRoot, tonic::Status>>,
-}
-
-impl SubtreeRootReplyStream {
-    /// Returns new instance of CompactBlockStream.
-    pub fn new(rx: tokio::sync::mpsc::Receiver<Result<SubtreeRoot, tonic::Status>>) -> Self {
-        SubtreeRootReplyStream {
-            inner: ReceiverStream::new(rx),
-        }
-    }
-}
-
-impl futures::Stream for SubtreeRootReplyStream {
-    type Item = Result<SubtreeRoot, tonic::Status>;
-
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        let poll = std::pin::Pin::new(&mut self.inner).poll_next(cx);
-        match poll {
-            std::task::Poll::Ready(Some(Ok(raw_tx))) => std::task::Poll::Ready(Some(Ok(raw_tx))),
-            std::task::Poll::Ready(Some(Err(e))) => std::task::Poll::Ready(Some(Err(e))),
-            std::task::Poll::Ready(None) => std::task::Poll::Ready(None),
-            std::task::Poll::Pending => std::task::Poll::Pending,
-        }
-    }
-}
-
-/// Stream of `Address`, input type for `get_taddress_balance_stream`.
-pub struct AddressStream {
-    inner: ReceiverStream<Result<Address, tonic::Status>>,
-}
-
-impl AddressStream {
-    /// Creates a new `AddressStream` instance.
-    pub fn new(rx: tokio::sync::mpsc::Receiver<Result<Address, tonic::Status>>) -> Self {
-        AddressStream {
-            inner: ReceiverStream::new(rx),
-        }
-    }
-}
-
-impl futures::Stream for AddressStream {
-    type Item = Result<Address, tonic::Status>;
-
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        let poll = std::pin::Pin::new(&mut self.inner).poll_next(cx);
-        match poll {
-            std::task::Poll::Ready(Some(Ok(address))) => std::task::Poll::Ready(Some(Ok(address))),
-            std::task::Poll::Ready(Some(Err(e))) => std::task::Poll::Ready(Some(Err(e))),
-            std::task::Poll::Ready(None) => std::task::Poll::Ready(None),
-            std::task::Poll::Pending => std::task::Poll::Pending,
-        }
-    }
-}
+/// Stream of `Address` items, input type for get_taddress_balance_stream.
+pub type AddressStream = ChannelStream<Address>;

--- a/packages/zainod/CHANGELOG.md
+++ b/packages/zainod/CHANGELOG.md
@@ -9,11 +9,40 @@ and this crate adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.7.0] - 2026-08-04
+
+### Added
+### Changed
+- Bumped the bundled crate dependencies: `zaino-proto` 0.3.0, `zaino-state`
+  0.6.0, `zaino-fetch` 0.4.1, and `zaino-serve` 0.5.1.
+- CI now gates on duplicate Rust logic (the workbench `check-code-duplication`
+  check).
+- ADR 0007 records the block-persistence row-set boundary.
+### Deprecated
+### Removed
+### Fixed
+
+## [0.6.0] - 2026-07-13
+
+### Added
 - Ironwood (NU6.3) / V6 transaction support, end to end through the
   workspace crates: V6 parsing and ironwood extraction (`zaino-fetch`),
   `ironwoodActions` in served compact blocks (`zaino-proto`, on by
   default), and ironwood treestate roots in the chain index
   (`zaino-state`).
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.5.0] - 2026-07-02
+
+### Added
 - `[storage.database]` config gains `sync_checkpoint_interval` (seconds, default
   120) — the bulk-sync write-batch flush interval, which also bounds the window of
   unflushed (`NO_SYNC`) writes at risk on a hard kill / eviction.
@@ -21,9 +50,6 @@ and this crate adheres to Rust's notion of
   default 8) — a dedicated heap budget for the txout-set accumulator rebuild,
   separate from `sync_write_batch_size`.
 ### Changed
-- Version marked `0.4.3-ironwood.1` so Ironwood feature builds identify
-  themselves at `zainod --version`; stock `0.4.2` binaries are otherwise
-  indistinguishable from this branch's builds.
 - **Breaking** — `[storage.database] sync_write_batch_bytes` (bytes) is renamed
   to `sync_write_batch_size` and is now given in **GiB** (default 8). It now
   budgets only the bulk-sync block buffer; the accumulator rebuild uses the new

--- a/packages/zainod/Cargo.toml
+++ b/packages/zainod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zainod"
-version = "0.6.0"
+version = "0.7.0"
 description = "Crate containing the Zaino Indexer binary."
 authors = { workspace = true }
 repository = { workspace = true }

--- a/tools/makefiles/lints.toml
+++ b/tools/makefiles/lints.toml
@@ -92,6 +92,11 @@ description = "Fail if any Dockerfile installs a libssl*/openssl* apt package. T
 command = "cargo"
 args = ["run", "-q", "--manifest-path", "tools/workbench/Cargo.toml", "--bin", "check-no-openssl-apt"]
 
+[tasks.lint-code-duplication]
+description = "Fail on any exact or near duplicate Rust logic (AST-normalized, min 50 nodes) in packages/ (minus generated zaino-proto and in-crate tests/), live-tests/, and tools/. Escape hatch: annotated entries in .dupes-ignore.toml."
+command = "cargo"
+args = ["run", "-q", "--manifest-path", "tools/workbench/Cargo.toml", "--bin", "check-code-duplication"]
+
 [tasks.deny]
 description = "Enforce deny.toml's crate bans (openssl/openssl-sys/boring*). Scoped to `bans`: advisories/licenses have pre-existing failures (e.g. RUSTSEC-2022-0001 lmdb) tracked separately."
 command = "cargo"
@@ -113,6 +118,7 @@ dependencies = [
     "lint-toolchain-pin",
     "lint-crypto-provider",
     "lint-no-openssl-apt",
+    "lint-code-duplication",
     "deny",
     "lint-shell",
 ]

--- a/tools/workbench/Cargo.lock
+++ b/tools/workbench/Cargo.lock
@@ -3,5 +3,273 @@
 version = 4
 
 [[package]]
+name = "dupes-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708adfad616d4800a92d6997700d39a82b73bbb85e6ed77701417caea94bad7b"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+ "toml",
+ "walkdir",
+]
+
+[[package]]
+name = "dupes-rust"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2335d2c56a41c539c58e7203bfb3f94edc8ee0ecc5d6ee8c88df0bcb774de70"
+dependencies = [
+ "dupes-core",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "workbench"
 version = "0.0.0"
+dependencies = [
+ "dupes-core",
+ "dupes-rust",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/tools/workbench/Cargo.toml
+++ b/tools/workbench/Cargo.toml
@@ -13,3 +13,7 @@ publish = false
 # Crate-wide: forbid unsafe across the lib and every binary in one place.
 [lints.rust]
 unsafe_code = "forbid"
+
+[dependencies]
+dupes-core = "=0.2.1"
+dupes-rust = "=0.2.1"

--- a/tools/workbench/src/bin/check-code-duplication.rs
+++ b/tools/workbench/src/bin/check-code-duplication.rs
@@ -1,0 +1,145 @@
+//! Guard: no duplicate Rust logic may enter the tree.
+//!
+//! Runs cargo-dupes' AST-normalizing analyzer (identifiers become positional
+//! placeholders and literals are erased, so renamed copies still match) over the
+//! first-party Rust scopes and fails if any exact or near duplicate group remains:
+//!
+//! - `packages/` — the production crates, excluding `zaino-proto` (tonic/prost
+//!   generated code) and in-crate `tests/` module directories.
+//! - `live-tests/` — the e2e and clientless harness crates, including their
+//!   integration-test helper code.
+//! - `tools/` — the developer tooling.
+//!
+//! `#[test]` functions and `#[cfg(test)]` modules visible per-file are excluded in
+//! every scope. The tree was deduplicated to zero groups when this gate landed, so
+//! both thresholds are zero: any new group is a regression.
+//!
+//! `MIN_NODES` was calibrated empirically against this tree on 2026-07-15: 50 is
+//! the floor at which every reported group was a genuine dedup-worthy twin. Below
+//! it the analyzer reports structurally-rhyming but semantically unrelated small
+//! functions (field-copy constructors, tiny delegating getters), whose "dedup"
+//! would couple unrelated types.
+//!
+//! Escape hatch: a genuinely irreducible group may be granted an annotated entry
+//! in `.dupes-ignore.toml` at the repo root — run
+//! `code-dupes ignore <fingerprint> --reason "..."` (crates.io package
+//! `code-dupes`, the CLI over the same libraries). Prefer deduplicating; entries
+//! are reviewed like code.
+
+use std::path::{Path, PathBuf};
+
+use dupes_core::config::Config;
+use dupes_core::scanner::{scan_files, ScanConfig};
+use dupes_rust::RustAnalyzer;
+use workbench::{repo_root, run};
+
+/// One scanned scope: a repo-relative directory and its excluded path substrings
+/// (matched against repo-relative paths, so the checkout location cannot affect
+/// the result).
+struct Scope {
+    path: &'static str,
+    excludes: &'static [&'static str],
+}
+
+const SCOPES: &[Scope] = &[
+    Scope {
+        path: "packages",
+        excludes: &["zaino-proto", "/tests/"],
+    },
+    Scope {
+        path: "live-tests",
+        excludes: &[],
+    },
+    Scope {
+        path: "tools",
+        excludes: &[],
+    },
+];
+
+/// Minimum AST-node count for a code unit to participate in duplicate analysis.
+/// See the module docs for the calibration rationale.
+const MIN_NODES: usize = 50;
+
+fn main() {
+    run("check-code-duplication", check, |n| {
+        println!("check-code-duplication: ok — no duplicate groups across {n} Rust file(s)");
+    })
+}
+
+fn check() -> Result<usize, Vec<String>> {
+    let root = repo_root()?;
+    let analyzer = RustAnalyzer;
+    let mut scanned_files = 0usize;
+    let mut offenders: Vec<String> = Vec::new();
+
+    for scope in SCOPES {
+        let files: Vec<PathBuf> = scan_files(&ScanConfig::new(root.join(scope.path)))
+            .into_iter()
+            .filter(|path| !is_excluded(path, &root, scope.excludes))
+            .collect();
+        scanned_files += files.len();
+
+        let config = Config {
+            min_nodes: MIN_NODES,
+            exclude_tests: true,
+            // The ignore file (`.dupes-ignore.toml`) is discovered at this root.
+            root: root.clone(),
+            ..Config::default()
+        };
+
+        let result = dupes_core::analyze(&analyzer, &files, &config)
+            .map_err(|e| vec![format!("analysis of {} failed: {e}", scope.path)])?;
+        for warning in &result.warnings {
+            eprintln!(
+                "check-code-duplication: warning ({}): {warning}",
+                scope.path
+            );
+        }
+
+        for (label, groups) in [
+            ("exact", &result.exact_groups),
+            ("near", &result.near_groups),
+        ] {
+            for group in groups {
+                offenders.push(format!(
+                    "{label} duplicate group in {} (fingerprint {}, similarity {:.0}%):",
+                    scope.path,
+                    group.fingerprint,
+                    group.similarity * 100.0
+                ));
+                for member in &group.members {
+                    let file = member.file.strip_prefix(&root).unwrap_or(&member.file);
+                    offenders.push(format!(
+                        "  - {} ({}) at {}:{}-{}",
+                        member.name,
+                        member.kind,
+                        file.display(),
+                        member.line_start,
+                        member.line_end
+                    ));
+                }
+            }
+        }
+    }
+
+    if offenders.is_empty() {
+        return Ok(scanned_files);
+    }
+    let mut msg = vec![
+        "duplicate Rust logic found — deduplicate it (prefer a plain fn; see CLAUDE.md §DRY):"
+            .to_string(),
+    ];
+    msg.extend(offenders);
+    msg.push(
+        "if a group is genuinely irreducible, add an annotated entry to .dupes-ignore.toml \
+         (`code-dupes ignore <fingerprint> --reason \"...\"`)."
+            .to_string(),
+    );
+    Err(msg)
+}
+
+/// Whether `path`, taken relative to the repo root, matches any exclude substring.
+fn is_excluded(path: &Path, root: &Path, excludes: &[&str]) -> bool {
+    let relative = path.strip_prefix(root).unwrap_or(path).to_string_lossy();
+    excludes.iter().any(|pattern| relative.contains(pattern))
+}


### PR DESCRIPTION
## Summary

Zaino 0.7.0 release.

- Merges `rc/0.7.0` into `stable`, resolving the divergence from the 0.6.0 release commits that were never backported to dev.
- Bumps all crate versions to their final stable form.

The bulk of 0.7.0 is a **DRY consolidation** pass across the workspace — de-duplicating error-object construction and shared logic in `zaino-fetch`, `zaino-proto`, `zaino-serve`, and `zaino-state` — plus a CI **duplicate-logic gate** to keep the consolidation from regressing.

### Crate versions

| Crate | 0.6.0 | 0.7.0 | Change |
|---|---|---|---|
| zaino-common | 0.4.0 | 0.4.0 | unchanged since 0.6.0 (realign) |
| zaino-fetch | 0.4.0 | 0.4.1 | internal DRY refactor (patch) |
| zaino-proto | 0.2.0 | **0.3.0** | **BREAKING** — new `PoolTypeError` variant + `ValidatedBlockRangeRequest` shape |
| zaino-serve | 0.5.0 | 0.5.1 | internal error-object DRY (patch) |
| zaino-state | 0.5.0 | **0.6.0** | **BREAKING** — removed pub ctors + `ZainoVersionedSerde` impls |
| zainod | 0.6.0 | 0.7.0 | umbrella binary + bumped lib deps |

Two crates carry breaking API changes this release: **zaino-proto** (0.3.0) and **zaino-state** (0.6.0).

After merge, tag `0.7.0` on the merge commit to trigger the release workflow.
